### PR TITLE
Add mock PDF generation flow for carga masiva

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -172,7 +172,7 @@
         <p>{{ resultado.resultadoExito.mensaje }}</p>
         <p class="carga__resumen">
           Se validaron {{ resultado.resultadoExito.totalAlumnos }} estudiantes en la hoja “TERCERO”.
-          El PDF de confirmación se generará con los mismos datos cuando el backend esté disponible.
+          El PDF de confirmación se descarga con el mock de FastAPI mientras llega el backend real.
         </p>
         <p class="carga__mensaje carga__mensaje--info" *ngIf="resultado.rutaGuardado">
           Archivo conservado en el almacenamiento local del navegador.
@@ -199,6 +199,40 @@
           }}
         </button>
         <button class="carga__boton-secundario" (click)="onEliminarResultado(resultado)">Quitar</button>
+      </div>
+
+      <div class="carga__pdf" *ngIf="resultado.pdfTipo">
+        <div
+          class="carga__pdf-estado"
+          [ngClass]="{
+            'carga__pdf-estado--cargando': resultado.pdfEstado === 'generando' || resultado.pdfEstado === 'descargando',
+            'carga__pdf-estado--ok': resultado.pdfEstado === 'listo',
+            'carga__pdf-estado--error': resultado.pdfEstado === 'error'
+          }"
+        >
+          {{
+            resultado.pdfEstado === 'generando'
+              ? 'Generando PDF mock (FastAPI)'
+              : resultado.pdfEstado === 'descargando'
+                ? 'Descargando PDF'
+                : resultado.pdfEstado === 'listo'
+                  ? 'PDF descargado'
+                  : 'No se pudo descargar'
+          }}
+        </div>
+        <p class="carga__pdf-detalle" *ngIf="resultado.pdfMensaje">{{ resultado.pdfMensaje }}</p>
+        <p class="carga__pdf-detalle carga__pdf-detalle--error" *ngIf="resultado.pdfError">{{ resultado.pdfError }}</p>
+        <p class="carga__pdf-detalle" *ngIf="resultado.pdfNombre && resultado.pdfEstado === 'listo'">
+          Archivo descargado: <strong>{{ resultado.pdfNombre }}</strong>
+        </p>
+        <button
+          type="button"
+          class="carga__boton-secundario carga__pdf-boton"
+          *ngIf="resultado.pdfEstado === 'error'"
+          (click)="reintentarDescargaPdf(resultado)"
+        >
+          Reintentar descarga de PDF
+        </button>
       </div>
     </article>
 

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
@@ -599,6 +599,61 @@
   text-decoration: underline;
 }
 
