### PR TITLE
Refuerza validación y mensajes en carga masiva

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -70,7 +70,11 @@
       </label>
     </form>
 
-    <div class="carga__drop">
+    <div
+      class="carga__drop"
+      [class.carga__drop--disabled]="correoControl.invalid"
+      [attr.aria-disabled]="correoControl.invalid"
+    >
       <div class="carga__instrucciones">
         <p class="carga__etiqueta">Arrastra y suelta tu archivo o selecciónalo desde tu equipo</p>
         <p class="carga__formatos">Solo se aceptan archivos XLSX. Máximo {{ pesoMaximoMb }} MB.</p>
@@ -137,7 +141,13 @@
         </span>
       </header>
 
-      <p class="carga__mensaje carga__mensaje--info" *ngIf="resultado.estado === 'validando'">{{ resultado.mensajeInformativo }}</p>
+      <p
+        class="carga__mensaje"
+        [ngClass]="{ 'carga__mensaje--info': resultado.estado !== 'error', 'carga__mensaje--error': resultado.estado === 'error' }"
+        *ngIf="resultado.mensajeInformativo"
+      >
+        {{ resultado.mensajeInformativo }}
+      </p>
 
       <ng-container *ngIf="resultado.estado === 'error' && resultado.errores.length">
         <p class="carga__mensaje carga__mensaje--error">Se encontraron problemas en tu archivo:</p>

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
@@ -276,6 +276,12 @@
   box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.05);
 }
 
+.carga__drop--disabled {
+  opacity: 0.6;
+  pointer-events: none;
+  filter: grayscale(0.2);
+}
+
 .carga__input {
   position: relative;
   overflow: hidden;

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -105,6 +105,17 @@ export class CargaMasivaComponent implements OnInit {
     const input = evento.target as HTMLInputElement;
     const archivos = input.files ? Array.from(input.files) : [];
 
+    if (!this.correoControl.valid) {
+      this.correoControl.markAllAsTouched();
+      await Swal.fire({
+        icon: 'warning',
+        title: 'Correo requerido',
+        text: 'Ingresa un correo electrónico válido antes de cargar tu archivo.'
+      });
+      this.limpiarSeleccion(input);
+      return;
+    }
+
     if (this.authService.requiereLoginParaNuevaCarga()) {
       await Swal.fire({
         icon: 'info',
@@ -121,16 +132,6 @@ export class CargaMasivaComponent implements OnInit {
       return;
     }
 
-    if (this.correoControl.invalid) {
-      await Swal.fire({
-        icon: 'warning',
-        title: 'Correo requerido',
-        text: 'Ingresa un correo electrónico válido antes de seleccionar archivos.'
-      });
-      this.limpiarSeleccion(input);
-      return;
-    }
-
     for (const archivo of archivos) {
       await this.procesarArchivo(archivo);
     }
@@ -139,6 +140,8 @@ export class CargaMasivaComponent implements OnInit {
   }
 
   private async procesarArchivo(file: File): Promise<void> {
+    const fechaDisponible = this.calcularFechaDisponible();
+
     const resultadoArchivo: ResultadoArchivo = {
       archivo: {
         name: file.name,
@@ -150,7 +153,7 @@ export class CargaMasivaComponent implements OnInit {
       errores: [],
       advertencias: [],
       resultadoExito: null,
-      mensajeInformativo: 'Validando tu archivo...',
+      mensajeInformativo: 'Validando tu archivo con el correo ingresado...',
       escDatos: null,
       guardando: false,
       guardado: false,
@@ -334,9 +337,10 @@ export class CargaMasivaComponent implements OnInit {
       return;
     }
 
-    const fechaDisponible = this.calcularFechaDisponible();
     resultadoArchivo.estado = 'exito';
-    resultadoArchivo.mensajeInformativo = 'Tu archivo ha sido validado correctamente.';
+    resultadoArchivo.mensajeInformativo =
+      'Validación exitosa. Podrás consultar tus resultados a partir del día: ' +
+      fechaDisponible.toLocaleDateString();
     resultadoArchivo.resultadoExito = {
       mensaje: `Podrás consultar tus resultados a partir del día: ${fechaDisponible.toLocaleDateString()}`,
       fechaDisponible,


### PR DESCRIPTION
## Summary
- Bloquea la selección o arrastre de archivos hasta capturar un correo válido y mantiene la advertencia al usuario.
- Actualiza los mensajes de estado para reflejar la validación con el correo y mostrar la fecha disponible (+4 días) tras pasar el checklist.
- Mantiene el checklist de validación inicial para impedir cargas si el correo del archivo, CCT u otras reglas no coinciden.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447268a25083209e75a86fbfa83ba2)