### PR TITLE
Add login navigation route

### DIFF
--- a/web/frontend/angular.json
+++ b/web/frontend/angular.json
@@ -119,5 +119,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { InicioComponent } from './components/inicio/inicio.component';
+import { LoginComponent } from './components/login/login.component';
 
 
 export const routes: Routes = [
@@ -11,6 +12,11 @@ export const routes: Routes = [
   {
     path: 'inicio',
     component: InicioComponent,
+    pathMatch: 'full',
+  },
+  {
+    path: 'login',
+    component: LoginComponent,
     pathMatch: 'full',
   },
  /*  {

--- a/web/frontend/src/app/components/inicio/inicio.component.ts
+++ b/web/frontend/src/app/components/inicio/inicio.component.ts
@@ -1,15 +1,18 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-inicio',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './inicio.component.html',
   styleUrl: './inicio.component.scss'
 })
 export class InicioComponent {
+  constructor(private readonly router: Router) {}
 
-usuarioAutenticado = false;
+  usuarioAutenticado = false;
   readonly llaveMxImage =
     'data:image/png;base64,' +
     'iVBORw0KGgoAAAANSUhEUgAAAlgAAAEYCAIAAAAPtB96AAAH+ElEQVR42u3dwU3rQBSFYYqgC2qgFCqgEKphCXWwoQIKAdZEQcnYE9+55/t0tg+ZYM+vSI9w9w0Awe68BAAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQAIIQBCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCCABCyFlvLw9eBAAh7Ny57fMyAghhVvl0EUAIxU8UAYRQ/xQRQAglUA4BhFD/FBFACCVQDgGEUALlEEAIJVAOAYRQA' +
@@ -21,8 +24,7 @@ usuarioAutenticado = false;
   }
 
   iniciarSesion(): void {
-    // TODO: Integrar flujo de inicio de sesión cuando esté disponible
-    console.log('Redirigir a inicio de sesión de LlaveMX');
+    this.router.navigate(['/login']);
   }
 }
 

--- a/web/frontend/src/app/components/login/login.component.ts
+++ b/web/frontend/src/app/components/login/login.component.ts
@@ -1,8 +1,10 @@
+import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-login',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss'
 })

--- a/web/frontend/src/app/shared/nav/nav.component.html
+++ b/web/frontend/src/app/shared/nav/nav.component.html
@@ -159,7 +159,7 @@
           <!-- Iniciar Sesión -->
           <!-- Iniciar Sesión -->
           <li class="nav-item">
-            <a class="nav-link subnav-link" href="javascript:void(0)" (click)="iniciarSesion()">
+            <a class="nav-link subnav-link" [routerLink]="['/login']">
               <i class="fas fa-sign-in-alt mr-1"></i>
               <strong class="d-none d-md-inline">Iniciar Sesión</strong>
               <strong class="d-inline d-md-none">Login</strong>

--- a/web/frontend/src/app/shared/nav/nav.component.ts
+++ b/web/frontend/src/app/shared/nav/nav.component.ts
@@ -81,10 +81,6 @@ export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
-  iniciarSesion(): void {
-    this.router.navigate(['/login']);
-  }
-
   registrarse(): void {
     this.router.navigate(['/registro']);
   }


### PR DESCRIPTION
## Summary
- add a dedicated login route and mark the login component as standalone
- wire the navigation bar login link and home page button to navigate to the login page
- disable Angular CLI analytics to avoid prompts during builds

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692748f8963c8320b8dda7a0ff535aa4)