+.carga__pdf {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.carga__pdf-estado {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-weight: 700;
+  width: fit-content;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+}
+
+.carga__pdf-estado--cargando {
+  color: #b45309;
+  border-color: #fbbf24;
+  background: #fffbeb;
+}
+
+.carga__pdf-estado--ok {
+  color: #065f46;
+  border-color: #34d399;
+  background: #ecfdf3;
+}
+
+.carga__pdf-estado--error {
+  color: #b91c1c;
+  border-color: #fca5a5;
+  background: #fef2f2;
+}
+
+.carga__pdf-detalle {
+  margin: 0;
+  color: #334155;
+}
+
+.carga__pdf-detalle--error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.carga__pdf-boton {
+  align-self: flex-start;
+}
+
 @media (max-width: 720px) {
   .carga__zona {
     flex-direction: column;

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -13,6 +13,7 @@ import Swal from 'sweetalert2';
 import { EscDatos } from '../../services/excel-validation.service';
 import { Subject, takeUntil } from 'rxjs';
 import { EstadoCredencialesService } from '../../services/estado-credenciales.service';
+import { MockPdfService } from '../../services/mock-pdf.service';
 
 interface ResultadoExito {
   mensaje: string;
@@ -40,6 +41,11 @@ interface ResultadoArchivo {
   errorGuardado: string | null;
   modoGuardado: 'localStorage' | null;
   notaGuardado: string | null;
+  pdfEstado: 'idle' | 'generando' | 'descargando' | 'listo' | 'error';
+  pdfMensaje: string | null;
+  pdfError: string | null;
+  pdfNombre: string | null;
+  pdfTipo: 'exito' | 'error' | null;
 }
 
 interface CredencialesMostradas {
@@ -86,6 +92,7 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     private readonly archivoStorageService: ArchivoStorageService,
     private readonly authService: AuthService,
     private readonly estadoCredencialesService: EstadoCredencialesService,
+    private readonly mockPdfService: MockPdfService,
     private readonly router: Router
   ) {}
 
@@ -173,7 +180,12 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       rutaGuardado: null,
       errorGuardado: null,
       modoGuardado: null,
-      notaGuardado: null
+      notaGuardado: null,
+      pdfEstado: 'idle',
+      pdfMensaje: null,
+      pdfError: null,
+      pdfNombre: null,
+      pdfTipo: null
     };
 
     this.resultados = [resultadoArchivo, ...this.resultados];
@@ -183,17 +195,15 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     );
 
     if (!extensionValida) {
-      resultadoArchivo.estado = 'error';
-      resultadoArchivo.mensajeInformativo = null;
       resultadoArchivo.errores = ['Formato no permitido. Usa únicamente archivos .xlsx'];
+      await this.finalizarConError(resultadoArchivo);
       return;
     }
 
     const tamanioMb = file.size / (1024 * 1024);
     if (tamanioMb > this.pesoMaximoMb) {
-      resultadoArchivo.estado = 'error';
-      resultadoArchivo.mensajeInformativo = null;
       resultadoArchivo.errores = [`El archivo supera los ${this.pesoMaximoMb} MB permitidos.`];
+      await this.finalizarConError(resultadoArchivo);
       return;
     }
 
@@ -202,13 +212,12 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       const resultado = await this.excelValidationService.validarPreescolar(buffer);
       await this.procesarResultado(resultado, resultadoArchivo);
     } catch (error) {
-      resultadoArchivo.estado = 'error';
-      resultadoArchivo.mensajeInformativo = null;
       resultadoArchivo.errores = [
         error instanceof Error
           ? error.message
           : 'No se pudo validar el archivo. Inténtalo de nuevo.'
       ];
+      await this.finalizarConError(resultadoArchivo);
       return;
     }
   }
@@ -304,18 +313,16 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     resultadoArchivo.escDatos = resultado.esc ?? null;
 
     if (!resultado.ok || !resultado.esc) {
-      resultadoArchivo.estado = 'error';
-      resultadoArchivo.mensajeInformativo = null;
+      await this.finalizarConError(resultadoArchivo);
       return;
     }
 
     if (!this.authService.coincidenCredenciales(resultado.esc.cct, resultado.esc.correo)) {
-      resultadoArchivo.estado = 'error';
-      resultadoArchivo.mensajeInformativo = null;
       resultadoArchivo.errores = [
         ...resultadoArchivo.errores,
         'El CCT y el correo deben coincidir con los registrados en tu primer envío.'
       ];
+      await this.finalizarConError(resultadoArchivo);
       return;
     }
 
@@ -323,12 +330,11 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     const correoEnArchivo = (resultado.esc.correo ?? '').trim().toLowerCase();
 
     if (correoFormulario !== correoEnArchivo) {
-      resultadoArchivo.estado = 'error';
-      resultadoArchivo.mensajeInformativo = null;
       resultadoArchivo.errores = [
         ...resultadoArchivo.errores,
         'El correo capturado debe coincidir con el que aparece en la hoja ESC del archivo.'
       ];
+      await this.finalizarConError(resultadoArchivo);
       return;
     }
 
@@ -341,14 +347,13 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       nuevasCredenciales = this.authService.registrarCredenciales(resultado.esc.cct, resultado.esc.correo);
       this.estadoCredencialesService.actualizar(resultado.esc.correo, nuevasCredenciales.contrasena);
     } catch (error) {
-      resultadoArchivo.estado = 'error';
-      resultadoArchivo.mensajeInformativo = null;
       resultadoArchivo.errores = [
         ...resultadoArchivo.errores,
         error instanceof Error
           ? error.message
           : 'No pudimos validar tus credenciales. Usa el CCT y correo originales.'
       ];
+      await this.finalizarConError(resultadoArchivo);
       return;
     }
 
