### PR TITLE
Add fallback home routes

### DIFF
--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -5,5 +5,14 @@ export const routes: Routes = [
   {
     path: '',
     component: HomeComponent
+  },
+  {
+    path: 'home',
+    component: HomeComponent
+  },
+  {
+    path: '**',
+    redirectTo: '',
+    pathMatch: 'full'
   }
 ];


### PR DESCRIPTION
## Summary
- add explicit /home route and wildcard redirect to the landing component so the homepage content always renders

## Testing
- npm install --progress=false --no-fund --no-audit *(fails: registry returned 403 access error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261287fc0883208d0172c44474687e)