### PR TITLE
Add delete control to saved files table

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
@@ -31,9 +31,28 @@
           <td data-label="Fecha">{{ registro.fechaGuardado | date:'medium' }}</td>
           <td data-label="Ruta">{{ registro.ruta }}</td>
           <td data-label="Acciones">
-            <button type="button" class="archivos__accion" (click)="descargar(registro)">
-              Descargar copia
-            </button>
+            <div class="archivos__acciones">
+              <button type="button" class="archivos__accion" (click)="descargar(registro)">
+                Descargar copia
+              </button>
+              <button
+                type="button"
+                class="archivos__accion archivos__accion--peligro"
+                (click)="eliminar(registro)"
+                aria-label="Eliminar archivo guardado"
+                title="Eliminar"
+              >
+                <svg class="archivos__icono" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path
+                    d="M9 3.5h6M4 7h16M18 7l-.6 11.1c-.08 1.4-1.23 2.4-2.63 2.4H9.23c-1.4 0-2.55-1.05-2.63-2.45L6 7"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                  />
+                  <path d="M10 11v6m4-6v6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                </svg>
+              </button>
+            </div>
           </td>
         </tr>
       </tbody>

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
@@ -87,12 +87,18 @@
   border-bottom: 1px solid #e2e8f0;
 }
 
-.archivos tbody tr:nth-child(every) {
+.archivos tbody tr:nth-child(even) {
   background: #fff;
 }
 
 .archivos tbody tr:hover {
   background: #f1f5f9;
+}
+
+.archivos__acciones {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .archivos__accion {
@@ -114,6 +120,27 @@
 
 .archivos__accion:active {
   transform: translateY(0);
+}
+
+.archivos__accion--peligro {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #b91c1c;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem;
+}
+
+.archivos__accion--peligro:hover {
+  background: #fecdd3;
+  box-shadow: 0 8px 20px rgba(248, 113, 113, 0.25);
+  transform: translateY(-1px);
+}
+
+.archivos__icono {
+  width: 1.15rem;
+  height: 1.15rem;
 }
 
 .archivos__vacio {

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -46,4 +46,13 @@ export class ArchivosGuardadosComponent implements OnInit {
         error instanceof Error ? error.message : 'No se pudo descargar el archivo seleccionado.';
     }
   }
+
+  eliminar(registro: RegistroArchivo): void {
+    try {
+      this.archivoStorageService.eliminarRegistro(registro);
+      this.cargarRegistros();
+    } catch (error) {
+      this.mensajeError = error instanceof Error ? error.message : 'No se pudo eliminar el archivo seleccionado.';
+    }
+  }
 }

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -75,6 +75,18 @@ export class ArchivoStorageService {
     URL.revokeObjectURL(url);
   }
 
+  eliminarRegistro(registroAEliminar: RegistroArchivo): void {
+    const registrosActualizados = this.obtenerRegistros().filter(
+      (registro) =>
+        !(
+          registro.nombre === registroAEliminar.nombre &&
+          registro.fechaGuardado === registroAEliminar.fechaGuardado
+        )
+    );
+
+    localStorage.setItem(this.storageKey, JSON.stringify(registrosActualizados));
+  }
+
   private async convertirA64(archivo: File): Promise<string> {
     const buffer = await archivo.arrayBuffer();
     const bytes = new Uint8Array(buffer);


### PR DESCRIPTION
## Summary
- add a delete action with icon to each saved file row in the archivos guardados table
- style the new danger action and align actions side by side
- support removal of stored records through the archivo storage service and refresh the view after deletion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694068eb746483208c22741267b5c70b)