@@ -374,6 +379,8 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     };
 
     this.actualizarEstadoSesion();
+
+    await this.generarPdfExito(resultadoArchivo, resultado.esc, fechaDisponible, resultado.alumnos?.length ?? 0);
   }
 
   private calcularFechaDisponible(): Date {
@@ -465,5 +472,84 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
 
     this.credencialesAsociadas = coincideCorreo;
     this.contrasenaAsociada = coincideCorreo ? credencialesGuardadas?.contrasena ?? null : null;
+  }
+
+  private async generarPdfExito(
+    resultadoArchivo: ResultadoArchivo,
+    esc: EscDatos,
+    fechaDisponible: Date,
+    totalAlumnos: number
+  ): Promise<void> {
+    resultadoArchivo.pdfTipo = 'exito';
+    resultadoArchivo.pdfEstado = 'generando';
+    resultadoArchivo.pdfMensaje = 'Preparando el PDF de confirmación...';
+    resultadoArchivo.pdfError = null;
+    resultadoArchivo.pdfNombre = `comprobante-${esc.cct.toLowerCase()}-${Date.now()}.pdf`;
+
+    try {
+      const blob = await this.mockPdfService.generarPdfExito({
+        correo: esc.correo,
+        contrasena: resultadoArchivo.resultadoExito?.credenciales.contrasena ?? '',
+        fechaDisponible: fechaDisponible.toLocaleDateString(),
+        alumnosValidados: totalAlumnos,
+        cct: esc.cct
+      });
+      resultadoArchivo.pdfEstado = 'descargando';
+      this.mockPdfService.descargarPdf(blob, resultadoArchivo.pdfNombre);
+      resultadoArchivo.pdfEstado = 'listo';
+      resultadoArchivo.pdfMensaje = 'PDF de confirmación descargado correctamente.';
+    } catch (error) {
+      resultadoArchivo.pdfEstado = 'error';
+      resultadoArchivo.pdfError =
+        error instanceof Error ? error.message : 'No se pudo descargar el PDF de confirmación.';
+      resultadoArchivo.pdfMensaje = 'No pudimos entregar tu PDF. Reintenta la descarga.';
+    }
+  }
+
+  private async generarPdfErrores(resultadoArchivo: ResultadoArchivo): Promise<void> {
+    resultadoArchivo.pdfTipo = 'error';
+    resultadoArchivo.pdfEstado = 'generando';
+    resultadoArchivo.pdfMensaje = 'Creando PDF con el detalle de errores...';
+    resultadoArchivo.pdfError = null;
+    resultadoArchivo.pdfNombre = `errores-${resultadoArchivo.archivo.name.replace(/\s+/g, '-')}`;
+
+    try {
+      const blob = await this.mockPdfService.generarPdfErrores({
+        correo: this.correoControl.value,
+        errores: resultadoArchivo.errores,
+        advertencias: resultadoArchivo.advertencias,
+        archivo: resultadoArchivo.archivo.name
+      });
+      resultadoArchivo.pdfEstado = 'descargando';
+      this.mockPdfService.descargarPdf(blob, resultadoArchivo.pdfNombre);
+      resultadoArchivo.pdfEstado = 'listo';
+      resultadoArchivo.pdfMensaje = 'PDF de errores descargado para revisar detalles.';
+    } catch (error) {
+      resultadoArchivo.pdfEstado = 'error';
+      resultadoArchivo.pdfError =
+        error instanceof Error ? error.message : 'No se pudo descargar el PDF de errores.';
+      resultadoArchivo.pdfMensaje = 'No pudimos entregar el PDF de errores. Reintenta la descarga.';
+    }
+  }
+
+  async reintentarDescargaPdf(resultadoArchivo: ResultadoArchivo): Promise<void> {
+    if (resultadoArchivo.pdfTipo === 'exito' && resultadoArchivo.resultadoExito && resultadoArchivo.escDatos) {
+      await this.generarPdfExito(
+        resultadoArchivo,
+        resultadoArchivo.escDatos,
+        resultadoArchivo.resultadoExito.fechaDisponible,
+        resultadoArchivo.resultadoExito.totalAlumnos
+      );
+    }
+
+    if (resultadoArchivo.pdfTipo === 'error') {
+      await this.generarPdfErrores(resultadoArchivo);
+    }
+  }
+
+  private async finalizarConError(resultadoArchivo: ResultadoArchivo): Promise<void> {
+    resultadoArchivo.estado = 'error';
+    resultadoArchivo.mensajeInformativo = null;
+    await this.generarPdfErrores(resultadoArchivo);
   }
 }

