### PR TITLE
Document email-first upload flow for EIA uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Sistema de Captura y Reporteo de Evaluación Diagnóstica para la Secretaría de Educación Pública (SEP) de México.
 
-**NOVEDAD:** Se incorpora la **Plataforma de Recepción, Validación y Descarga** para la **segunda aplicación de los Ejercicios Integradores del Aprendizaje (EIA)**. Este módulo web permite recibir archivos .xlsx sin autenticación previa, validar automáticamente estructura y contenido, generar credenciales solo en la primera carga válida (usuario = CCT, contraseña = correo validado), emitir PDFs de confirmación/errores y exponer ligas de descarga de resultados procesados externamente. No procesa evaluaciones ni determina si un envío es de primera o segunda aplicación; cada carga válida se registra como solicitud independiente y el sistema únicamente publica las ligas de descarga generadas fuera de la plataforma.
+**NOVEDAD:** Se incorpora la **Plataforma de Recepción, Validación y Descarga** para la **segunda aplicación de los Ejercicios Integradores del Aprendizaje (EIA)**. Este módulo web obliga a capturar el **correo electrónico antes de elegir el Excel**, recibe archivos .xlsx sin autenticación previa, valida automáticamente estructura y contenido, genera una **contraseña aleatoria en la primera carga válida** (usuario = correo ingresado y validado contra el archivo) y permite reutilizar el **mismo correo para varios CCT**. Muestra nuevos mensajes de ayuda/confirmación, emite PDFs de confirmación/errores y expone ligas de descarga de resultados procesados externamente. No procesa evaluaciones ni determina si un envío es de primera o segunda aplicación; cada carga válida se registra como solicitud independiente y el sistema únicamente publica las ligas de descarga generadas fuera de la plataforma.
 
 ---
 
@@ -97,10 +97,10 @@ El sistema permite la captura, procesamiento y generación de reportes detallado
 
 ### Plataforma de Recepción, Validación y Descarga (Segunda Aplicación EIA)
 
-- 📥 **Recepción sin autenticación:** carga de archivo .xlsx con etiqueta "Validando tu archivo...".
-- ✅ **Validación automática con 9 verificaciones:**
-  1. CCT
-  2. Correo
+- 📥 **Recepción guiada:** la pantalla exige capturar el correo (será el usuario) antes de habilitar el selector de archivo y luego muestra la etiqueta «Validando tu archivo con el correo ingresado…».
+- ✅ **Validación automática con 9 verificaciones en orden:**
+  1. Coincidencia entre el correo ingresado y el correo dentro del Excel (solo en la primera carga de ese correo)
+  2. CCT
   3. Nivel
   4. Campo obligatorio por hoja
   5. Columnas obligatorias
@@ -108,10 +108,10 @@ El sistema permite la captura, procesamiento y generación de reportes detallado
   7. Estructura general de archivo
   8. Número y nombre de hojas
   9. Consistencia interna
-- 🔐 **Credenciales autogeneradas:** solo en la primera carga válida (usuario = CCT validado, contraseña = correo validado). No se regeneran en cargas posteriores.
-- 🧾 **PDF de confirmación/errores:** descarga automática con mensaje, fecha de disponibilidad (hoy + 4 días), usuario, contraseña y marca de tiempo; PDF de errores cuando el archivo es inválido.
+- 🔐 **Credenciales autogeneradas:** solo en la primera carga válida se crea una contraseña aleatoria; el usuario para login y descargas es siempre el correo validado (el mismo correo puede usarse con varios CCT). No se regeneran contraseñas en cargas posteriores.
+- 🧾 **PDF de confirmación/errores:** descarga automática con mensaje, fecha de disponibilidad (hoy + 4 días), usuario (correo), contraseña aleatoria generada y marca de tiempo; PDF de errores cuando el archivo es inválido o el correo no coincide con el Excel.
 - 🗂️ **Registro y consecutivos:** cada carga válida se almacena como solicitud independiente y mantiene repositorio de archivos recibidos; el sistema no compara ni sustituye envíos previos.
