### PR TITLE
Add seguimiento panel for descargas

### DIFF
--- a/web/frontend/src/app/app.config.ts
+++ b/web/frontend/src/app/app.config.ts
@@ -3,7 +3,13 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { seguimientoProviders } from './services/seguimiento.service';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideHttpClient()]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideHttpClient(),
+    ...seguimientoProviders
+  ]
 };

--- a/web/frontend/src/app/components/descargas/descargas.component.html
+++ b/web/frontend/src/app/components/descargas/descargas.component.html
@@ -42,6 +42,8 @@
     </div>
 
     <div *ngIf="autenticado" class="contenido">
+      <app-seguimiento-descargas></app-seguimiento-descargas>
+
       <div class="estado" *ngIf="cargandoVersiones">Cargando versiones disponibles...</div>
       <div class="estado estado-error" *ngIf="error && !cargandoVersiones">{{ error }}</div>
 

--- a/web/frontend/src/app/components/descargas/descargas.component.ts
+++ b/web/frontend/src/app/components/descargas/descargas.component.ts
@@ -7,11 +7,12 @@ import { finalize, firstValueFrom, Subject, takeUntil } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 import { EstadoCredencialesService } from '../../services/estado-credenciales.service';
 import { VersionDisponible, VersionesService } from '../../services/versiones.service';
+import { SeguimientoDescargasComponent } from './seguimiento-descargas/seguimiento-descargas.component';
 
 @Component({
   selector: 'app-descargas',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, SeguimientoDescargasComponent],
   templateUrl: './descargas.component.html',
   styleUrl: './descargas.component.scss'
 })