--- a/web/frontend/src/app/services/mock-pdf.service.ts
+++ b/web/frontend/src/app/services/mock-pdf.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@angular/core';
+
+interface PdfExitoPayload {
+  correo: string;
+  contrasena: string;
+  fechaDisponible: string;
+  alumnosValidados: number;
+  cct: string;
+}
+
+interface PdfErroresPayload {
+  correo: string;
+  errores: string[];
+  advertencias?: string[];
+  archivo: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MockPdfService {
+  private readonly probabilidadFalloRed = 0.2;
+  private readonly demoraMs = 900;
+
+  async generarPdfExito(payload: PdfExitoPayload, simularFallo = true): Promise<Blob> {
+    await this.simularLlamada(simularFallo);
+    const contenido = this.armarContenidoExito(payload);
+    return this.crearPdf(contenido);
+  }
+
+  async generarPdfErrores(payload: PdfErroresPayload, simularFallo = true): Promise<Blob> {
+    await this.simularLlamada(simularFallo);
+    const contenido = this.armarContenidoErrores(payload);
+    return this.crearPdf(contenido);
+  }
+
+  descargarPdf(blob: Blob, nombre: string): void {
+    const url = URL.createObjectURL(blob);
+    const enlace = document.createElement('a');
+    enlace.href = url;
+    enlace.download = nombre;
+    enlace.click();
+    URL.revokeObjectURL(url);
+  }
+
+  private async simularLlamada(simularFallo: boolean): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, this.demoraMs));
+    const fallo = simularFallo && Math.random() < this.probabilidadFalloRed;
+    if (fallo) {
+      throw new Error('Fallo de red simulado. Intenta nuevamente.');
+    }
+  }
+
+  private crearPdf(contenido: string): Blob {
+    const cuerpo = this.sanitizar(contenido);
+    return new Blob([cuerpo], { type: 'application/pdf' });
+  }
+
+  private armarContenidoExito(payload: PdfExitoPayload): string {
+    return `PDF SIMULADO\n\n` +
+      `Comprobante de envío exitoso\n` +
+      `CCT: ${payload.cct}\n` +
+      `Correo: ${payload.correo}\n` +
+      `Contraseña generada: ${payload.contrasena}\n` +
+      `Fecha disponible: ${payload.fechaDisponible}\n` +
+      `Total de alumnos validados: ${payload.alumnosValidados}\n` +
+      `Este PDF sustituye temporalmente al emitido por FastAPI.`;
+  }
+
+  private armarContenidoErrores(payload: PdfErroresPayload): string {
+    const errores = payload.errores.map((error, idx) => `${idx + 1}. ${error}`).join('\n');
+    const advertencias = (payload.advertencias ?? []).map((adv) => `⚠️ ${adv}`).join('\n');
+    return `PDF SIMULADO\n\n` +
+      `El archivo ${payload.archivo} no pasó la validación.\n` +
+      `Correo capturado: ${payload.correo || 'N/D'}\n` +
+      `Errores detectados:\n${errores || 'Sin detalles'}\n` +
+      (advertencias ? `\nAdvertencias:\n${advertencias}\n` : '') +
+      `Corrige los puntos anteriores y vuelve a cargar el archivo.`;
+  }
+
+  private sanitizar(texto: string): string {
+    return texto.replace(/[\u0000-\u001F\u007F]/g, ' ').trim();
+  }
+}


### PR DESCRIPTION
## Summary
- add a mock PDF service that simulates the upcoming FastAPI endpoints and network issues
- trigger automatic success/error PDF downloads during carga masiva validation with retry handling
- surface PDF download status indicators and styling in the UI

## Testing
- `npm run build` *(fails: existing SweetAlert2 module resolution error in the project setup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694492cb27e08320839bccad95afebb5)