### PR TITLE
Add email validation gate to carga masiva upload

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -9,17 +9,36 @@
   </div>
 
   <div class="carga__zona" [class.carga__zona--error]="estado === 'error'">
+    <div class="carga__campo">
+      <label for="correo" class="carga__etiqueta">Correo electrónico de contacto</label>
+      <input
+        id="correo"
+        type="email"
+        [formControl]="correoControl"
+        class="carga__input-texto"
+        placeholder="ejemplo@correo.mx"
+        autocomplete="email"
+      >
+      <p class="carga__mensaje carga__mensaje--error" *ngIf="correoControl.touched && correoControl.invalid">
+        <ng-container *ngIf="correoControl.errors?.['required']">El correo es obligatorio.</ng-container>
+        <ng-container *ngIf="correoControl.errors?.['email'] || correoControl.errors?.['pattern']">
+          Ingresa un correo electrónico válido.
+        </ng-container>
+      </p>
+    </div>
+
     <div class="carga__instrucciones">
       <p class="carga__etiqueta">Arrastra y suelta tu archivo o selecciónalo desde tu equipo</p>
       <p class="carga__formatos">Solo se aceptan archivos XLSX. Máximo {{ pesoMaximoMb }} MB.</p>
     </div>
 
-    <label class="carga__input">
+    <label class="carga__input" [class.carga__input--disabled]="!correoControl.valid">
       <input
         #archivoInput
         type="file"
         accept=".xlsx"
         (change)="onArchivoSeleccionado($event)"
+        [disabled]="!correoControl.valid"
       >
       <span class="carga__boton">Elegir archivo</span>
     </label>
@@ -73,7 +92,7 @@
       <button
         class="carga__boton-primario"
         (click)="guardarArchivo()"
-        [disabled]="estado !== 'exito' || guardando"
+        [disabled]="estado !== 'exito' || guardando || !correoControl.valid"
       >
         {{ guardando ? 'Guardando…' : 'Cargar Archivo' }}
       </button>

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
@@ -44,6 +44,32 @@
   gap: 1rem;
 }
 
+.carga__campo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+}
+
+.carga__input-texto {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.85rem 0.95rem;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.carga__input-texto:focus-visible {
+  border-color: #0f766e;
+  box-shadow: 0 0 0 4px rgba(15, 118, 110, 0.15);
+}
+
+.carga__input-texto.ng-invalid.ng-touched {
+  border-color: #b91c1c;
+  background: #fef2f2;
+}
+
 .carga__zona--error {
   border-color: #b91c1c;
   background: #fef2f2;
@@ -70,11 +96,21 @@
   overflow: hidden;
 }
 
+.carga__input--disabled .carga__boton {
+  background: #9ca3af;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
 .carga__input input[type='file'] {
   position: absolute;
   inset: 0;
   opacity: 0;
   cursor: pointer;
+}
+
+.carga__input input[type='file']:disabled {
+  cursor: not-allowed;
 }
 
 .carga__boton {
@@ -231,6 +267,10 @@
   .carga__zona {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .carga__campo {
+    width: 100%;
   }
 
   .carga__acciones {

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
@@ -56,6 +56,7 @@ describe('CargaMasivaComponent', () => {
   });
 
   it('should reject files with unsupported extensions', async () => {
+    component.correoControl.setValue('demo@correo.mx');
     const input = document.createElement('input');
     const archivo = new File(['contenido'], 'archivo.txt', { type: 'text/plain' });
     Object.defineProperty(input, 'files', { value: [archivo] });

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { ExcelValidationService, ResultadoValidacion } from '../../services/excel-validation.service';
 import {
@@ -26,13 +27,20 @@ interface ResultadoExito {
 @Component({
   selector: 'app-carga-masiva',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, ReactiveFormsModule],
   templateUrl: './carga-masiva.component.html',
   styleUrl: './carga-masiva.component.scss'
 })
 export class CargaMasivaComponent implements OnInit {
   readonly extensionesPermitidas = ['.xlsx'];
   readonly pesoMaximoMb = 10;
+  private readonly correoKey = 'correo-carga-preescolar';
+  private readonly correoPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  readonly correoControl = new FormControl('', {
+    nonNullable: true,
+    validators: [Validators.required, Validators.email, Validators.pattern(this.correoPattern)]
+  });
 
   archivoSeleccionado: SelectedFile | null = null;
   archivoOriginal: File | null = null;
@@ -59,6 +67,20 @@ export class CargaMasivaComponent implements OnInit {
       void this.router.navigate(['/login'], { queryParams: { redirect: '/carga-masiva' } });
       return;
     }
+
+    const correoGuardado = localStorage.getItem(this.correoKey);
+    if (correoGuardado) {
+      this.correoControl.setValue(correoGuardado);
+    }
+
+    this.correoControl.valueChanges.subscribe((value) => {
+      const correo = value?.trim();
+      if (correo) {
+        localStorage.setItem(this.correoKey, correo);
+      } else {
+        localStorage.removeItem(this.correoKey);
+      }
+    });
   }
 
   async onArchivoSeleccionado(evento: Event): Promise<void> {
@@ -66,6 +88,17 @@ export class CargaMasivaComponent implements OnInit {
     const file = input.files?.[0];
 
     this.resetMensajes();
+
+    if (!this.correoControl.valid) {
+      this.correoControl.markAllAsTouched();
+      await Swal.fire({
+        icon: 'warning',
+        title: 'Correo requerido',
+        text: 'Ingresa un correo válido antes de seleccionar el archivo.'
+      });
+      this.limpiarSeleccion(input);
+      return;
+    }
 
     if (this.authService.requiereLoginParaNuevaCarga()) {
       await Swal.fire({
@@ -132,6 +165,17 @@ export class CargaMasivaComponent implements OnInit {
   }
 
   async guardarArchivo(): Promise<void> {
+    if (!this.correoControl.valid) {
+      this.correoControl.markAllAsTouched();
+      this.errorGuardado = 'Agrega un correo electrónico válido para continuar con la carga.';
+      await Swal.fire({
+        icon: 'warning',
+        title: 'Correo requerido',
+        text: this.errorGuardado
+      });
+      return;
+    }
+
     if (!this.archivoOriginal || this.estado !== 'exito') {
       this.errorGuardado = 'Primero valida correctamente tu archivo para poder guardarlo.';
       await Swal.fire({


### PR DESCRIPTION
## Summary
- add a required email field with inline validation and persistence to the carga masiva flow
- block file selection and upload actions until a valid email is provided, showing SweetAlert warnings when needed
- style the new input and update specs accordingly

## Testing
- npm install *(fails: npm registry access returned 403)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69409a4d31ac8320b02dd99b71ae39e1)