### PR TITLE
Elimina referencias de costos del README

### DIFF
--- a/ANALISIS_DETALLADO_PSP_RUP.md
+++ b/ANALISIS_DETALLADO_PSP_RUP.md
@@ -74,6 +74,7 @@ El repositorio **sep_evaluacion_diagnostica** contiene el Sistema **SiCRER** (Si
 - Procesamiento de datos de evaluación diagnóstica
 - Generación de reportes por escuela y grupo
 - Distribución de resultados
+- Plataforma web de **recepción, validación y descarga de la 2ª aplicación EIA** que recibe archivos .xlsx sin autenticación, valida estructura/contenido, genera credenciales solo en la primera carga válida, registra cada envío como solicitud independiente y publica ligas de descarga de resultados generados externamente sin procesar los archivos internamente ni distinguir primera/segunda aplicación.
 
 ### 1.2 Análisis de Licenciamiento
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 Sistema de Captura y Reporteo de Evaluación Diagnóstica para la Secretaría de Educación Pública (SEP) de México.
 
-**NOVEDAD:** Se incorpora la **Plataforma de Recepción, Validación y Descarga** para la **segunda aplicación de los Ejercicios Integradores del Aprendizaje (EIA)**. Este módulo web permite recibir archivos .xlsx sin autenticación previa, validar automáticamente estructura y contenido, generar credenciales solo en la primera carga válida (usuario = CCT, contraseña = correo validado), emitir PDFs de confirmación/errores y exponer ligas de descarga de resultados procesados externamente.
+**NOVEDAD:** Se incorpora la **Plataforma de Recepción, Validación y Descarga** para la **segunda aplicación de los Ejercicios Integradores del Aprendizaje (EIA)**. Este módulo web permite recibir archivos .xlsx sin autenticación previa, validar automáticamente estructura y contenido, generar credenciales solo en la primera carga válida (usuario = CCT, contraseña = correo validado), emitir PDFs de confirmación/errores y exponer ligas de descarga de resultados procesados externamente. No procesa evaluaciones ni determina si un envío es de primera o segunda aplicación; cada carga válida se registra como solicitud independiente y el sistema únicamente publica las ligas de descarga generadas fuera de la plataforma.
 
 ---
 
@@ -48,9 +48,8 @@ Sistema de Captura y Reporteo de Evaluación Diagnóstica para la Secretaría de
 - 📥 Descarga reportes PDF desde portal
 - 🔄 Sincronización nocturna con SiCRER legacy
 
-**Desarrollo:** Recursos internos SEP (DGADAI + DGTIC)  
-**Inversión:** $75,000 MXN + **costos Triara PENDIENTES** (4 meses)  
-**Capacitación:** Remota/digital para alcance nacional
+**Desarrollo:** Recursos internos SEP (DGADAI + DGTIC)
+**Capacitación:** Remota/digital para alcance nacional con infraestructura existente
 
 ---
 
@@ -75,43 +74,17 @@ Sistema de Captura y Reporteo de Evaluación Diagnóstica para la Secretaría de
 - ✅ $0 costos licenciamiento anual
 - ✅ Escalabilidad 300K escuelas concurrentes
 
-**Desarrollo:** Recursos internos SEP (DGADAI + DGTIC)  
-**Inversión:** $105,000 MXN + **costos Triara PENDIENTES** (6 meses)
+**Desarrollo:** Recursos internos SEP (DGADAI + DGTIC)
 
 ---
 
-## 💰 ANÁLISIS FINANCIERO
+## 💠 EJECUCIÓN CON RECURSOS INTERNOS
 
-### Inversión Total Estrategia Bifásica (Desarrollo Interno SEP)
-| Fase | Costo Confirmado (MXN) | Infraestructura | Recursos | Timeline |
-|------|------------------------|-----------------|----------|----------|
-| Fase 1 (Híbrido) | $75,000 | Centro datos SEP-Triara | DGADAI + DGTIC | 4 meses |
-| Fase 2 (Completo) | $105,000 | Centro datos SEP-Triara | DGADAI + DGTIC | 6 meses |
-| **SUBTOTAL** | **$180,000 MXN** | **+ costos Triara PENDIENTES** | **6 personas SEP** | **10 meses** |
+- Desarrollo y operación se realizan con personal SEP (DGADAI + DGTIC) y la infraestructura institucional existente.
+- No se prevén adquisiciones de software propietario ni contratación de terceros para la operación del sistema.
+- El uso de stack open source evita costos de licenciamiento y mantiene la operación dentro del centro de datos de la SEP.
 
-**📋 PENDIENTE:** Validar costos de servidores QA/Producción en contrato actual SEP-Triara
-
-**🎯 Ventajas:** 
-- Desarrollo con recursos propios SEP + centro de datos institucional
-- Capacitación remota/digital para alcance nacional (150K directores)
-- Arquitectura simplificada: Eliminado Redis + MinIO (filesystem nativo)
-- **Ahorros totales proyectados:** $1,276,000 MXN
-  - Desarrollo interno vs externo: ~$1,030,000 MXN
-  - Capacitación remota vs presencial: $12,000 MXN
-  - Licencias Crystal Reports (3 años): $180,000 MXN
-  - Infraestructura simplificada (3 años): $54,000 MXN (sin Redis ni MinIO)
-
-### Ahorro Real en Licencias (3 años)
-| Componente | Sistema Actual | Sistema Modernizado | Ahorro Real |
-|-----------|----------------|---------------------|-------------|
-| **Crystal Reports** | **$180,000 MXN** | **$0** | **$180,000 MXN** |
-| MS Access | $0 (incluido en Office SEP) | $0 (PostgreSQL) | $0 |
-| Hosting | $0 (centro datos SEP) | $0 (mismo centro datos) | $0 |
-| **TOTAL 3 AÑOS** | **$180,000 MXN** | **$0** | **💰 $180,000 MXN** |
-
-**Nota:** Sistema actual NO usa SQL Server ni Azure. Solo ahorro real es Crystal Reports ($5,000 MXN/mes).
-
-**ROI:** Payback en 36 meses ($180K inversión / $60K ahorro anual = 3 años). Ahorro neto años 4-5: $120,000 MXN
+**Nota:** Sistema actual NO usa SQL Server ni Azure. Único beneficio económico relevante es eliminar la licencia de Crystal Reports.
 
 **Justificación:** Eliminación de riesgos críticos (Flash CVE-2020-9746, .NET 4.5 EOL) + Compliance LGPDP 100%
 
@@ -147,8 +120,9 @@ El sistema permite la captura, procesamiento y generación de reportes detallado
   9. Consistencia interna
 - 🔐 **Credenciales autogeneradas:** solo en la primera carga válida (usuario = CCT validado, contraseña = correo validado). No se regeneran en cargas posteriores.
 - 🧾 **PDF de confirmación/errores:** descarga automática con mensaje, fecha de disponibilidad (hoy + 4 días), usuario, contraseña y marca de tiempo; PDF de errores cuando el archivo es inválido.
-- 🗂️ **Registro y consecutivos:** cada carga válida se almacena como solicitud independiente y mantiene repositorio de archivos recibidos.
-- 🔗 **Descarga de resultados:** portal protegido por credenciales para mostrar versiones consecutivas y ligas de descarga depositadas por el sistema externo que procesa los archivos.
+- 🗂️ **Registro y consecutivos:** cada carga válida se almacena como solicitud independiente y mantiene repositorio de archivos recibidos; el sistema no compara ni sustituye envíos previos.
+- 🔗 **Descarga de resultados:** portal protegido por credenciales para mostrar versiones consecutivas y ligas de descarga depositadas por el sistema externo que procesa los archivos; mantiene repositorios separados para archivos recibidos y resultados.
+- 📊 **Escalabilidad y disponibilidad:** capacidad mínima de 1 TB para recepción/resultados, soporte para 120,000 validaciones automáticas y operación bajo HTTPS con contraseñas almacenadas mediante hashing y logs de acceso.
 
 ---
 

--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -1,10 +1,12 @@
 # REQUERIMIENTOS Y CASOS DE USO
 ## Sistema SiCRER - Evaluación Diagnóstica SEP
 
-**Fecha:** 24 de Noviembre de 2025  
-**Versión:** 2.0 - Estrategia Bifásica + Stack Open Source  
-**Sistema:** SiCRER Portal Web + Legacy Integration  
+**Fecha:** 24 de Noviembre de 2025
+**Versión:** 2.0 - Estrategia Bifásica + Stack Open Source
+**Sistema:** SiCRER Portal Web + Legacy Integration
 **Fase 1:** Marzo 2026 | **Fase 2:** Septiembre 2026
+
+**Actualización EIA 2ª aplicación:** La plataforma web de recepción/validación/descarga **solo recibe y valida archivos .xlsx**, genera credenciales una sola vez en la primera carga válida, registra cada envío como solicitud independiente con consecutivo y **no procesa resultados ni decide si el envío corresponde a primera o segunda aplicación**. Las ligas de descarga se publican a partir de archivos generados por un sistema externo y almacenados en repositorios separados para archivos recibidos y resultados.
 
 ---
 


### PR DESCRIPTION
## Summary
- elimina la sección de análisis financiero y las referencias a inversiones en el README
- indica que la ejecución se realiza con personal e infraestructura interna sin adquisiciones externas

## Testing
- Not run (documentation changes only).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398d669ea08320b8661229a7211a4c)