### PR TITLE
Ajustar credenciales de acceso por correo

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -222,7 +222,11 @@ export class CargaMasivaComponent implements OnInit {
           try {
             const resultadoReemplazo = await this.archivoStorageService.guardarArchivoPreescolar(
               this.archivoOriginal,
-              { forzarReemplazo: true }
+              {
+                forzarReemplazo: true,
+                cct: this.escDatos?.cct,
+                correo: this.correoControl.value
+              }
             );
             await this.mostrarConfirmacionGuardado(resultadoReemplazo, 'reemplazo');
             return;
@@ -276,7 +280,10 @@ export class CargaMasivaComponent implements OnInit {
 
     try {
       habiaCredenciales = !!this.authService.obtenerCredenciales();
-      this.authService.registrarCredenciales(resultado.esc.cct, resultado.esc.correo);
+      const nuevasCredenciales = this.authService.registrarCredenciales(
+        resultado.esc.cct,
+        resultado.esc.correo
+      );
     } catch (error) {
       this.estado = 'error';
       this.mensajeInformativo = null;
@@ -292,16 +299,16 @@ export class CargaMasivaComponent implements OnInit {
     const fechaDisponible = this.calcularFechaDisponible();
     this.estado = 'exito';
     this.mensajeInformativo = 'Tu archivo ha sido validado correctamente.';
-    this.resultadoExito = {
-      mensaje: `Podrás consultar tus resultados a partir del día: ${fechaDisponible.toLocaleDateString()}`,
-      fechaDisponible,
-      credenciales: {
-        usuario: resultado.esc.cct,
-        contrasena: resultado.esc.correo,
-        esNueva: !habiaCredenciales
-      },
-      totalAlumnos: resultado.alumnos?.length ?? 0
-    };
+      this.resultadoExito = {
+        mensaje: `Podrás consultar tus resultados a partir del día: ${fechaDisponible.toLocaleDateString()}`,
+        fechaDisponible,
+        credenciales: {
+        usuario: resultado.esc.correo,
+        contrasena: nuevasCredenciales.contrasena,
+        esNueva: nuevasCredenciales.esNueva && !habiaCredenciales
+        },
+        totalAlumnos: resultado.alumnos?.length ?? 0
+      };
   }
 
   private calcularFechaDisponible(): Date {

--- a/web/frontend/src/app/components/login/login.component.html
+++ b/web/frontend/src/app/components/login/login.component.html
@@ -1,23 +1,10 @@
 <section class="login">
   <div class="login__card">
     <h1>Inicia sesión para continuar</h1>
-    <p>Usa el CCT y el correo capturados en tu primer envío.</p>
+    <p>Usa el correo y la contraseña generada en tu primer envío.</p>
 
     <form (ngSubmit)="iniciarSesion()" #loginForm="ngForm" novalidate>
-      <label for="cct">CCT</label>
-      <input
-        id="cct"
-        name="cct"
-        type="text"
-        required
-        minlength="10"
-        maxlength="10"
-        [(ngModel)]="cct"
-        autocomplete="username"
-        placeholder="01DJN0000A"
-      />
-
-      <label for="correo">Correo</label>
+      <label for="correo">Correo (usuario)</label>
       <input
         id="correo"
         name="correo"
@@ -26,6 +13,17 @@
         [(ngModel)]="correo"
         autocomplete="email"
         placeholder="correo@dominio.com"
+      />
+
+      <label for="contrasena">Contraseña</label>
+      <input
+        id="contrasena"
+        name="contrasena"
+        type="password"
+        required
+        [(ngModel)]="contrasena"
+        autocomplete="current-password"
+        placeholder="Clave enviada en tu primer carga"
       />
 
       <div class="login__error" *ngIf="error">{{ error }}</div>

--- a/web/frontend/src/app/components/login/login.component.ts
+++ b/web/frontend/src/app/components/login/login.component.ts
@@ -13,8 +13,8 @@ import { AuthService } from '../../services/auth.service';
   styleUrl: './login.component.scss'
 })
 export class LoginComponent implements OnInit {
-  cct = '';
   correo = '';
+  contrasena = '';
   error: string | null = null;
   autenticando = false;
   redirect = '/carga-masiva';
@@ -33,7 +33,6 @@ export class LoginComponent implements OnInit {
     }
 
     this.redirect = this.route.snapshot.queryParamMap.get('redirect') ?? this.redirect;
-    this.cct = credenciales.cct;
     this.correo = credenciales.correo;
   }
 
@@ -42,7 +41,7 @@ export class LoginComponent implements OnInit {
     this.autenticando = true;
 
     try {
-      this.authService.iniciarSesion(this.cct, this.correo);
+      this.authService.iniciarSesion(this.correo, this.contrasena);
       await Swal.fire({
         icon: 'success',
         title: 'Sesión iniciada',

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -32,12 +32,24 @@ export class ArchivoStorageService {
 
   async guardarArchivoPreescolar(
     archivo: File,
-    opciones?: { forzarReemplazo?: boolean; cct?: string; correo?: string }
+    parametros?: { forzarReemplazo?: boolean; cct?: string; correo?: string; email?: string },
+    opciones?: { forzarReemplazo?: boolean }
   ): Promise<ResultadoGuardado> {
     const rutaDestino = `assets/archivos/preescolar/${archivo.name}`;
     const buffer = await archivo.arrayBuffer();
     const hash = await this.calcularHash(buffer);
     const contenido = this.arrayBufferABase64(buffer);
+    const emailNormalizado = this.normalizarCorreo(parametros?.correo ?? parametros?.email ?? '');
+    const registrosPorCorreo = this.obtenerMapaRegistros();
+    const registros = [...(registrosPorCorreo[emailNormalizado] ?? [])];
+    const forzarReemplazo = opciones?.forzarReemplazo ?? parametros?.forzarReemplazo ?? false;
+
+    const hashesActualizados = await this.agregarHashesFaltantes(registros);
+    if (hashesActualizados) {
+      registrosPorCorreo[emailNormalizado] = registros;
+      localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
+    }
+
     const registro: RegistroArchivo = {
       nombre: archivo.name,
       tamano: archivo.size,
@@ -45,23 +57,25 @@ export class ArchivoStorageService {
       ruta: rutaDestino,
       contenidoBase64: contenido,
       hash,
-      cct: opciones?.cct,
-      correo: this.normalizarCorreo(opciones?.correo ?? '') || undefined
+      cct: parametros?.cct,
+      correo: emailNormalizado || undefined
     };
 
-    const registros = this.obtenerRegistros();
-    await this.agregarHashesFaltantes(registros);
-
-    const duplicado = registros.find((registroGuardado) => registroGuardado.hash === hash);
+    const duplicado = registros.find(
+      (registroGuardado) => registroGuardado.hash === hash && registroGuardado.cct === registro.cct
+    );
 
     if (duplicado) {
-      if (!opciones?.forzarReemplazo) {
+      if (!forzarReemplazo) {
         throw new ArchivoDuplicadoError(duplicado);
       }
 
-      const registrosSinDuplicado = registros.filter((registroGuardado) => registroGuardado.hash !== hash);
-      registrosSinDuplicado.unshift(registro);
-      localStorage.setItem(this.storageKey, JSON.stringify(registrosSinDuplicado.slice(0, 5)));
+      const registrosSinDuplicado = registros.filter(
+        (registroGuardado) => !(registroGuardado.hash === hash && registroGuardado.cct === registro.cct)
+      );
+
+      registrosPorCorreo[emailNormalizado] = [registro, ...registrosSinDuplicado].slice(0, 5);
+      localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
 
       return {
         rutaVirtual: rutaDestino,
@@ -73,8 +87,7 @@ export class ArchivoStorageService {
       };
     }
 
-    registros.unshift(registro);
-    registrosPorCorreo[emailNormalizado] = registros.slice(0, 5);
+    registrosPorCorreo[emailNormalizado] = [registro, ...registros].slice(0, 5);
     localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
 
     return {
@@ -87,9 +100,8 @@ export class ArchivoStorageService {
     };
   }
 
-  obtenerRegistros(_email?: string | null): RegistroArchivo[] {
-    const guardados = localStorage.getItem(this.storageKey);
-    if (!guardados) {
+  obtenerRegistros(email?: string | null): RegistroArchivo[] {
+    if (!email) {
       return [];
     }
 
@@ -114,7 +126,13 @@ export class ArchivoStorageService {
   }
 
   eliminarRegistro(registroAEliminar: RegistroArchivo): void {
-    const registrosActualizados = this.obtenerRegistros().filter(
+    const correo = this.normalizarCorreo(registroAEliminar.correo ?? '');
+    if (!correo) {
+      return;
+    }
+
+    const registrosPorCorreo = this.obtenerMapaRegistros();
+    const registrosActualizados = (registrosPorCorreo[correo] ?? []).filter(
       (registro) =>
         !(
           registro.nombre === registroAEliminar.nombre &&
@@ -122,10 +140,11 @@ export class ArchivoStorageService {
         )
     );
 
-    localStorage.setItem(this.storageKey, JSON.stringify(registrosActualizados));
+    registrosPorCorreo[correo] = registrosActualizados;
+    localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
   }
 
-  private async agregarHashesFaltantes(registros: RegistroArchivo[]): Promise<void> {
+  private async agregarHashesFaltantes(registros: RegistroArchivo[]): Promise<boolean> {
     let actualizado = false;
 
     for (const registro of registros) {
@@ -136,8 +155,22 @@ export class ArchivoStorageService {
       }
     }
 
-    if (actualizado) {
-      localStorage.setItem(this.storageKey, JSON.stringify(registros));
+    return actualizado;
+  }
+
+  private obtenerMapaRegistros(): Record<string, RegistroArchivo[]> {
+    const guardados = localStorage.getItem(this.storageKey);
+
+    if (!guardados) {
+      return {};
+    }
+
+    try {
+      const registros = JSON.parse(guardados) as Record<string, RegistroArchivo[]>;
+      return registros ?? {};
+    } catch (error) {
+      console.error('No se pudieron leer los registros almacenados', error);
+      return {};
     }
   }
 

--- a/web/frontend/src/app/services/auth.service.ts
+++ b/web/frontend/src/app/services/auth.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 export interface CredencialesGuardadas {
   cct: string;
   correo: string;
+  contrasena: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -18,10 +19,11 @@ export class AuthService {
 
     try {
       const parsed = JSON.parse(guardadas) as CredencialesGuardadas;
-      if (parsed?.cct && parsed?.correo) {
+      if (parsed?.cct && parsed?.correo && parsed?.contrasena) {
         return {
           cct: this.normalizarCct(parsed.cct),
-          correo: this.normalizarCorreo(parsed.correo)
+          correo: this.normalizarCorreo(parsed.correo),
+          contrasena: parsed.contrasena
         };
       }
       return null;
@@ -30,7 +32,7 @@ export class AuthService {
     }
   }
 
-  registrarCredenciales(cct: string, correo: string): void {
+  registrarCredenciales(cct: string, correo: string): { contrasena: string; esNueva: boolean } {
     const credencialesActuales = this.obtenerCredenciales();
     const cctNormalizado = this.normalizarCct(cct);
     const correoNormalizado = this.normalizarCorreo(correo);
@@ -42,11 +44,16 @@ export class AuthService {
       throw new Error('Ya existe un acceso asociado a otro CCT o correo. Usa las credenciales originales.');
     }
 
+    const esNueva = !credencialesActuales;
+    const contrasena = credencialesActuales?.contrasena ?? this.generarContrasena();
+
     localStorage.setItem(
       this.credencialesKey,
-      JSON.stringify({ cct: cctNormalizado, correo: correoNormalizado })
+      JSON.stringify({ cct: cctNormalizado, correo: correoNormalizado, contrasena })
     );
     this.cerrarSesion();
+
+    return { contrasena, esNueva };
   }
 
   coincidenCredenciales(cct: string, correo: string): boolean {
@@ -60,14 +67,14 @@ export class AuthService {
     );
   }
 
-  iniciarSesion(cct: string, correo: string): void {
+  iniciarSesion(correo: string, contrasena: string): void {
     const guardadas = this.obtenerCredenciales();
     if (!guardadas) {
       throw new Error('Aún no hay credenciales registradas. Realiza tu primera carga para generarlas.');
     }
 
-    if (!this.coincidenCredenciales(cct, correo)) {
-      throw new Error('El CCT o el correo no coinciden con tu primer envío.');
+    if (guardadas.correo !== this.normalizarCorreo(correo) || guardadas.contrasena !== contrasena) {
+      throw new Error('El correo o la contraseña no coinciden con tu primer envío.');
     }
 
     this.marcarSesionActiva();
@@ -95,5 +102,16 @@ export class AuthService {
 
   private normalizarCorreo(correo: string): string {
     return (correo ?? '').trim().toLowerCase();
+  }
+
+  private generarContrasena(): string {
+    const caracteres = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+    let contrasena = '';
+
+    for (let i = 0; i < 12; i++) {
+      contrasena += caracteres.charAt(Math.floor(Math.random() * caracteres.length));
+    }
+
+    return contrasena;
   }
 }


### PR DESCRIPTION
## Summary
- Generar y persistir una contraseña aleatoria asociada al correo desde la primera carga
- Mostrar el correo como usuario y la contraseña guardada en la confirmación de la carga masiva
- Actualizar el formulario de login para solicitar correo y contraseña en lugar de CCT

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941d0a008588320a4fd58085afe1193)