-- 🔗 **Descarga de resultados:** portal protegido por credenciales para mostrar versiones consecutivas y ligas de descarga depositadas por el sistema externo que procesa los archivos; mantiene repositorios separados para archivos recibidos y resultados.
+- 🔗 **Descarga de resultados:** portal protegido por credenciales (correo + contraseña aleatoria) para mostrar versiones consecutivas y ligas de descarga depositadas por el sistema externo que procesa los archivos; mantiene repositorios separados para archivos recibidos y resultados.
 - 📊 **Escalabilidad y disponibilidad:** capacidad mínima de 1 TB para recepción/resultados, soporte para 120,000 validaciones automáticas y operación bajo HTTPS con contraseñas almacenadas mediante hashing y logs de acceso.
 
 ---

--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -8,7 +8,7 @@
 
 > **Alineación tecnológica 2025:** Todas las iteraciones de diseño y construcción se basarán en **Python 3.12 + FastAPI** para backend, **Angular 17 + TypeScript 5** para frontend y **PostgreSQL 16** como base de datos. Las referencias previas a React/Node.js quedan como histórico y deberán reinterpretarse con el nuevo stack durante el refinamiento de cada módulo.
 
-**Actualización EIA 2ª aplicación:** La plataforma web de recepción/validación/descarga **solo recibe y valida archivos .xlsx**, genera credenciales una sola vez en la primera carga válida, registra cada envío como solicitud independiente con consecutivo y **no procesa resultados ni decide si el envío corresponde a primera o segunda aplicación**. Las ligas de descarga se publican a partir de archivos generados por un sistema externo y almacenados en repositorios separados para archivos recibidos y resultados.
+**Actualización EIA 2ª aplicación:** La plataforma web de recepción/validación/descarga **solo recibe y valida archivos .xlsx** después de que el usuario capture su correo (será su identificador). En la primera carga válida se valida que el correo coincida con el declarado en el Excel, se genera una **contraseña aleatoria** y el mismo correo puede usarse con múltiples CCT. Cada envío queda como solicitud independiente con consecutivo y el portal **no procesa resultados ni decide si el envío corresponde a primera o segunda aplicación**; únicamente publica ligas de descarga generadas por un sistema externo en repositorios separados para archivos recibidos y resultados.
 
 ---
 
@@ -198,16 +198,16 @@
 - **RF-15.6** El sistema debe manejar errores de sincronización con reintentos automáticos
 
 ### RF-16: Plataforma Recepción/Validación/Descarga EIA (2ª aplicación)
