### PR TITLE
Persist frontend credential state for repeated uploads

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -67,6 +67,10 @@
         <small class="carga__campo-error" *ngIf="correoControl.invalid && correoControl.touched">
           Ingresa un correo electrónico válido.
         </small>
+        <small class="carga__campo-aviso" *ngIf="credencialesAsociadas">
+          Ya existe una contraseña ligada a este correo. Se reutilizará para tus siguientes cargas y no se generará una nueva
+          clave.
+        </small>
       </label>
     </form>
 

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
@@ -42,6 +42,11 @@
   font-weight: 500;
 }
 
+.carga__campo-aviso {
+  color: #0f5132;
+  font-weight: 500;
+}
+
 .carga__encabezado {
   display: flex;
   flex-direction: column;

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, HostListener, OnInit } from '@angular/core';
+import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { ExcelValidationService, ResultadoValidacion } from '../../services/excel-validation.service';
@@ -11,6 +11,8 @@ import {
 import { AuthService } from '../../services/auth.service';
 import Swal from 'sweetalert2';
 import { EscDatos } from '../../services/excel-validation.service';
+import { Subject, takeUntil } from 'rxjs';
+import { EstadoCredencialesService } from '../../services/estado-credenciales.service';
 
 interface ResultadoExito {
   mensaje: string;
@@ -53,7 +55,7 @@ interface CredencialesMostradas {
   templateUrl: './carga-masiva.component.html',
   styleUrl: './carga-masiva.component.scss'
 })
-export class CargaMasivaComponent implements OnInit {
+export class CargaMasivaComponent implements OnInit, OnDestroy {
   readonly extensionesPermitidas = ['.xlsx'];
   readonly pesoMaximoMb = 10;
   readonly correoPattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
@@ -68,8 +70,12 @@ export class CargaMasivaComponent implements OnInit {
   correoSesion: string | null = null;
   tieneCredenciales = false;
   credencialesMostradas: CredencialesMostradas | null = null;
+  credencialesAsociadas = false;
+  contrasenaAsociada: string | null = null;
   trackByArchivo = (_: number, item: ResultadoArchivo): string =>
     `${item.archivo.name}-${item.archivo.lastModified.getTime()}`;
+
+  private readonly destroy$ = new Subject<void>();
 
   get hayErrores(): boolean {
     return this.resultados.some((resultado) => resultado.estado === 'error');
@@ -79,6 +85,7 @@ export class CargaMasivaComponent implements OnInit {
     private readonly excelValidationService: ExcelValidationService,
     private readonly archivoStorageService: ArchivoStorageService,
     private readonly authService: AuthService,
+    private readonly estadoCredencialesService: EstadoCredencialesService,
     private readonly router: Router
   ) {}
 
@@ -99,6 +106,12 @@ export class CargaMasivaComponent implements OnInit {
 
   ngOnInit(): void {
     this.actualizarEstadoSesion();
+    this.inicializarEstadoCredenciales();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   async onArchivoSeleccionado(evento: Event): Promise<void> {
@@ -326,6 +339,7 @@ export class CargaMasivaComponent implements OnInit {
     try {
       habiaCredenciales = !!this.authService.obtenerCredenciales();
       nuevasCredenciales = this.authService.registrarCredenciales(resultado.esc.cct, resultado.esc.correo);
+      this.estadoCredencialesService.actualizar(resultado.esc.correo, nuevasCredenciales.contrasena);
     } catch (error) {
       resultadoArchivo.estado = 'error';
       resultadoArchivo.mensajeInformativo = null;
@@ -407,16 +421,49 @@ export class CargaMasivaComponent implements OnInit {
     this.tieneCredenciales = !!credenciales;
     this.correoSesion = credenciales?.correo ?? null;
 
-    if (!this.credencialesMostradas && credenciales) {
+    this.establecerCredencialesMostradas();
+
+    if (credenciales?.correo && !this.correoControl.value.trim()) {
+      this.correoControl.setValue(credenciales.correo);
+    }
+  }
+
+  private inicializarEstadoCredenciales(): void {
+    const credencialesGuardadas = this.estadoCredencialesService.obtener();
+
+    if (credencialesGuardadas && !this.correoControl.value.trim()) {
+      this.correoControl.setValue(credencialesGuardadas.correo);
+    }
+
+    this.establecerCredencialesMostradas();
+    this.actualizarAvisoCredenciales(this.correoControl.value);
+
+    this.correoControl.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((correo) => {
+      this.actualizarAvisoCredenciales(correo);
+    });
+  }
+
+  private establecerCredencialesMostradas(): void {
+    const credencialesExistentes = this.authService.obtenerCredenciales();
+    const credencialesGuardadas = this.estadoCredencialesService.obtener();
+
+    const credencialesFuente = credencialesGuardadas ?? credencialesExistentes;
+
+    if (!this.credencialesMostradas && credencialesFuente) {
       this.credencialesMostradas = {
-        usuario: credenciales.correo,
-        contrasena: credenciales.contrasena,
+        usuario: credencialesFuente.correo,
+        contrasena: credencialesFuente.contrasena,
         esNueva: false
       };
     }
+  }
 
-    if (this.sesionActiva && credenciales?.correo && !this.correoControl.value.trim()) {
-      this.correoControl.setValue(credenciales.correo);
-    }
+  private actualizarAvisoCredenciales(correo: string): void {
+    const credencialesGuardadas = this.estadoCredencialesService.obtener();
+    const correoNormalizado = (correo ?? '').trim().toLowerCase();
+    const coincideCorreo = credencialesGuardadas?.correo === correoNormalizado;
+
+    this.credencialesAsociadas = coincideCorreo;
+    this.contrasenaAsociada = coincideCorreo ? credencialesGuardadas?.contrasena ?? null : null;
   }
 }

--- a/web/frontend/src/app/components/login/login.component.html
+++ b/web/frontend/src/app/components/login/login.component.html
@@ -26,6 +26,11 @@
         placeholder="Clave enviada en tu primer carga"
       />
 
+      <div class="login__alerta" *ngIf="contrasenaGuardada">
+        Ya existe una contraseña guardada para {{ correo }}. La llenamos por ti para que puedas continuar con tus cargas sin
+        generar una nueva clave.
+      </div>
+
       <div class="login__error" *ngIf="error">{{ error }}</div>
 
       <button class="login__submit" type="submit" [disabled]="loginForm.invalid || autenticando">

--- a/web/frontend/src/app/components/login/login.component.scss
+++ b/web/frontend/src/app/components/login/login.component.scss
@@ -59,6 +59,16 @@ input:focus {
   border: 1px solid #feb2b2;
 }
 
+.login__alerta {
+  background: #f0fdf4;
+  color: #1d5130;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  margin-bottom: 1rem;
+  border: 1px solid #c6f6d5;
+  font-size: 0.95rem;
+}
+
 .login__submit {
   width: 100%;
   background: #2e7d32;

--- a/web/frontend/src/app/components/login/login.component.ts
+++ b/web/frontend/src/app/components/login/login.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import Swal from 'sweetalert2';
 import { AuthService } from '../../services/auth.service';
+import { EstadoCredencialesService } from '../../services/estado-credenciales.service';
 
 @Component({
   selector: 'app-login',
@@ -18,15 +19,18 @@ export class LoginComponent implements OnInit {
   error: string | null = null;
   autenticando = false;
   redirect = '/carga-masiva';
+  contrasenaGuardada: string | null = null;
 
   constructor(
     private readonly authService: AuthService,
+    private readonly estadoCredencialesService: EstadoCredencialesService,
     private readonly router: Router,
     private readonly route: ActivatedRoute
   ) {}
 
   ngOnInit(): void {
-    const credenciales = this.authService.obtenerCredenciales();
+    const credenciales = this.estadoCredencialesService.obtener() ?? this.authService.obtenerCredenciales();
+
     if (!credenciales) {
       void this.router.navigate(['/carga-masiva']);
       return;
@@ -34,6 +38,10 @@ export class LoginComponent implements OnInit {
 
     this.redirect = this.route.snapshot.queryParamMap.get('redirect') ?? this.redirect;
     this.correo = credenciales.correo;
+    this.contrasenaGuardada = credenciales.contrasena;
+    if (!this.contrasena) {
+      this.contrasena = credenciales.contrasena;
+    }
   }
 
   async iniciarSesion(): Promise<void> {

--- a/web/frontend/src/app/services/estado-credenciales.service.ts
+++ b/web/frontend/src/app/services/estado-credenciales.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { AuthService } from './auth.service';
+
+export interface EstadoCredenciales {
+  correo: string;
+  contrasena: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class EstadoCredencialesService {
+  private readonly storageKey = 'estado-credenciales-preescolar';
+
+  constructor(private readonly authService: AuthService) {}
+
+  obtener(): EstadoCredenciales | null {
+    const persistido = this.cargarPersistido();
+    if (persistido) {
+      return persistido;
+    }
+
+    const credenciales = this.authService.obtenerCredenciales();
+    if (credenciales) {
+      const estadoDesdeAuth = {
+        correo: credenciales.correo,
+        contrasena: credenciales.contrasena
+      };
+      this.persistir(estadoDesdeAuth);
+      return estadoDesdeAuth;
+    }
+
+    return null;
+  }
+
+  actualizar(correo: string, contrasena: string): void {
+    this.persistir({ correo: this.normalizarCorreo(correo), contrasena });
+  }
+
+  limpiar(): void {
+    localStorage.removeItem(this.storageKey);
+  }
+
+  coincideCorreo(correo: string): boolean {
+    const estado = this.obtener();
+    return !!estado && estado.correo === this.normalizarCorreo(correo);
+  }
+
+  private persistir(estado: EstadoCredenciales): void {
+    localStorage.setItem(this.storageKey, JSON.stringify(estado));
+  }
+
+  private cargarPersistido(): EstadoCredenciales | null {
+    const guardado = localStorage.getItem(this.storageKey);
+    if (!guardado) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(guardado) as Partial<EstadoCredenciales>;
+      if (parsed?.correo && parsed?.contrasena) {
+        return { correo: this.normalizarCorreo(parsed.correo), contrasena: parsed.contrasena };
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private normalizarCorreo(correo: string): string {
+    return (correo ?? '').trim().toLowerCase();
+  }
+}


### PR DESCRIPTION
## Summary
- add a credential state service to cache the first generated email and password locally
- prefill carga masiva and login forms with stored credentials and avoid regenerating new passwords
- surface UI notices and styles when an email already has saved access data

## Testing
- npm run build *(fails: missing sweetalert2 dependency because registry access is blocked in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69448eb47d7c83209be74a88ea920b86)