### PR TITLE
Fix home page visibility

### DIFF
--- a/web/frontend/src/app/app.component.html
+++ b/web/frontend/src/app/app.component.html
@@ -1,3 +1,5 @@
-<H1>HOLA MUNDO SEP</H1>
-
-<router-outlet></router-outlet>
+<main class="page-wrapper">
+  <section class="content-container">
+    <router-outlet></router-outlet>
+  </section>
+</main>

--- a/web/frontend/src/app/app.component.scss
+++ b/web/frontend/src/app/app.component.scss
@@ -1,73 +1,28 @@
-body {
-  margin: 0;
-  font-family: 'Noto Sans', sans-serif;
-  color: #ffffff;
-  /* Padding ajustado para sin espacio */
-  padding-top: 133px !important; /* 78px header + 55px navbar */
+:host {
+  display: block;
+  min-height: 100vh;
+  background-color: #f5f7fa;
+  color: #1f2937;
 }
 
-h1 {
-  font-size: 28px;
+.page-wrapper {
+  padding-top: 140px;
+  padding-bottom: 48px;
 }
 
-main {
-  text-align: center;
+.content-container {
   margin: 0 auto;
-  max-width: 100vw;
-  padding-bottom: 39px;
-}
-
-.breadcrumb {
-  display: flex !important;
-  position: relative;
-  top: -3em;
-  margin: 10px;
-}
-
-.breadcrumb a {
-  color: #393C3E;
-  margin: 5px !important;
-}
-
-.breadcrumb > li + li:before {
-  display: none !important;
-}
-
-.breadcrumb .icon {
-  font-size: 16px !important;
-  margin-top: 6px !important;
-}
-
-.hero-section {
-  background-image: url('../assets/images/bnr_documentos.webp');
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  text-align: center;
-  color: rgb(27, 22, 22);
-  padding: 100px 20px;
-}
-
-.hero-title {
-  display: none;
+  max-width: 1100px;
+  padding: 0 24px;
 }
 
 @media (max-width: 768px) {
-  body {
-    padding-top: 138px !important;
+  .page-wrapper {
+    padding-top: 150px;
+    padding-bottom: 32px;
   }
 
-  .hero-section {
-    padding: 60px 20px;
-    text-align: justify;
-  }
-
-  main {
-    text-align: center;
-    margin: 0 auto;
-    max-width: 92vw;
-    padding: 0;
-    margin-left: 1em;
-    margin-top: 1em;
+  .content-container {
+    padding: 0 16px;
   }
 }

--- a/web/frontend/src/app/home/home.component.html
+++ b/web/frontend/src/app/home/home.component.html
@@ -1,5 +1,18 @@
 <section class="home-card">
-  <h1>Bienvenido</h1>
-  <p>Este es el punto de partida para la aplicación de evaluación diagnóstica.</p>
-  <p>Puedes comenzar a construir tus componentes y rutas desde esta base Angular.</p>
+  <div class="home-card__header">
+    <p class="home-card__eyebrow">Evaluación diagnóstica SEP</p>
+    <h1 class="home-card__title">Bienvenido</h1>
+  </div>
+  <div class="home-card__body">
+    <p>
+      Esta página reúne los accesos principales y los indicadores iniciales para comenzar a
+      trabajar con la evaluación diagnóstica. Explora las secciones disponibles y encuentra la
+      información que necesitas de manera rápida.
+    </p>
+    <ul class="home-card__highlights">
+      <li>Consulta los módulos disponibles desde el menú superior.</li>
+      <li>Accede a documentación y transparencia mediante los enlaces institucionales.</li>
+      <li>Reporta incidencias o consultas desde la sección de contacto.</li>
+    </ul>
+  </div>
 </section>

--- a/web/frontend/src/app/home/home.component.scss
+++ b/web/frontend/src/app/home/home.component.scss
@@ -1,16 +1,49 @@
 .home-card {
-  background-color: #e70303;
-  border-radius: 12px;
-  padding: 24px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 28px 32px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e5e7eb;
+}
 
-  h1 {
-    margin-top: 0;
-    color: #1f3b57;
+.home-card__eyebrow {
+  margin: 0 0 8px;
+  color: #a11d33;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 12px;
+}
+
+.home-card__title {
+  margin: 0;
+  color: #111827;
+  font-size: 32px;
+  line-height: 1.2;
+}
+
+.home-card__body {
+  margin-top: 16px;
+  color: #374151;
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+.home-card__highlights {
+  margin: 16px 0 0;
+  padding-left: 20px;
+}
+
+.home-card__highlights li + li {
+  margin-top: 8px;
+}
+
+@media (max-width: 768px) {
+  .home-card {
+    padding: 22px 20px;
   }
 
-  p {
-    color: #334155;
-    line-height: 1.5;
+  .home-card__title {
+    font-size: 26px;
   }
 }


### PR DESCRIPTION
## Summary
- Wrap the routed content in a padded layout container so home details render below the institutional header/footer
- Refresh the home view copy and styling to present a clear welcome card with key highlights

## Testing
- Not run (npm install/ng commands blocked by registry 403 errors)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261500cc4083209ab5d3df654dc5e4)