-- **RF-16.1** El portal debe permitir subir archivo .xlsx sin autenticación previa y mostrar la etiqueta "Validando tu archivo..." al seleccionar el archivo.
-- **RF-16.2** La validación automática debe revisar CCT, correo, nivel, campos y columnas obligatorias por hoja, valores válidos (0-3), número y nombre de hojas, estructura general y consistencia interna; si alguno falla, el archivo se rechaza.
-  - **Checklist mínimo de validación (9 puntos):** CCT, correo, nivel, campo obligatorio por hoja, columnas obligatorias, valores válidos (0-3), estructura general de archivo, número de hojas, consistencia interna.
-- **RF-16.3** Si el archivo es válido, el sistema debe mostrar el mensaje "Tu archivo ha sido validado correctamente. Podrás consultar tus resultados a partir del día: [hoy + 4 días]".
-- **RF-16.4** En la primera carga válida se deben generar credenciales de consulta (usuario = CCT validado, contraseña = correo validado) y no regenerarse en cargas posteriores.
-- **RF-16.5** El sistema debe generar y descargar automáticamente un PDF de confirmación con mensaje de éxito, fecha futura de consulta, usuario, contraseña y marca de tiempo; si es inválido, debe descargar PDF de errores.
+- **RF-16.1** El portal debe pedir primero el correo electrónico (será el usuario) y, solo después de capturarlo, habilitar la selección del archivo .xlsx mostrando la etiqueta "Validando tu archivo con el correo ingresado...".
+- **RF-16.2** La validación automática debe ejecutarse en orden para confirmar coincidencia entre el correo ingresado y el del Excel (solo en la primera carga ligada a ese correo), CCT, nivel, campos y columnas obligatorias por hoja, valores válidos (0-3), número y nombre de hojas, estructura general y consistencia interna; si alguno falla, el archivo se rechaza.
+  - **Checklist mínimo de validación (9 puntos):** correo ingresado vs. Excel (primera carga), CCT, nivel, campo obligatorio por hoja, columnas obligatorias, valores válidos (0-3), estructura general de archivo, número de hojas, consistencia interna.
+- **RF-16.3** Si el archivo es válido, el sistema debe mostrar el mensaje "Tu archivo ha sido validado correctamente. Generamos una contraseña aleatoria y podrás consultar tus resultados a partir del día: [hoy + 4 días]".
+- **RF-16.4** En la primera carga válida se deben generar credenciales de consulta con **usuario = correo validado** (reutilizable para múltiples CCT) y **contraseña = cadena aleatoria**; no se regeneran en cargas posteriores.
+- **RF-16.5** El sistema debe generar y descargar automáticamente un PDF de confirmación con mensaje de éxito, fecha futura de consulta, usuario (correo), contraseña aleatoria y marca de tiempo; si es inválido o falla la coincidencia de correo, debe descargar PDF de errores.
 - **RF-16.6** Cada carga válida debe registrarse como solicitud independiente con consecutivo y almacenarse en un repositorio de archivos recibidos.
 - **RF-16.7** El sistema no determinará si el envío corresponde a primera o segunda aplicación ni comparará/mezclará archivos; solo registrará solicitudes.
 - **RF-16.8** La generación de resultados, comparativos y paquetes ZIP corresponde a un sistema externo; el portal solo debe mostrar las ligas de descarga depositadas externamente.
-- **RF-16.9** El módulo de descarga debe permitir autenticación por CCT y contraseña para listar todas las versiones disponibles con número consecutivo y liga de descarga.
+- **RF-16.9** El módulo de descarga debe permitir autenticación por correo y contraseña para listar todas las versiones disponibles con número consecutivo y liga de descarga.
 - **RF-16.10** El sistema debe ofrecer un panel básico de monitoreo técnico para seguimiento de solicitudes y descargas.
 
 ---
@@ -461,16 +461,16 @@ graph TB
 - El portal de carga es público y **no requiere autenticación previa** para subir el archivo.
 
 **Flujo Principal:**
