### PR TITLE
Fix nth-child selector typo in archivos table

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
@@ -87,7 +87,7 @@
   border-bottom: 1px solid #e2e8f0;
 }
 
-.archivos tbody tr:nth-child(every) {
+.archivos tbody tr:nth-child(even) {
   background: #fff;
 }
 


### PR DESCRIPTION
## Summary
- correct the table row selector in archivos-guardados styles
- prevent Sass build error by using the proper nth-child keyword

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694068eb746483208c22741267b5c70b)