--- a/web/frontend/src/app/components/descargas/seguimiento-descargas/seguimiento-descargas.component.html
+++ b/web/frontend/src/app/components/descargas/seguimiento-descargas/seguimiento-descargas.component.html
@@ -1,0 +1,111 @@
+<section class="seguimiento">
+  <header class="encabezado">
+    <div>
+      <p class="eyebrow">Seguimiento y descargas recientes</p>
+      <h2>Estado de solicitudes y validaciones</h2>
+      <p class="descripcion">Filtra por CCT o fecha para revisar avances, errores simulados y últimos intentos de descarga.</p>
+    </div>
+    <form class="filtros" [formGroup]="filtroForm" (ngSubmit)="consultar()">
+      <div class="control">
+        <label for="cct">CCT</label>
+        <input id="cct" type="text" placeholder="Ej. 09A1234A" formControlName="cct" />
+      </div>
+      <div class="control">
+        <label for="fechaInicio">Desde</label>
+        <input id="fechaInicio" type="date" formControlName="fechaInicio" />
+      </div>
+      <div class="control">
+        <label for="fechaFin">Hasta</label>
+        <input id="fechaFin" type="date" formControlName="fechaFin" />
+      </div>
+      <label class="checkbox">
+        <input type="checkbox" formControlName="simularFallo" />
+        Simular fallo para reintento
+      </label>
+      <button type="submit" class="btn">Aplicar filtros</button>
+    </form>
+  </header>
+
+  <div *ngIf="cargando" class="estado">Consultando seguimiento...</div>
+  <div *ngIf="error && !cargando" class="estado estado-error">
+    {{ error }}
+    <button type="button" class="btn" (click)="consultar()">Reintentar</button>
+  </div>
+
+  <ng-container *ngIf="!cargando && !error && resumen">
+    <div class="resumen">
+      <article class="tarjeta">
+        <p class="label">Solicitudes recibidas</p>
+        <h3>{{ resumenSolicitudes?.total }}</h3>
+        <small>Actualizado {{ resumen?.actualizado | date: 'dd/MM, HH:mm' }}</small>
+      </article>
+      <article class="tarjeta">
+        <p class="label">Validadas</p>
+        <h3 class="exito">{{ resumenSolicitudes?.validadas }}</h3>
+        <small>{{ resumenSolicitudes?.validadas }} listas para descarga</small>
+      </article>
+      <article class="tarjeta">
+        <p class="label">En proceso</p>
+        <h3 class="proceso">{{ resumenSolicitudes?.enProceso }}</h3>
+        <small>Incluye reglas de negocio pendientes</small>
+      </article>
+      <article class="tarjeta">
+        <p class="label">Con observaciones</p>
+        <h3 class="alerta">{{ resumenSolicitudes?.conObservaciones }}</h3>
+        <small>Requieren revisión adicional</small>
+      </article>
+    </div>
+
+    <section class="validaciones">
+      <div class="titulo">
+        <h3>Estado de validaciones</h3>
+        <p>Monitoreo rápido de los módulos clave.</p>
+      </div>
+      <div class="lista">
+        <article *ngFor="let validacion of validaciones" class="item">
+          <div>
+            <p class="label">{{ validacion.nombre }}</p>
+            <small>Actualizado {{ validacion.actualizado | date: 'dd/MM, HH:mm' }}</small>
+            <p class="comentario">{{ validacion.comentario }}</p>
+          </div>
+          <span class="chip" [ngClass]="validacion.estado">{{ validacion.estado }}</span>
+        </article>
+      </div>
+    </section>
+
+    <section class="descargas">
+      <div class="titulo">
+        <h3>Descargas recientes</h3>
+        <p>Incluye intentos con error para simular reintentos.</p>
+      </div>
+      <table class="tabla" *ngIf="descargas.length; else sinDescargas">
+        <thead>
+          <tr>
+            <th>CCT</th>
+            <th>Archivo</th>
+            <th>Fecha</th>
+            <th>Estado</th>
+            <th>Reintentos</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let descarga of descargas">
+            <td>{{ descarga.cct }}</td>
+            <td>{{ descarga.archivo }}</td>
+            <td>{{ descarga.fecha | date: 'dd/MM/yyyy HH:mm' }}</td>
+            <td>
+              <span class="chip" [ngClass]="descarga.estado">{{ descarga.estado }}</span>
+            </td>
+            <td>
+              <span class="reintentos" *ngIf="descarga.estado === 'error'">{{ descarga.reintentos }} reintentos sugeridos</span>
+              <span *ngIf="descarga.estado !== 'error'">{{ descarga.reintentos }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <ng-template #sinDescargas>
+        <p class="estado">No hay descargas que coincidan con los filtros seleccionados.</p>
+      </ng-template>
+    </section>
+  </ng-container>
+</section>

--- a/web/frontend/src/app/components/descargas/seguimiento-descargas/seguimiento-descargas.component.scss
+++ b/web/frontend/src/app/components/descargas/seguimiento-descargas/seguimiento-descargas.component.scss
@@ -1,0 +1,267 @@
+.seguimiento {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.encabezado {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+h2 {
+  margin: 0.25rem 0;
+  color: #0f172a;
+}
+
+.descripcion {
+  margin: 0;
+  color: #475569;
+}
+
+.filtros {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  align-items: end;
+  background: #fff;
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.control label {
+  font-weight: 600;
+  color: #111827;
+}
+
+.control input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.btn {
+  padding: 0.55rem 0.9rem;
+  border-radius: 10px;
+  border: none;
+  background: linear-gradient(135deg, #0284c7, #0ea5e9);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(14, 165, 233, 0.25);
+}
+
+.estado {
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: #e0f2fe;
+  color: #075985;
+  font-weight: 600;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.estado-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecdd3;
+}
+
+.resumen {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.tarjeta {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.04);
+}
+
+.tarjeta .label {
+  margin: 0;
+  color: #64748b;
+  font-weight: 700;
+}
+
+.tarjeta h3 {
+  margin: 0.35rem 0 0;
+  font-size: 1.7rem;
+}
+
+.tarjeta .exito {
+  color: #15803d;
+}
+
+.tarjeta .proceso {
+  color: #c2410c;
+}
+
+.tarjeta .alerta {
+  color: #be123c;
+}
+
+.tarjeta small {
+  color: #94a3b8;
+}
+
+.validaciones,
+.descargas {
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.04);
+}
+
+.titulo {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.titulo h3 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.titulo p {
+  margin: 0;
+  color: #475569;
+}
+
+.lista {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+
+.item {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.item .label {
+  margin: 0;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.item small {
+  color: #94a3b8;
+}
+
+.item .comentario {
+  margin: 0.35rem 0 0;
+  color: #475569;
+}
+
+.chip {
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: capitalize;
+}
+
+.chip.validado {
+  background: #ecfdf3;
+  color: #15803d;
+}
+
+.chip.completada {
+  background: #ecfdf3;
+  color: #15803d;
+}
+
+.chip.en-proceso {
+  background: #fff7ed;
+  color: #c2410c;
+}
+
+.chip.pendiente {
+  background: #f8fafc;
+  color: #1f2937;
+}
+
+.chip.error {
+  background: #fef2f2;
+  color: #be123c;
+}
+
+.tabla {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tabla th,
+.tabla td {
+  text-align: left;
+  padding: 0.6rem 0.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.tabla th {
+  color: #475569;
+  font-weight: 700;
+}
+
+.reintentos {
+  color: #be123c;
+  font-weight: 700;
+}
+
+@media (max-width: 768px) {
+  .encabezado {
+    flex-direction: column;
+  }
+}

--- a/web/frontend/src/app/components/descargas/seguimiento-descargas/seguimiento-descargas.component.ts
+++ b/web/frontend/src/app/components/descargas/seguimiento-descargas/seguimiento-descargas.component.ts
@@ -1,0 +1,91 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { finalize, Subject, takeUntil } from 'rxjs';
+import {
+  DescargaReciente,
+  SeguimientoFiltro,
+  SeguimientoService,
+  SeguimientoSnapshot,
+  ValidacionDetalle
+} from '../../../services/seguimiento.service';
+
+@Component({
+  selector: 'app-seguimiento-descargas',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './seguimiento-descargas.component.html',
+  styleUrl: './seguimiento-descargas.component.scss'
+})
+export class SeguimientoDescargasComponent implements OnInit, OnDestroy {
+  filtroForm = new FormGroup({
+    cct: new FormControl<string | null>(''),
+    fechaInicio: new FormControl<string>(''),
+    fechaFin: new FormControl<string>(''),
+    simularFallo: new FormControl<boolean>(false)
+  });
+
+  resumen: SeguimientoSnapshot | null = null;
+  cargando = false;
+  error: string | null = null;
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(private readonly seguimientoService: SeguimientoService) {}
+
+  ngOnInit(): void {
+    this.consultar();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  get descargas(): DescargaReciente[] {
+    return this.resumen?.descargasRecientes ?? [];
+  }
+
+  get validaciones(): ValidacionDetalle[] {
+    return this.resumen?.validaciones ?? [];
+  }
+
+  get resumenSolicitudes() {
+    return this.resumen?.resumenSolicitudes;
+  }
+
+  consultar(): void {
+    const filtro = this.construirFiltro();
+    this.cargando = true;
+    this.error = null;
+
+    this.seguimientoService
+      .consultarSeguimiento(filtro)
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.cargando = false;
+        })
+      )
+      .subscribe({
+        next: (resumen) => {
+          this.resumen = resumen;
+        },
+        error: () => {
+          this.error = filtro.simularError
+            ? 'Se simuló un fallo para validar la vista de reintentos.'
+            : 'No fue posible obtener el seguimiento. Intenta nuevamente.';
+        }
+      });
+  }
+
+  private construirFiltro(): SeguimientoFiltro {
+    const { cct, fechaInicio, fechaFin, simularFallo } = this.filtroForm.value;
+
+    return {
+      cct: cct?.trim() || undefined,
+      fechaInicio: fechaInicio ? new Date(fechaInicio) : undefined,
+      fechaFin: fechaFin ? new Date(fechaFin) : undefined,
+      simularError: simularFallo ?? false
+    };
+  }
+}

--- a/web/frontend/src/app/services/seguimiento.service.ts
+++ b/web/frontend/src/app/services/seguimiento.service.ts
@@ -1,0 +1,128 @@
+import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, delay, map, of, throwError } from 'rxjs';
+
+export interface ResumenSolicitudes {
+  total: number;
+  validadas: number;
+  enProceso: number;
+  conObservaciones: number;
+}
+
+export type EstadoValidacion = 'validado' | 'en-proceso' | 'pendiente' | 'error';
+
+export interface ValidacionDetalle {
+  nombre: string;
+  estado: EstadoValidacion;
+  comentario?: string;
+  actualizado: Date;
+}
+
+export type EstadoDescarga = 'completada' | 'en-proceso' | 'error';
+
+export interface DescargaReciente {
+  cct: string;
+  archivo: string;
+  fecha: Date;
+  estado: EstadoDescarga;
+  reintentos: number;
+}
+
+export interface SeguimientoSnapshot {
+  actualizado: Date;
+  resumenSolicitudes: ResumenSolicitudes;
+  validaciones: ValidacionDetalle[];
+  descargasRecientes: DescargaReciente[];
+}
+
+export interface SeguimientoFiltro {
+  cct?: string;
+  fechaInicio?: Date;
+  fechaFin?: Date;
+  simularError?: boolean;
+}
+
+export interface SeguimientoDataSource {
+  consultarSeguimiento(filtro: SeguimientoFiltro): Observable<SeguimientoSnapshot>;
+}
+
+export const SEGUIMIENTO_DATASOURCE = new InjectionToken<SeguimientoDataSource>('SEGUIMIENTO_DATASOURCE');
+
+@Injectable({ providedIn: 'root' })
+export class SeguimientoService {
+  constructor(@Inject(SEGUIMIENTO_DATASOURCE) private readonly dataSource: SeguimientoDataSource) {}
+
+  consultarSeguimiento(filtro: SeguimientoFiltro): Observable<SeguimientoSnapshot> {
+    return this.dataSource.consultarSeguimiento(filtro);
+  }
+}
+
+@Injectable({ providedIn: 'root' })
+export class MockSeguimientoDataSource implements SeguimientoDataSource {
+  // TODO: Sustituir la URL por el endpoint real cuando esté disponible.
+  private readonly apiUrl = '/api/seguimiento';
+
+  constructor(_http: HttpClient) {}
+
+  consultarSeguimiento(filtro: SeguimientoFiltro): Observable<SeguimientoSnapshot> {
+    if (filtro.simularError) {
+      return throwError(() => new Error('Fallo simulado en la consulta de seguimiento.')).pipe(delay(400));
+    }
+
+    const descargas: DescargaReciente[] = [
+      { cct: '09A1234A', archivo: 'ed_ciclo_2024.zip', fecha: new Date('2024-09-25T10:30:00'), estado: 'completada', reintentos: 0 },
+      { cct: '15B5678B', archivo: 'catalogos_actualizados.xlsx', fecha: new Date('2024-09-26T08:15:00'), estado: 'en-proceso', reintentos: 1 },
+      { cct: '21C9012C', archivo: 'validaciones_parciales.csv', fecha: new Date('2024-09-26T09:40:00'), estado: 'error', reintentos: 2 },
+      { cct: '09A1234A', archivo: 'ed_ciclo_2024_v2.zip', fecha: new Date('2024-09-27T12:05:00'), estado: 'completada', reintentos: 0 },
+      { cct: '30D3456D', archivo: 'reportes_validacion.pdf', fecha: new Date('2024-09-27T13:50:00'), estado: 'en-proceso', reintentos: 0 }
+    ];
+
+    const filtradas = descargas.filter((descarga) => {
+      const coincideCct = !filtro.cct || descarga.cct.toLowerCase().includes(filtro.cct.toLowerCase());
+      const fecha = descarga.fecha.getTime();
+      const despuesDe = filtro.fechaInicio?.getTime();
+      const antesDe = filtro.fechaFin?.getTime();
+
+      if (despuesDe && fecha < despuesDe) {
+        return false;
+      }
+
+      if (antesDe && fecha > antesDe) {
+        return false;
+      }
+
+      return coincideCct;
+    });
+
+    const resumen: ResumenSolicitudes = {
+      total: 186,
+      validadas: 144,
+      enProceso: 32,
+      conObservaciones: 10
+    };
+
+    const validaciones: ValidacionDetalle[] = [
+      { nombre: 'Integridad de datos', estado: 'validado', comentario: 'Sin hallazgos', actualizado: new Date('2024-09-26T08:45:00') },
+      { nombre: 'Consistencia de claves', estado: 'en-proceso', comentario: 'Se recalculan CCT duplicadas', actualizado: new Date('2024-09-26T09:10:00') },
+      { nombre: 'Estructura de archivos', estado: 'validado', comentario: 'Cumple con el layout', actualizado: new Date('2024-09-26T07:55:00') },
+      { nombre: 'Reglas de negocio', estado: 'pendiente', comentario: 'Esperando catálogos definitivos', actualizado: new Date('2024-09-25T17:20:00') }
+    ];
+
+    const snapshot: SeguimientoSnapshot = {
+      actualizado: new Date(),
+      resumenSolicitudes: resumen,
+      validaciones,
+      descargasRecientes: filtradas
+    };
+
+    // Simulación de llamada HTTP: return this.http.get<SeguimientoSnapshot>(`${this.apiUrl}`, { params: ... })
+    return of(snapshot).pipe(delay(450), map((valor) => ({ ...valor })));
+  }
+}
+
+export const seguimientoProviders = [
+  {
+    provide: SEGUIMIENTO_DATASOURCE,
+    useExisting: MockSeguimientoDataSource
+  }
+];


### PR DESCRIPTION
## Summary
- add a seguimiento data layer with interchangeable mock datasource to prepare for real tracking endpoints
- build a seguimiento-descargas component that summarizes solicitudes, validaciones, and descargas with filters and simulated reintentos
- embed the seguimiento panel into the descargas view and register the new providers

## Testing
- npm run build -- --configuration development *(fails: registry blocks installing sweetalert2 dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69449f2e9d4883208763bb97fb8556e5)