-1. Director accede al portal público (URL: https://evaluaciones.sep.gob.mx) y selecciona el archivo .xlsx.
-2. El portal muestra el indicador **"Validando tu archivo..."** mientras ejecuta las verificaciones automáticas.
+1. Director accede al portal público (URL: https://evaluaciones.sep.gob.mx), captura su correo (será su usuario y puede usarse para varios CCT) y con ello se habilita el selector del archivo .xlsx.
+2. Selecciona el archivo .xlsx y el portal muestra el indicador **"Validando tu archivo con el correo ingresado..."** mientras ejecuta las verificaciones automáticas.
 3. El sistema valida de forma inmediata:
    - Extensión .xlsx válida ✓
    - Archivo no corrupto ✓
-4. El sistema ejecuta validaciones backend (30-45 segundos) alineadas al checklist de 9 puntos del documento final:
+4. El sistema ejecuta validaciones backend (30-45 segundos) alineadas al checklist de 9 puntos del documento final y respetando el orden de coincidencia de correo en la primera carga:
    ```
+   Validando correo ingresado vs. correo del Excel... ✓
    Validando estructura... ✓
    Validando CCT... ✓
-   Validando correo... ✓
    Validando nivel... ✓
    Validando valores (0-3)... ✓
    Validando campos obligatorios... ✓
@@ -479,9 +479,9 @@ graph TB
    Verificando consistencia interna... ✓
    ```
 5. **SI todas las validaciones son exitosas:**
-    - Sistema muestra mensaje de éxito con fecha futura: **"Tu archivo ha sido validado correctamente. Podrás consultar tus resultados a partir del día: [hoy + 4 días]"**.
-    - Para la primera carga válida, el sistema genera credenciales de consulta (**usuario = CCT**, **contraseña = correo validado**) y no las regenera en cargas posteriores.
-    - Se descarga automáticamente un PDF de confirmación con mensaje, fecha futura, usuario, contraseña y marca de tiempo.
+    - Sistema muestra mensaje de éxito con fecha futura: **"Tu archivo ha sido validado correctamente. Generamos una contraseña aleatoria y podrás consultar tus resultados a partir del día: [hoy + 4 días]"**.
+    - Para la primera carga válida de ese correo, el sistema genera credenciales de consulta (**usuario = correo validado**, **contraseña = cadena aleatoria**) y no las regenera en cargas posteriores.
+    - Se descarga automáticamente un PDF de confirmación con mensaje, fecha futura, usuario (correo), contraseña aleatoria y marca de tiempo.
     - Sistema registra la solicitud con consecutivo y almacena el archivo en el repositorio de recepción.
 
 6. **SI existen errores de validación:**
@@ -495,6 +495,7 @@ graph TB
     | 45   | D       | Val_ENS | Fuera de rango | 5 | 0-3 |
     | 78   | B       | Nombre | Campo vacío | (vacío) | Requerido |
     ```
+    - Cuando el correo capturado no coincide con el que viene en el Excel en la primera carga, se muestra el mensaje: **"El correo capturado no coincide con el que está en tu Excel. Corrige el dato en la pantalla o en el archivo y vuelve a intentarlo."**
     - Director puede:
       * Descargar reporte de errores (Excel)
       * Corregir archivo localmente
@@ -520,11 +521,11 @@ graph TB
 **Precondiciones:** Archivo .xlsx de segunda aplicación de EIA disponible localmente.
 
 **Flujo Principal:**
-1. Director ingresa al portal público y selecciona el archivo .xlsx.
-2. El portal muestra la etiqueta **"Validando tu archivo..."** mientras se procesa.
+1. Director ingresa al portal público, captura su correo (será su usuario y queda validado contra el Excel en la primera carga) y habilita el selector del archivo .xlsx.
+2. El portal muestra la etiqueta **"Validando tu archivo con el correo ingresado..."** mientras se procesa.
 3. El sistema ejecuta validaciones automáticas (9 puntos mínimos):
-   1. CCT
-   2. Correo
+   1. Coincidencia correo ingresado ↔ correo dentro del Excel (solo en la primera carga asociada a ese correo)
+   2. CCT
    3. Nivel educativo
    4. Campo obligatorio por hoja
    5. Columnas obligatorias
@@ -533,15 +534,15 @@ graph TB
    8. Número y nombre de hojas
    9. Consistencia interna
 4. **Si el archivo es válido:**
-   - Se muestra el mensaje de éxito con fecha futura de consulta (hoy + 4 días).
-   - Se generan credenciales solo en la primera carga válida (**usuario = CCT**, **contraseña = correo validado**) sin regeneración posterior.
-   - Se descarga automáticamente un PDF de confirmación con mensaje, fecha, usuario, contraseña y marca de tiempo.
+   - Se muestra el mensaje de éxito con fecha futura de consulta (hoy + 4 días) y se informa que se generó una contraseña aleatoria.
+   - Se generan credenciales solo en la primera carga válida (**usuario = correo validado**, **contraseña = cadena aleatoria**) sin regeneración posterior; el mismo correo puede asociarse a varios CCT.
+   - Se descarga automáticamente un PDF de confirmación con mensaje, fecha, usuario (correo), contraseña aleatoria y marca de tiempo.
    - Se registra la solicitud con consecutivo y se almacena el archivo en repositorio de recepción.
-5. **Si el archivo es inválido:**
-   - Se muestra mensaje de rechazo.
-   - Se descarga PDF de errores con detalles de validación incumplida.
+5. **Si el archivo es inválido o no coincide el correo en la primera carga:**
+   - Se muestra mensaje de rechazo con la alerta correspondiente.
+   - Se descarga PDF de errores con detalles de validación incumplida o de coincidencia de correo.
 6. El portal no determina si el envío corresponde a primera o segunda aplicación; cada carga válida queda como solicitud independiente.
-7. Cuando el sistema externo deposita resultados procesados, el director ingresa con CCT y contraseña para visualizar versiones consecutivas y ligas de descarga.
+7. Cuando el sistema externo deposita resultados procesados, el director ingresa con correo y contraseña para visualizar versiones consecutivas y ligas de descarga.
 
 **Postcondiciones:** Solicitud registrada, credenciales creadas solo en la primera validación exitosa y descarga de PDF de confirmación o errores.
 **Frecuencia:** Picos de 120,000 validaciones por ciclo (segunda aplicación EIA).
@@ -554,7 +555,7 @@ graph TB
 
 **Postcondiciones:**
 - Archivo válido almacenado en repositorio de recepción con consecutivo y metadatos de solicitud.
-- Credenciales creadas solo en la primera validación exitosa; cargas posteriores reutilizan mismas credenciales.
+- Credenciales creadas solo en la primera validación exitosa con usuario = correo y contraseña aleatoria; cargas posteriores reutilizan mismas credenciales.
 - Registro de auditoría de validaciones y descargas (logs de acceso/actividad).
 
 **Frecuencia:** Picos concentrados durante segunda aplicación EIA.

--- a/plataforma_recepcion_validacion_descarga_EIA.md
+++ b/plataforma_recepcion_validacion_descarga_EIA.md
@@ -10,7 +10,7 @@ El sistema no procesa ni genera resultados, únicamente recibe los archivos, val
 
 ## II. Objetivo General del Sistema
 
-Desarrollar una plataforma web que permita recibir archivos, validarlos automáticamente, generar credenciales de acceso (únicamente en la primera carga válida), registrar cada envío como una solicitud independiente y publicar las ligas de descarga correspondientes a los archivos procesados por un sistema externo.
+Desarrollar una plataforma web que permita recibir archivos, validarlos automáticamente, generar credenciales de acceso (únicamente en la primera carga válida con usuario = correo y contraseña aleatoria), registrar cada envío como una solicitud independiente y publicar las ligas de descarga correspondientes a los archivos procesados por un sistema externo. El mismo correo puede administrarse para varios CCT y siempre funge como identificador de inicio de sesión.
 
 ---
 
@@ -30,43 +30,51 @@ El sistema comprenderá:
 
 ## IV. Requerimientos Funcionales por módulo
 
-La plataforma permitirá subir un archivo .xlsx sin necesidad de autenticación previa.
+La plataforma permitirá subir un archivo .xlsx sin necesidad de autenticación previa **solo después de que el usuario capture su correo**, el cual se convierte en su identificador y debe coincidir con el correo declarado dentro del Excel en la primera carga.
 
-Al seleccionar el archivo aparecerá la etiqueta: **"Validando tu archivo..."**
+Al habilitar el selector de archivo aparecerá la etiqueta: **"Validando tu archivo con el correo ingresado..."**
 
 La validación se ejecutará automáticamente revisando:
 
-1. CCT  
-2. Correo  
-3. Nivel  
-4. Campo obligatorio por hoja  
-5. Columnas obligatorias  
-6. Valores válidos (0-3)  
-7. Estructura general de archivo  
-8. Número de hojas  
-9. Consistencia interna  
+1. Coincidencia entre el correo ingresado y el correo dentro del Excel (solo en la primera carga ligada a ese correo)
+2. CCT
+3. Nivel
+4. Campo obligatorio por hoja
+5. Columnas obligatorias
+6. Valores válidos (0-3)
+7. Estructura general de archivo
+8. Número de hojas
+9. Consistencia interna
 
 Si el archivo es válido, el sistema mostrará el mensaje:
 
-**"Tu archivo ha sido validado correctamente. Podrás consultar tus resultados a partir del día: [fecha = hoy + 4 días]"**
+**"Tu archivo ha sido validado correctamente. Generamos una contraseña aleatoria y podrás consultar tus resultados a partir del día: [fecha = hoy + 4 días]"**
 
 Si el archivo es válido, el sistema deberá generar credenciales para consulta futura de resultados, donde:
 
-- **Usuario = CCT validado**  
-- **Contraseña = Correo validado en la primera carga válida.**  
-  - En cargas posteriores NO se regenera contraseña.
+- **Usuario = correo ingresado y validado contra el Excel** (el mismo correo puede vincularse a varios CCT).
+- **Contraseña = cadena aleatoria generada en la primera carga válida** (no se regenera en cargas posteriores; permanece asociada al correo).
 
 El sistema generará automáticamente un **PDF de confirmación**, que incluirá:
 
-- Mensaje: "Archivo validado correctamente"  
-- Fecha futura en que podrá consultar resultados  
-- Usuario (CCT)  
-- Contraseña (correo validado)  
-- Marca de tiempo de la validación  
+- Mensaje de éxito actualizado
+- Fecha futura en que podrá consultar resultados
+- Usuario (correo validado)
+- Contraseña aleatoria generada
+- Marca de tiempo de la validación
 
 El PDF se descargará automáticamente.
 
-Si el archivo es inválido, se mostrará un mensaje de rechazo y se generará el **PDF de errores**.
+Si el archivo es inválido o el correo capturado no coincide con el del Excel en la primera carga, se mostrará un mensaje de rechazo y se generará el **PDF de errores**.
+
+**Mensajes de UX actualizados:**
+
+- **Entrada de correo:** "Escribe el correo institucional que usarás como usuario. Podrás reutilizarlo para diferentes CCT."
+- **Estado de validación:** "Validando tu archivo con el correo ingresado…"
+- **Éxito primera carga:** "Tu archivo ha sido validado correctamente. Generamos tu contraseña aleatoria: [*******]. Guarda este dato; tus descargas y reenvíos se harán con tu correo y esta contraseña. Podrás consultar tus resultados a partir del día: [hoy + 4 días]."
+- **Reenvío éxito (correo existente):** "Archivo validado. Conserva tu correo como usuario; tu contraseña sigue siendo la misma creada en tu primera carga válida."
+- **Error por correo que no coincide con Excel (primera vez):** "El correo capturado no coincide con el que está en tu Excel. Corrige el dato en la pantalla o en el archivo y vuelve a intentarlo."
+- **Error genérico de validación:** "No pudimos validar tu archivo. Descarga el PDF con los detalles y corrige antes de reenviar."
 
 ---
 
@@ -118,12 +126,12 @@ La plataforma únicamente mostrará las ligas de descarga generadas externamente
 
 ### 5. Módulo de Descarga de Resultados
 
-El usuario accede con su **CCT y contraseña (correo validado)** para consultar todas las versiones de resultados que se hayan generado externamente.
+El usuario accede con su **correo y contraseña aleatoria generada en la primera carga válida** para consultar todas las versiones de resultados que se hayan generado externamente, aun cuando el mismo correo se use para varios CCT.
 
 Cada versión aparecerá con:
 
-- Número consecutivo  
-- Liga de descarga  
+- Número consecutivo
+- Liga de descarga
 
 ---
 


### PR DESCRIPTION
## Summary
- describe the email-first upload flow, new validation order, and random password generation in README
- align the EIA platform specification with email as username, reusable addresses across CCTs, and updated UX copy for prompts and errors
- refresh requirements and use cases to reflect the new validation order, credential rules, and messaging for first uploads and reuploads

## Testing
- Not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408d20ac8083208500a1205b11eb0d)