### PR TITLE
Validate email on upload and scope duplicate hashes by CCT

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
@@ -3,6 +3,7 @@ import { CargaMasivaComponent } from './carga-masiva.component';
 import { ExcelValidationService, ResultadoValidacion } from '../../services/excel-validation.service';
 import { ArchivoStorageService } from '../../services/archivo-storage.service';
 import { AuthService } from '../../services/auth.service';
+import Swal from 'sweetalert2';
 
 const resultadoValido: ResultadoValidacion = {
   ok: true,
@@ -19,8 +20,10 @@ const resultadoValido: ResultadoValidacion = {
 };
 
 class ExcelValidationServiceStub {
+  resultado: ResultadoValidacion = resultadoValido;
+
   validarPreescolar(): Promise<ResultadoValidacion> {
-    return Promise.resolve(resultadoValido);
+    return Promise.resolve(this.resultado);
   }
 }
 
@@ -49,6 +52,10 @@ class AuthServiceStub {
 
   registrarCarga(): { password: string; esNuevo: boolean } {
     return { password: 'demoPass', esNuevo: true };
+  }
+
+  obtenerCuenta(): null {
+    return null;
   }
 }
 
@@ -86,5 +93,32 @@ describe('CargaMasivaComponent', () => {
     expect(component.estado).toBe('error');
     expect(component.errores[0]).toContain('Formato no permitido');
     expect(component.archivoSeleccionado).toBeNull();
+  });
+
+  it('should block when Excel email differs from the form', async () => {
+    const excelService = TestBed.inject(
+      ExcelValidationService
+    ) as unknown as ExcelValidationServiceStub;
+    excelService.resultado = {
+      ...resultadoValido,
+      esc: { ...resultadoValido.esc!, correo: 'otro@correo.mx' }
+    };
+
+    const swalSpy = spyOn(Swal, 'fire').and.resolveTo({} as any);
+
+    component.correoControl.setValue('demo@correo.mx');
+    const input = document.createElement('input');
+    const archivo = new File(['contenido'], 'archivo.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    });
+    Object.defineProperty(input, 'files', { value: [archivo] });
+
+    await component.onArchivoSeleccionado({ target: input } as unknown as Event);
+
+    expect(component.estado).toBe('error');
+    expect(component.errores).toContain(
+      'El correo del formulario debe coincidir con el capturado en el archivo.'
+    );
+    expect(swalSpy).toHaveBeenCalled();
   });
 });

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -148,7 +148,7 @@ export class CargaMasivaComponent implements OnInit {
     try {
       const buffer = await file.arrayBuffer();
       const resultado = await this.excelValidationService.validarPreescolar(buffer);
-      this.procesarResultado(resultado);
+      await this.procesarResultado(resultado);
     } catch (error) {
       this.estado = 'error';
       this.errores = [
@@ -256,7 +256,7 @@ export class CargaMasivaComponent implements OnInit {
     }
   }
 
-  private procesarResultado(resultado: ResultadoValidacion): void {
+  private async procesarResultado(resultado: ResultadoValidacion): Promise<void> {
     this.errores = resultado.errores;
     this.advertencias = resultado.advertencias;
     this.ultimoCctValidado = null;
@@ -279,6 +279,13 @@ export class CargaMasivaComponent implements OnInit {
           ...this.errores,
           'El correo del formulario debe coincidir con el capturado en el archivo.'
         ];
+
+        await Swal.fire({
+          icon: 'error',
+          title: 'Correo no coincide',
+          text: 'Para tu primer envío usa el mismo correo en la plantilla y en el formulario.'
+        });
+
         return;
       }
 

--- a/web/frontend/src/app/services/archivo-storage.service.spec.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.spec.ts
@@ -1,0 +1,70 @@
+import { ArchivoDuplicadoError, ArchivoStorageService } from './archivo-storage.service';
+
+describe('ArchivoStorageService', () => {
+  let service: ArchivoStorageService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    service = new ArchivoStorageService();
+  });
+
+  function crearArchivo(nombre: string, contenido: string): File {
+    return new File([contenido], nombre, {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    });
+  }
+
+  it('should detect duplicates by hash for the same email and CCT', async () => {
+    const hashSpy = spyOn<any>(service as any, 'calcularHash').and.returnValue(
+      Promise.resolve('hash-duplicado')
+    );
+    const archivo = crearArchivo('demo.xlsx', 'contenido');
+
+    await service.guardarArchivoPreescolar(archivo, { email: 'demo@correo.mx', cct: 'ABC1234567' });
+
+    await expectAsync(
+      service.guardarArchivoPreescolar(archivo, { email: 'demo@correo.mx', cct: 'ABC1234567' })
+    ).toBeRejectedWith(jasmine.any(ArchivoDuplicadoError));
+
+    expect(hashSpy).toHaveBeenCalled();
+  });
+
+  it('should allow identical hashes across different CCT values for the same email', async () => {
+    spyOn<any>(service as any, 'calcularHash').and.returnValue(Promise.resolve('hash-compartido'));
+    const archivo = crearArchivo('demo.xlsx', 'contenido');
+
+    await service.guardarArchivoPreescolar(archivo, { email: 'demo@correo.mx', cct: 'ABC1234567' });
+    await service.guardarArchivoPreescolar(archivo, { email: 'demo@correo.mx', cct: 'DEF9876543' });
+
+    const registros = service.obtenerRegistros('demo@correo.mx');
+    expect(registros.length).toBe(2);
+    expect(registros.map((registro) => registro.cct)).toEqual(['DEF9876543', 'ABC1234567']);
+  });
+
+  it('should replace duplicates when forcing replacement for the same email and CCT', async () => {
+    spyOn<any>(service as any, 'calcularHash').and.returnValue(Promise.resolve('hash-reemplazo'));
+    const archivoOriginal = crearArchivo('demo.xlsx', 'contenido');
+    const archivoNuevo = crearArchivo('nuevo.xlsx', 'contenido distinto');
+
+    await service.guardarArchivoPreescolar(archivoOriginal, {
+      email: 'demo@correo.mx',
+      cct: 'ABC1234567'
+    });
+
+    await expectAsync(
+      service.guardarArchivoPreescolar(archivoOriginal, { email: 'demo@correo.mx', cct: 'ABC1234567' })
+    ).toBeRejectedWith(jasmine.any(ArchivoDuplicadoError));
+
+    const resultado = await service.guardarArchivoPreescolar(
+      archivoNuevo,
+      { email: 'demo@correo.mx', cct: 'ABC1234567' },
+      { forzarReemplazo: true }
+    );
+
+    const registros = service.obtenerRegistros('demo@correo.mx');
+    expect(registros.length).toBe(1);
+    expect(registros[0].nombre).toBe('nuevo.xlsx');
+    expect(registros[0].cct).toBe('ABC1234567');
+    expect(resultado.nota).toContain('Se reemplazó el archivo previo');
+  });
+});

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -64,7 +64,10 @@ export class ArchivoStorageService {
     const registros = registrosPorCorreo[emailNormalizado] ?? [];
     await this.agregarHashesFaltantes(registros);
 
-    const duplicado = registros.find((registroGuardado) => registroGuardado.hash === hash);
+    const duplicado = registros.find(
+      (registroGuardado) =>
+        registroGuardado.hash === hash && registroGuardado.cct === cctNormalizado
+    );
 
     if (duplicado) {
       if (!opciones?.forzarReemplazo) {
@@ -72,7 +75,10 @@ export class ArchivoStorageService {
       }
 
       const registrosSinDuplicado = registros
-        .filter((registroGuardado) => registroGuardado.hash !== hash)
+        .filter(
+          (registroGuardado) =>
+            !(registroGuardado.hash === hash && registroGuardado.cct === cctNormalizado)
+        )
         .slice(0, 4);
       registrosSinDuplicado.unshift(registro);
       registrosPorCorreo[emailNormalizado] = registrosSinDuplicado;


### PR DESCRIPTION
## Summary
- ensure the upload flow validates Excel and form emails together and surfaces SweetAlert feedback when they differ
- adjust local duplicate detection to work per email and CCT while still allowing replacements of matching hashes
- add unit coverage for email mismatch handling and duplicate storage scenarios across multiple CCT values

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69409e364c648320a840d19b9a7e6536)