### PR TITLE
Implement email-based session handling for uploads

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
@@ -18,6 +18,7 @@
       <thead>
         <tr>
           <th>Nombre</th>
+          <th>CCT</th>
           <th>Peso (KB)</th>
           <th>Fecha de guardado</th>
           <th>Ruta de referencia</th>
@@ -27,6 +28,7 @@
       <tbody>
         <tr *ngFor="let registro of registros">
           <td data-label="Nombre">{{ registro.nombre }}</td>
+          <td data-label="CCT">{{ registro.cct }}</td>
           <td data-label="Peso">{{ (registro.tamano / 1024) | number:'1.0-2' }}</td>
           <td data-label="Fecha">{{ registro.fechaGuardado | date:'medium' }}</td>
           <td data-label="Ruta">{{ registro.ruta }}</td>

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.spec.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.spec.ts
@@ -1,21 +1,31 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArchivosGuardadosComponent } from './archivos-guardados.component';
 import { ArchivoStorageService, RegistroArchivo } from '../../services/archivo-storage.service';
+import { AuthService } from '../../services/auth.service';
 
 class ArchivoStorageServiceStub {
-  obtenerRegistros(): RegistroArchivo[] {
+  obtenerRegistros(_email?: string | null): RegistroArchivo[] {
     return [
       {
         nombre: 'demo.xlsx',
         tamano: 2048,
         fechaGuardado: new Date().toISOString(),
         ruta: 'assets/archivos/preescolar/demo.xlsx',
-        contenidoBase64: 'ZGF0YQ=='
+        contenidoBase64: 'ZGF0YQ==',
+        hash: 'hash-demo',
+        cct: '01DJN0000A',
+        email: 'demo@correo.mx'
       }
     ];
   }
 
   descargarRegistro(): void {}
+}
+
+class AuthServiceStub {
+  obtenerSesionActiva(): { email: string } {
+    return { email: 'demo@correo.mx' };
+  }
 }
 
 describe('ArchivosGuardadosComponent', () => {
@@ -25,7 +35,10 @@ describe('ArchivosGuardadosComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ArchivosGuardadosComponent],
-      providers: [{ provide: ArchivoStorageService, useClass: ArchivoStorageServiceStub }]
+      providers: [
+        { provide: ArchivoStorageService, useClass: ArchivoStorageServiceStub },
+        { provide: AuthService, useClass: AuthServiceStub }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ArchivosGuardadosComponent);

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -5,6 +5,7 @@ import {
   ArchivoStorageService,
   RegistroArchivo
 } from '../../services/archivo-storage.service';
+import { AuthService } from '../../services/auth.service';
 import Swal from 'sweetalert2';
 
 @Component({
@@ -18,16 +19,29 @@ export class ArchivosGuardadosComponent implements OnInit {
   registros: RegistroArchivo[] = [];
   mensajeInfo: string | null = null;
   mensajeError: string | null = null;
+  correoActivo: string | null = null;
 
-  constructor(private readonly archivoStorageService: ArchivoStorageService) {}
+  constructor(
+    private readonly archivoStorageService: ArchivoStorageService,
+    private readonly authService: AuthService
+  ) {}
 
   ngOnInit(): void {
+    const sesion = this.authService.obtenerSesionActiva();
+    this.correoActivo = sesion?.email ?? null;
+
+    if (!this.correoActivo) {
+      this.mensajeInfo =
+        'Inicia sesión con el correo de tu primera carga para ver los archivos almacenados en este navegador.';
+      return;
+    }
+
     this.cargarRegistros();
   }
 
   cargarRegistros(): void {
     this.mensajeError = null;
-    this.registros = this.archivoStorageService.obtenerRegistros();
+    this.registros = this.archivoStorageService.obtenerRegistros(this.correoActivo);
 
     if (this.registros.length === 0) {
       this.mensajeInfo = 'Aún no has cargado archivos de Preescolar en este navegador.';

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -76,8 +76,14 @@
         El PDF de confirmación se generará con los mismos datos cuando el backend esté disponible.
       </p>
       <div class="carga__credenciales">
-        <p><strong>Usuario (CCT):</strong> {{ resultadoExito.credenciales.usuario }}</p>
-        <p><strong>Contraseña (correo validado):</strong> {{ resultadoExito.credenciales.contrasena }}</p>
+        <p><strong>Correo de acceso:</strong> {{ resultadoExito.credenciales.usuario }}</p>
+        <p><strong>Contraseña de sesión:</strong> {{ resultadoExito.credenciales.contrasena }}</p>
+        <p
+          class="carga__mensaje carga__mensaje--warning"
+          *ngIf="resultadoExito.credenciales.esNueva"
+        >
+          Guarda esta contraseña: la necesitarás para futuras cargas con este correo.
+        </p>
       </div>
       <p class="carga__mensaje carga__mensaje--info" *ngIf="rutaGuardado">
         Archivo conservado en el almacenamiento local del navegador.

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CargaMasivaComponent } from './carga-masiva.component';
 import { ExcelValidationService, ResultadoValidacion } from '../../services/excel-validation.service';
 import { ArchivoStorageService } from '../../services/archivo-storage.service';
+import { AuthService } from '../../services/auth.service';
 
 const resultadoValido: ResultadoValidacion = {
   ok: true,
@@ -24,12 +25,30 @@ class ExcelValidationServiceStub {
 }
 
 class ArchivoStorageServiceStub {
-  guardarArchivoPreescolar(): Promise<{ rutaVirtual: string; modo: 'localStorage'; nota: string }> {
+  guardarArchivoPreescolar(
+    _archivo: File,
+    _contexto?: { email: string; cct: string },
+    _opciones?: { forzarReemplazo?: boolean }
+  ): Promise<{ rutaVirtual: string; modo: 'localStorage'; nota: string }> {
     return Promise.resolve({
       rutaVirtual: 'assets/archivos/preescolar/demo.xlsx',
       modo: 'localStorage',
       nota: 'Guardado en localStorage para referencia.'
     });
+  }
+}
+
+class AuthServiceStub {
+  normalizarCorreo(correo: string): string {
+    return (correo ?? '').trim().toLowerCase();
+  }
+
+  requiereLoginParaCorreo(): boolean {
+    return false;
+  }
+
+  registrarCarga(): { password: string; esNuevo: boolean } {
+    return { password: 'demoPass', esNuevo: true };
   }
 }
 
@@ -42,7 +61,8 @@ describe('CargaMasivaComponent', () => {
       imports: [CargaMasivaComponent],
       providers: [
         { provide: ExcelValidationService, useClass: ExcelValidationServiceStub },
-        { provide: ArchivoStorageService, useClass: ArchivoStorageServiceStub }
+        { provide: ArchivoStorageService, useClass: ArchivoStorageServiceStub },
+        { provide: AuthService, useClass: AuthServiceStub }
       ]
     }).compileComponents();
 

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -20,7 +20,7 @@ interface SelectedFile {
 interface ResultadoExito {
   mensaje: string;
   fechaDisponible: Date;
-  credenciales: { usuario: string; contrasena: string };
+  credenciales: { usuario: string; contrasena: string; esNueva: boolean };
   totalAlumnos: number;
 }
 
@@ -54,6 +54,7 @@ export class CargaMasivaComponent implements OnInit {
   errorGuardado: string | null = null;
   modoGuardado: 'localStorage' | null = null;
   notaGuardado: string | null = null;
+  ultimoCctValidado: string | null = null;
 
   constructor(
     private readonly excelValidationService: ExcelValidationService,
@@ -63,14 +64,13 @@ export class CargaMasivaComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    if (this.authService.requiereLoginParaNuevaCarga()) {
-      void this.router.navigate(['/login'], { queryParams: { redirect: '/carga-masiva' } });
-      return;
-    }
-
     const correoGuardado = localStorage.getItem(this.correoKey);
     if (correoGuardado) {
       this.correoControl.setValue(correoGuardado);
+      if (this.authService.requiereLoginParaCorreo(correoGuardado)) {
+        void this.router.navigate(['/login'], { queryParams: { redirect: '/carga-masiva' } });
+        return;
+      }
     }
 
     this.correoControl.valueChanges.subscribe((value) => {
@@ -100,11 +100,11 @@ export class CargaMasivaComponent implements OnInit {
       return;
     }
 
-    if (this.authService.requiereLoginParaNuevaCarga()) {
+    if (this.authService.requiereLoginParaCorreo(this.correoControl.value)) {
       await Swal.fire({
         icon: 'info',
         title: 'Inicia sesión',
-        text: 'Ya registraste un envío. Inicia sesión para cargar un nuevo archivo.',
+        text: 'Ya registraste un envío con este correo. Inicia sesión para cargar un nuevo archivo.',
         confirmButtonText: 'Ir a login'
       });
       void this.router.navigate(['/login'], { queryParams: { redirect: '/carga-masiva' } });
@@ -186,6 +186,16 @@ export class CargaMasivaComponent implements OnInit {
       return;
     }
 
+    if (!this.ultimoCctValidado) {
+      this.errorGuardado = 'Vuelve a validar el archivo para recuperar el CCT asociado.';
+      await Swal.fire({
+        icon: 'warning',
+        title: 'Datos incompletos',
+        text: this.errorGuardado
+      });
+      return;
+    }
+
     this.guardando = true;
     this.errorGuardado = null;
     this.rutaGuardado = null;
@@ -193,7 +203,10 @@ export class CargaMasivaComponent implements OnInit {
     this.notaGuardado = null;
 
     try {
-      const resultado = await this.archivoStorageService.guardarArchivoPreescolar(this.archivoOriginal);
+      const resultado = await this.archivoStorageService.guardarArchivoPreescolar(this.archivoOriginal, {
+        email: this.authService.normalizarCorreo(this.correoControl.value),
+        cct: this.ultimoCctValidado
+      });
       await this.mostrarConfirmacionGuardado(resultado, 'guardado');
     } catch (error) {
       if (error instanceof ArchivoDuplicadoError) {
@@ -210,6 +223,10 @@ export class CargaMasivaComponent implements OnInit {
           try {
             const resultadoReemplazo = await this.archivoStorageService.guardarArchivoPreescolar(
               this.archivoOriginal,
+              {
+                email: this.authService.normalizarCorreo(this.correoControl.value),
+                cct: this.ultimoCctValidado
+              },
               { forzarReemplazo: true }
             );
             await this.mostrarConfirmacionGuardado(resultadoReemplazo, 'reemplazo');
@@ -242,6 +259,7 @@ export class CargaMasivaComponent implements OnInit {
   private procesarResultado(resultado: ResultadoValidacion): void {
     this.errores = resultado.errores;
     this.advertencias = resultado.advertencias;
+    this.ultimoCctValidado = null;
 
     if (!resultado.ok || !resultado.esc) {
       this.estado = 'error';
@@ -249,18 +267,37 @@ export class CargaMasivaComponent implements OnInit {
       return;
     }
 
-    if (!this.authService.coincidenCredenciales(resultado.esc.cct, resultado.esc.correo)) {
-      this.estado = 'error';
-      this.mensajeInformativo = null;
-      this.errores = [
-        ...this.errores,
-        'El CCT y el correo deben coincidir con los registrados en tu primer envío.'
-      ];
-      return;
-    }
-
     try {
-      this.authService.registrarCredenciales(resultado.esc.cct, resultado.esc.correo);
+      const correoFormulario = this.authService.normalizarCorreo(this.correoControl.value);
+      const correoArchivo = this.authService.normalizarCorreo(resultado.esc.correo);
+      const cctNormalizado = (resultado.esc.cct ?? '').trim().toUpperCase();
+
+      if (correoFormulario !== correoArchivo) {
+        this.estado = 'error';
+        this.mensajeInformativo = null;
+        this.errores = [
+          ...this.errores,
+          'El correo del formulario debe coincidir con el capturado en el archivo.'
+        ];
+        return;
+      }
+
+      const registroCuenta = this.authService.registrarCarga(correoFormulario, cctNormalizado);
+      this.ultimoCctValidado = cctNormalizado;
+      const fechaDisponible = this.calcularFechaDisponible();
+
+      this.estado = 'exito';
+      this.mensajeInformativo = 'Tu archivo ha sido validado correctamente.';
+      this.resultadoExito = {
+        mensaje: `Podrás consultar tus resultados a partir del día: ${fechaDisponible.toLocaleDateString()}`,
+        fechaDisponible,
+        credenciales: {
+          usuario: correoFormulario,
+          contrasena: registroCuenta.password,
+          esNueva: registroCuenta.esNuevo
+        },
+        totalAlumnos: resultado.alumnos?.length ?? 0
+      };
     } catch (error) {
       this.estado = 'error';
       this.mensajeInformativo = null;
@@ -268,23 +305,9 @@ export class CargaMasivaComponent implements OnInit {
         ...this.errores,
         error instanceof Error
           ? error.message
-          : 'No pudimos validar tus credenciales. Usa el CCT y correo originales.'
+          : 'No pudimos validar tus credenciales. Usa el correo de tu primer envío.'
       ];
-      return;
     }
-
-    const fechaDisponible = this.calcularFechaDisponible();
-    this.estado = 'exito';
-    this.mensajeInformativo = 'Tu archivo ha sido validado correctamente.';
-    this.resultadoExito = {
-      mensaje: `Podrás consultar tus resultados a partir del día: ${fechaDisponible.toLocaleDateString()}`,
-      fechaDisponible,
-      credenciales: {
-        usuario: resultado.esc.cct,
-        contrasena: resultado.esc.correo
-      },
-      totalAlumnos: resultado.alumnos?.length ?? 0
-    };
   }
 
   private calcularFechaDisponible(): Date {
@@ -305,6 +328,7 @@ export class CargaMasivaComponent implements OnInit {
     this.rutaGuardado = null;
     this.errorGuardado = null;
     this.modoGuardado = null;
+    this.ultimoCctValidado = null;
   }
 
   private async mostrarConfirmacionGuardado(

--- a/web/frontend/src/app/components/login/login.component.html
+++ b/web/frontend/src/app/components/login/login.component.html
@@ -1,22 +1,9 @@
 <section class="login">
   <div class="login__card">
     <h1>Inicia sesión para continuar</h1>
-    <p>Usa el CCT y el correo capturados en tu primer envío.</p>
+    <p>Usa el correo y la contraseña generada en tu primer envío exitoso.</p>
 
     <form (ngSubmit)="iniciarSesion()" #loginForm="ngForm" novalidate>
-      <label for="cct">CCT</label>
-      <input
-        id="cct"
-        name="cct"
-        type="text"
-        required
-        minlength="10"
-        maxlength="10"
-        [(ngModel)]="cct"
-        autocomplete="username"
-        placeholder="01DJN0000A"
-      />
-
       <label for="correo">Correo</label>
       <input
         id="correo"
@@ -26,6 +13,18 @@
         [(ngModel)]="correo"
         autocomplete="email"
         placeholder="correo@dominio.com"
+      />
+
+      <label for="password">Contraseña</label>
+      <input
+        id="password"
+        name="password"
+        type="password"
+        required
+        minlength="8"
+        [(ngModel)]="password"
+        autocomplete="current-password"
+        placeholder="Ingresa la contraseña generada"
       />
 
       <div class="login__error" *ngIf="error">{{ error }}</div>

--- a/web/frontend/src/app/components/login/login.component.ts
+++ b/web/frontend/src/app/components/login/login.component.ts
@@ -13,11 +13,12 @@ import { AuthService } from '../../services/auth.service';
   styleUrl: './login.component.scss'
 })
 export class LoginComponent implements OnInit {
-  cct = '';
   correo = '';
+  password = '';
   error: string | null = null;
   autenticando = false;
   redirect = '/carga-masiva';
+  correosRegistrados: string[] = [];
 
   constructor(
     private readonly authService: AuthService,
@@ -26,15 +27,17 @@ export class LoginComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const credenciales = this.authService.obtenerCredenciales();
-    if (!credenciales) {
+    this.correosRegistrados = this.authService.obtenerCuentasRegistradas();
+    if (this.correosRegistrados.length === 0) {
       void this.router.navigate(['/carga-masiva']);
       return;
     }
 
     this.redirect = this.route.snapshot.queryParamMap.get('redirect') ?? this.redirect;
-    this.cct = credenciales.cct;
-    this.correo = credenciales.correo;
+    const correoGuardado = localStorage.getItem('correo-carga-preescolar');
+    this.correo = correoGuardado
+      ? this.authService.normalizarCorreo(correoGuardado)
+      : this.correosRegistrados[0];
   }
 
   async iniciarSesion(): Promise<void> {
@@ -42,7 +45,7 @@ export class LoginComponent implements OnInit {
     this.autenticando = true;
 
     try {
-      this.authService.iniciarSesion(this.cct, this.correo);
+      this.authService.iniciarSesion(this.correo, this.password);
       await Swal.fire({
         icon: 'success',
         title: 'Sesión iniciada',

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -7,6 +7,8 @@ export interface RegistroArchivo {
   ruta: string;
   contenidoBase64: string;
   hash: string;
+  cct: string;
+  email: string;
 }
 
 export interface ResultadoGuardado {
@@ -28,24 +30,38 @@ export class ArchivoDuplicadoError extends Error {
 export class ArchivoStorageService {
   private readonly storageKey = 'archivos-preescolar';
 
+  private normalizarCorreo(correo: string): string {
+    return (correo ?? '').trim().toLowerCase();
+  }
+
+  private normalizarCct(cct: string): string {
+    return (cct ?? '').trim().toUpperCase();
+  }
+
   async guardarArchivoPreescolar(
     archivo: File,
+    contexto: { email: string; cct: string },
     opciones?: { forzarReemplazo?: boolean }
   ): Promise<ResultadoGuardado> {
     const rutaDestino = `assets/archivos/preescolar/${archivo.name}`;
     const buffer = await archivo.arrayBuffer();
     const hash = await this.calcularHash(buffer);
     const contenido = this.arrayBufferABase64(buffer);
+    const emailNormalizado = this.normalizarCorreo(contexto.email);
+    const cctNormalizado = this.normalizarCct(contexto.cct);
     const registro: RegistroArchivo = {
       nombre: archivo.name,
       tamano: archivo.size,
       fechaGuardado: new Date().toISOString(),
       ruta: rutaDestino,
       contenidoBase64: contenido,
-      hash
+      hash,
+      cct: cctNormalizado,
+      email: emailNormalizado
     };
 
-    const registros = this.obtenerRegistros();
+    const registrosPorCorreo = this.obtenerMapaRegistros();
+    const registros = registrosPorCorreo[emailNormalizado] ?? [];
     await this.agregarHashesFaltantes(registros);
 
     const duplicado = registros.find((registroGuardado) => registroGuardado.hash === hash);
@@ -55,9 +71,12 @@ export class ArchivoStorageService {
         throw new ArchivoDuplicadoError(duplicado);
       }
 
-      const registrosSinDuplicado = registros.filter((registroGuardado) => registroGuardado.hash !== hash);
+      const registrosSinDuplicado = registros
+        .filter((registroGuardado) => registroGuardado.hash !== hash)
+        .slice(0, 4);
       registrosSinDuplicado.unshift(registro);
-      localStorage.setItem(this.storageKey, JSON.stringify(registrosSinDuplicado.slice(0, 5)));
+      registrosPorCorreo[emailNormalizado] = registrosSinDuplicado;
+      localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
 
       return {
         rutaVirtual: rutaDestino,
@@ -70,7 +89,8 @@ export class ArchivoStorageService {
     }
 
     registros.unshift(registro);
-    localStorage.setItem(this.storageKey, JSON.stringify(registros.slice(0, 5)));
+    registrosPorCorreo[emailNormalizado] = registros.slice(0, 5);
+    localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
 
     return {
       rutaVirtual: rutaDestino,
@@ -82,19 +102,14 @@ export class ArchivoStorageService {
     };
   }
 
-  obtenerRegistros(): RegistroArchivo[] {
-    const guardados = localStorage.getItem(this.storageKey);
-    if (!guardados) {
+  obtenerRegistros(email: string | null): RegistroArchivo[] {
+    if (!email) {
       return [];
     }
 
-    try {
-      const registros = JSON.parse(guardados) as RegistroArchivo[];
-      return Array.isArray(registros) ? registros : [];
-    } catch (error) {
-      console.warn('No se pudieron leer los archivos guardados localmente', error);
-      return [];
-    }
+    const registros = this.obtenerMapaRegistros();
+    const correoNormalizado = this.normalizarCorreo(email);
+    return registros[correoNormalizado] ?? [];
   }
 
   descargarRegistro(registro: RegistroArchivo): void {
@@ -113,15 +128,19 @@ export class ArchivoStorageService {
   }
 
   eliminarRegistro(registroAEliminar: RegistroArchivo): void {
-    const registrosActualizados = this.obtenerRegistros().filter(
+    const registrosPorCorreo = this.obtenerMapaRegistros();
+    const correoNormalizado = this.normalizarCorreo(registroAEliminar.email);
+    const registrosActualizados = (registrosPorCorreo[correoNormalizado] ?? []).filter(
       (registro) =>
         !(
           registro.nombre === registroAEliminar.nombre &&
-          registro.fechaGuardado === registroAEliminar.fechaGuardado
+          registro.fechaGuardado === registroAEliminar.fechaGuardado &&
+          registro.hash === registroAEliminar.hash
         )
     );
 
-    localStorage.setItem(this.storageKey, JSON.stringify(registrosActualizados));
+    registrosPorCorreo[correoNormalizado] = registrosActualizados;
+    localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
   }
 
   private async agregarHashesFaltantes(registros: RegistroArchivo[]): Promise<void> {
@@ -136,7 +155,43 @@ export class ArchivoStorageService {
     }
 
     if (actualizado) {
-      localStorage.setItem(this.storageKey, JSON.stringify(registros));
+      const registrosPorCorreo = this.obtenerMapaRegistros();
+      const correo = registros[0]?.email;
+      if (correo) {
+        registrosPorCorreo[this.normalizarCorreo(correo)] = registros;
+        localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
+      }
+    }
+  }
+
+  private obtenerMapaRegistros(): Record<string, RegistroArchivo[]> {
+    const guardados = localStorage.getItem(this.storageKey);
+    if (!guardados) {
+      return {};
+    }
+
+    try {
+      const registros = JSON.parse(guardados) as Record<string, RegistroArchivo[]>;
+      if (!registros || typeof registros !== 'object') {
+        return {};
+      }
+
+      return Object.entries(registros).reduce<Record<string, RegistroArchivo[]>>(
+        (acumulado, [correo, lista]) => {
+          acumulado[this.normalizarCorreo(correo)] = Array.isArray(lista)
+            ? lista.map((registro) => ({
+                ...registro,
+                email: this.normalizarCorreo(registro.email ?? correo),
+                cct: this.normalizarCct(registro.cct ?? '')
+              }))
+            : [];
+          return acumulado;
+        },
+        {}
+      );
+    } catch (error) {
+      console.warn('No se pudieron leer los archivos guardados localmente', error);
+      return {};
     }
   }
 

--- a/web/frontend/src/app/services/auth.service.ts
+++ b/web/frontend/src/app/services/auth.service.ts
@@ -1,99 +1,149 @@
 import { Injectable } from '@angular/core';
 
-export interface CredencialesGuardadas {
-  cct: string;
-  correo: string;
+export interface CuentaGuardada {
+  email: string;
+  password: string;
+  ccts: string[];
+}
+
+interface SesionActiva {
+  email: string;
 }
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  private readonly credencialesKey = 'credenciales-preescolar';
+  private readonly cuentasKey = 'cuentas-preescolar';
   private readonly sesionKey = 'sesion-preescolar-activa';
 
-  obtenerCredenciales(): CredencialesGuardadas | null {
-    const guardadas = localStorage.getItem(this.credencialesKey);
-    if (!guardadas) {
-      return null;
-    }
-
-    try {
-      const parsed = JSON.parse(guardadas) as CredencialesGuardadas;
-      if (parsed?.cct && parsed?.correo) {
-        return {
-          cct: this.normalizarCct(parsed.cct),
-          correo: this.normalizarCorreo(parsed.correo)
-        };
-      }
-      return null;
-    } catch {
-      return null;
-    }
-  }
-
-  registrarCredenciales(cct: string, correo: string): void {
-    const credencialesActuales = this.obtenerCredenciales();
+  registrarCarga(email: string, cct: string): { password: string; esNuevo: boolean } {
+    const correoNormalizado = this.normalizarCorreo(email);
     const cctNormalizado = this.normalizarCct(cct);
-    const correoNormalizado = this.normalizarCorreo(correo);
+    const cuentas = this.obtenerCuentas();
+    const existente = cuentas.find((cuenta) => cuenta.email === correoNormalizado);
 
-    if (
-      credencialesActuales &&
-      (credencialesActuales.cct !== cctNormalizado || credencialesActuales.correo !== correoNormalizado)
-    ) {
-      throw new Error('Ya existe un acceso asociado a otro CCT o correo. Usa las credenciales originales.');
+    if (!existente) {
+      const password = this.generarContrasena();
+      cuentas.push({ email: correoNormalizado, password, ccts: [cctNormalizado] });
+      this.persistirCuentas(cuentas);
+      this.marcarSesionActiva(correoNormalizado);
+      return { password, esNuevo: true };
     }
 
-    localStorage.setItem(
-      this.credencialesKey,
-      JSON.stringify({ cct: cctNormalizado, correo: correoNormalizado })
-    );
-    this.cerrarSesion();
+    if (!this.estaAutenticado(correoNormalizado)) {
+      throw new Error('Ya existe una cuenta con este correo. Inicia sesión para continuar con nuevas cargas.');
+    }
+
+    if (!existente.ccts.includes(cctNormalizado)) {
+      existente.ccts.push(cctNormalizado);
+      this.persistirCuentas(cuentas);
+    }
+
+    return { password: existente.password, esNuevo: false };
   }
 
-  coincidenCredenciales(cct: string, correo: string): boolean {
-    const guardadas = this.obtenerCredenciales();
-    if (!guardadas) {
-      return true;
+  iniciarSesion(email: string, password: string): void {
+    const correoNormalizado = this.normalizarCorreo(email);
+    const cuentas = this.obtenerCuentas();
+    const cuenta = cuentas.find((c) => c.email === correoNormalizado);
+
+    if (!cuenta) {
+      throw new Error('Aún no hay una cuenta asociada a este correo. Realiza tu primera carga.');
     }
 
-    return (
-      guardadas.cct === this.normalizarCct(cct) && guardadas.correo === this.normalizarCorreo(correo)
-    );
-  }
-
-  iniciarSesion(cct: string, correo: string): void {
-    const guardadas = this.obtenerCredenciales();
-    if (!guardadas) {
-      throw new Error('Aún no hay credenciales registradas. Realiza tu primera carga para generarlas.');
+    if (cuenta.password !== password) {
+      throw new Error('La contraseña es incorrecta para este correo.');
     }
 
-    if (!this.coincidenCredenciales(cct, correo)) {
-      throw new Error('El CCT o el correo no coinciden con tu primer envío.');
-    }
-
-    this.marcarSesionActiva();
+    this.marcarSesionActiva(correoNormalizado);
   }
 
   cerrarSesion(): void {
     localStorage.removeItem(this.sesionKey);
   }
 
-  estaAutenticado(): boolean {
-    return localStorage.getItem(this.sesionKey) === 'true';
+  requiereLoginParaCorreo(email: string): boolean {
+    const correoNormalizado = this.normalizarCorreo(email);
+    return !!this.obtenerCuenta(correoNormalizado) && !this.estaAutenticado(correoNormalizado);
   }
 
-  requiereLoginParaNuevaCarga(): boolean {
-    return !!this.obtenerCredenciales() && !this.estaAutenticado();
+  estaAutenticado(email?: string): boolean {
+    const sesion = this.obtenerSesionActiva();
+    if (!sesion) {
+      return false;
+    }
+
+    if (!email) {
+      return true;
+    }
+
+    return sesion.email === this.normalizarCorreo(email);
   }
 
-  private marcarSesionActiva(): void {
-    localStorage.setItem(this.sesionKey, 'true');
+  obtenerSesionActiva(): SesionActiva | null {
+    const guardada = localStorage.getItem(this.sesionKey);
+    if (!guardada) {
+      return null;
+    }
+
+    try {
+      const sesion = JSON.parse(guardada) as SesionActiva;
+      return sesion?.email ? { email: sesion.email } : null;
+    } catch {
+      return null;
+    }
+  }
+
+  obtenerCuenta(email: string): CuentaGuardada | null {
+    const correoNormalizado = this.normalizarCorreo(email);
+    return this.obtenerCuentas().find((cuenta) => cuenta.email === correoNormalizado) ?? null;
+  }
+
+  obtenerCuentasRegistradas(): string[] {
+    return this.obtenerCuentas().map((cuenta) => cuenta.email);
+  }
+
+  private obtenerCuentas(): CuentaGuardada[] {
+    const guardadas = localStorage.getItem(this.cuentasKey);
+    if (!guardadas) {
+      return [];
+    }
+
+    try {
+      const cuentas = JSON.parse(guardadas) as CuentaGuardada[];
+      return Array.isArray(cuentas)
+        ? cuentas.map((cuenta) => ({
+            email: this.normalizarCorreo(cuenta.email),
+            password: cuenta.password,
+            ccts: (cuenta.ccts ?? []).map((cct) => this.normalizarCct(cct))
+          }))
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private persistirCuentas(cuentas: CuentaGuardada[]): void {
+    localStorage.setItem(this.cuentasKey, JSON.stringify(cuentas));
+  }
+
+  private marcarSesionActiva(email: string): void {
+    const sesion: SesionActiva = { email: this.normalizarCorreo(email) };
+    localStorage.setItem(this.sesionKey, JSON.stringify(sesion));
   }
 
   private normalizarCct(cct: string): string {
     return (cct ?? '').trim().toUpperCase();
   }
 
-  private normalizarCorreo(correo: string): string {
+  normalizarCorreo(correo: string): string {
     return (correo ?? '').trim().toLowerCase();
+  }
+
+  private generarContrasena(): string {
+    const randomBytes = crypto.getRandomValues(new Uint8Array(9));
+    const randomString = Array.from(randomBytes)
+      .map((byte) => String.fromCharCode(byte))
+      .join('');
+    return btoa(randomString).replace(/[^a-zA-Z0-9]/g, '').slice(0, 12);
   }
 }


### PR DESCRIPTION
## Summary
- store upload accounts per email with generated passwords and multiple CCT associations
- require email/password authentication after the first upload and adapt the login flow
- persist file metadata per email with associated CCT and updated guarded views

## Testing
- npm run build *(fails: missing NestJS dependencies in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69409c01c4ec832085590ceff8a7dd24)