### PR TITLE
Prefill email for authenticated users

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -388,5 +388,9 @@ export class CargaMasivaComponent implements OnInit {
     this.sesionActiva = this.authService.estaAutenticado();
     this.tieneCredenciales = !!credenciales;
     this.correoSesion = credenciales?.correo ?? null;
+
+    if (this.sesionActiva && credenciales?.correo && !this.correoControl.value.trim()) {
+      this.correoControl.setValue(credenciales.correo);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- prefill the carga masiva email field with the saved user email when the session is active

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694458fe01608320be23d282bef58343)