### PR TITLE
Ignore Angular CLI cache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Angular CLI cache
+web/frontend/.angular/
+**/.angular/cache


### PR DESCRIPTION
## Summary
- add Angular CLI cache directories to the root .gitignore so cache artifacts do not appear as changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926395c06648320a374cf9a79f1e954)