### PR TITLE
Add protected downloads route and mock version retrieval

### DIFF
--- a/web/frontend/src/app/app.config.ts
+++ b/web/frontend/src/app/app.config.ts
@@ -1,8 +1,9 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideHttpClient()]
 };

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { InicioComponent } from './components/inicio/inicio.component';
 import { CargaMasivaComponent } from './components/carga-masiva/carga-masiva.component';
 import { ArchivosGuardadosComponent } from './components/archivos-guardados/archivos-guardados.component';
 import { LoginComponent } from './components/login/login.component';
+import { DescargasComponent } from './components/descargas/descargas.component';
 
 
 export const routes: Routes = [
@@ -39,6 +40,11 @@ export const routes: Routes = [
   {
     path: 'login',
     component: LoginComponent,
+    pathMatch: 'full'
+  },
+  {
+    path: 'descargas',
+    component: DescargasComponent,
     pathMatch: 'full'
   },
   /* {

--- a/web/frontend/src/app/components/descargas/descargas.component.html
+++ b/web/frontend/src/app/components/descargas/descargas.component.html
@@ -1,0 +1,75 @@
+<div class="descargas">
+  <header class="encabezado">
+    <h1>Descarga de versiones</h1>
+    <p>Ingresa con el correo y contraseña generada para acceder a las ligas de descarga.</p>
+  </header>
+
+  <section class="tarjeta">
+    <div *ngIf="!autenticado" class="formulario">
+      <form [formGroup]="accesoForm" (ngSubmit)="iniciarSesion()">
+        <div class="campo">
+          <label for="correo">Correo electrónico</label>
+          <input
+            id="correo"
+            type="email"
+            formControlName="correo"
+            placeholder="usuario@dominio.com"
+            [class.error]="accesoForm.controls.correo.invalid && accesoForm.controls.correo.touched"
+          />
+          <small *ngIf="accesoForm.controls.correo.invalid && accesoForm.controls.correo.touched">
+            Ingresa un correo válido.
+          </small>
+        </div>
+
+        <div class="campo">
+          <label for="contrasena">Contraseña generada</label>
+          <input
+            id="contrasena"
+            type="password"
+            formControlName="contrasena"
+            placeholder="Ej. Abc123456789"
+            [class.error]="accesoForm.controls.contrasena.invalid && accesoForm.controls.contrasena.touched"
+          />
+          <small *ngIf="accesoForm.controls.contrasena.invalid && accesoForm.controls.contrasena.touched">
+            La contraseña es obligatoria.
+          </small>
+        </div>
+
+        <button type="submit" [disabled]="autenticando" class="btn primario">
+          {{ autenticando ? 'Validando...' : 'Ingresar' }}
+        </button>
+      </form>
+    </div>
+
+    <div *ngIf="autenticado" class="contenido">
+      <div class="estado" *ngIf="cargandoVersiones">Cargando versiones disponibles...</div>
+      <div class="estado estado-error" *ngIf="error && !cargandoVersiones">{{ error }}</div>
+
+      <div *ngIf="!cargandoVersiones && !error">
+        <table class="tabla" *ngIf="versiones.length; else sinVersiones">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Versión</th>
+              <th>Fecha de publicación</th>
+              <th>Descarga</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let version of versiones">
+              <td>{{ version.numero }}</td>
+              <td>{{ version.nombre }}</td>
+              <td>{{ version.fechaPublicacion | date: 'dd/MM/yyyy' }}</td>
+              <td>
+                <button class="btn" type="button" (click)="descargar(version)">Descargar</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <ng-template #sinVersiones>
+          <p class="estado">No hay versiones disponibles por el momento.</p>
+        </ng-template>
+      </div>
+    </div>
+  </section>
+</div>

--- a/web/frontend/src/app/components/descargas/descargas.component.scss
+++ b/web/frontend/src/app/components/descargas/descargas.component.scss
@@ -1,0 +1,129 @@
+.descargas {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 1rem;
+}
+
+.encabezado {
+  margin-bottom: 1.5rem;
+
+  h1 {
+    margin: 0;
+    font-size: 1.8rem;
+    color: #1f2937;
+  }
+
+  p {
+    margin: 0.25rem 0 0;
+    color: #4b5563;
+  }
+}
+
+.tarjeta {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.formulario {
+  display: grid;
+  gap: 1rem;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+
+  label {
+    font-weight: 600;
+    color: #374151;
+  }
+
+  input {
+    padding: 0.75rem 0.9rem;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    font-size: 1rem;
+    transition: border-color 0.2s ease;
+
+    &.error {
+      border-color: #ef4444;
+    }
+
+    &:focus {
+      outline: none;
+      border-color: #2563eb;
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    }
+  }
+
+  small {
+    color: #ef4444;
+  }
+}
+
+.btn {
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  background: #e5e7eb;
+  color: #111827;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: #d1d5db;
+  }
+
+  &.primario {
+    background: #2563eb;
+    color: #fff;
+
+    &:hover {
+      background: #1d4ed8;
+    }
+  }
+}
+
+.contenido {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.estado {
+  padding: 0.75rem 1rem;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  color: #1d4ed8;
+}
+
+.estado-error {
+  background: #fef2f2;
+  border-color: #fecdd3;
+  color: #b91c1c;
+}
+
+.tabla {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+
+  th,
+  td {
+    padding: 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  th {
+    background: #f9fafb;
+    font-weight: 700;
+    color: #1f2937;
+  }
+}

--- a/web/frontend/src/app/components/descargas/descargas.component.ts
+++ b/web/frontend/src/app/components/descargas/descargas.component.ts
@@ -1,0 +1,122 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import Swal from 'sweetalert2';
+import { finalize, firstValueFrom, Subject, takeUntil } from 'rxjs';
+import { AuthService } from '../../services/auth.service';
+import { EstadoCredencialesService } from '../../services/estado-credenciales.service';
+import { VersionDisponible, VersionesService } from '../../services/versiones.service';
+
+@Component({
+  selector: 'app-descargas',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './descargas.component.html',
+  styleUrl: './descargas.component.scss'
+})
+export class DescargasComponent implements OnInit, OnDestroy {
+  autenticado = false;
+  cargandoVersiones = false;
+  autenticando = false;
+  error: string | null = null;
+  versiones: VersionDisponible[] = [];
+  private readonly destroy$ = new Subject<void>();
+
+  readonly accesoForm = new FormGroup({
+    correo: new FormControl('', [Validators.required, Validators.email]),
+    contrasena: new FormControl('', [Validators.required])
+  });
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly estadoCredencialesService: EstadoCredencialesService,
+    private readonly versionesService: VersionesService
+  ) {}
+
+  ngOnInit(): void {
+    const estado = this.estadoCredencialesService.obtener();
+    if (estado) {
+      this.accesoForm.patchValue({ correo: estado.correo, contrasena: estado.contrasena });
+    }
+
+    this.autenticado = this.authService.estaAutenticado();
+    if (this.autenticado) {
+      this.cargarVersiones();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  async iniciarSesion(): Promise<void> {
+    if (this.accesoForm.invalid) {
+      this.accesoForm.markAllAsTouched();
+      return;
+    }
+
+    const correo = this.accesoForm.controls.correo.value ?? '';
+    const contrasena = this.accesoForm.controls.contrasena.value ?? '';
+
+    this.error = null;
+    this.autenticando = true;
+
+    try {
+      this.authService.iniciarSesion(correo, contrasena);
+      this.estadoCredencialesService.actualizar(correo, contrasena);
+      this.autenticado = true;
+      await Swal.fire({
+        icon: 'success',
+        title: 'Acceso concedido',
+        text: 'Ya puedes descargar las versiones disponibles.',
+        timer: 2300,
+        timerProgressBar: true
+      });
+      this.cargarVersiones();
+    } catch (error) {
+      this.autenticado = false;
+      this.error = error instanceof Error ? error.message : 'No fue posible iniciar sesión.';
+      await Swal.fire({
+        icon: 'error',
+        title: 'Credenciales inválidas',
+        text: this.error
+      });
+    } finally {
+      this.autenticando = false;
+    }
+  }
+
+  cargarVersiones(): void {
+    this.error = null;
+    this.cargandoVersiones = true;
+    this.versionesService
+      .obtenerVersiones()
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.cargandoVersiones = false;
+        })
+      )
+      .subscribe({
+        next: (versiones) => (this.versiones = versiones),
+        error: () => {
+          this.error = 'No se pudieron obtener las versiones. Intenta más tarde.';
+        }
+      });
+  }
+
+  async descargar(version: VersionDisponible): Promise<void> {
+    await firstValueFrom(this.versionesService.registrarDescarga(version).pipe(takeUntil(this.destroy$)));
+
+    await Swal.fire({
+      icon: 'info',
+      title: 'Descarga simulada',
+      text: 'La descarga se abrirá cuando el backend real esté disponible.',
+      confirmButtonText: 'Entendido'
+    });
+
+    window.open(version.urlDescarga, '_blank');
+  }
+}

--- a/web/frontend/src/app/services/versiones.service.ts
+++ b/web/frontend/src/app/services/versiones.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { delay, Observable, of } from 'rxjs';
+
+export interface VersionDisponible {
+  numero: number;
+  nombre: string;
+  fechaPublicacion: Date;
+  urlDescarga: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class VersionesService {
+  // TODO: Reemplazar la URL base por el endpoint real cuando el backend esté disponible.
+  private readonly apiBaseUrl = '/api/versiones';
+
+  constructor(private readonly http: HttpClient) {}
+
+  obtenerVersiones(): Observable<VersionDisponible[]> {
+    // Simulación de respuesta del repositorio externo. Sustituir por:
+    // return this.http.get<VersionDisponible[]>(`${this.apiBaseUrl}`);
+    const versiones: VersionDisponible[] = [
+      {
+        numero: 1,
+        nombre: 'Versión de inicio de ciclo',
+        fechaPublicacion: new Date('2024-08-15'),
+        urlDescarga: 'https://repositorio.externoligas/descargas/version-1.zip'
+      },
+      {
+        numero: 2,
+        nombre: 'Actualización de catálogos',
+        fechaPublicacion: new Date('2024-09-01'),
+        urlDescarga: 'https://repositorio.externoligas/descargas/version-2.zip'
+      },
+      {
+        numero: 3,
+        nombre: 'Ajustes de validación y reporte',
+        fechaPublicacion: new Date('2024-09-18'),
+        urlDescarga: 'https://repositorio.externoligas/descargas/version-3.zip'
+      }
+    ];
+
+    return of(versiones).pipe(delay(450));
+  }
+
+  registrarDescarga(_version: VersionDisponible): Observable<boolean> {
+    // Preparado para registrar descargas en el backend real.
+    // return this.http.post<boolean>(`${this.apiBaseUrl}/descargas`, { version: version.numero });
+    return of(true).pipe(delay(200));
+  }
+}


### PR DESCRIPTION
## Summary
- add protected `descargas` route with credential form and versions table
- mock external version retrieval and download registration through a dedicated service
- enable HTTP client provisioning to connect with the upcoming backend

## Testing
- npm run build *(fails: npm registry 403 for sweetalert2 dependency in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69449cc1d0648320b23b93b1ca2f6016)