### PR TITLE
Widen carga-masiva container to reduce side whitespace

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
@@ -1,7 +1,7 @@
 .carga {
-  max-width: 880px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 3rem 1.5rem;
+  padding: 3rem 2rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;


### PR DESCRIPTION
### Motivation
- The `carga-masiva` view had excessive horizontal white space on large screens and should occupy more of the viewport without becoming full-width.
- Adjust the layout so content feels less narrow while keeping spacing on smaller screens.

### Description
- Updated `web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss` to increase the container width and horizontal padding.
- Changed `max-width` from `880px` to `1120px` and `padding` from `3rem 1.5rem` to `3rem 2rem` on the `.carga` selector.

### Testing
- Attempted an automated visual check with Playwright to capture a screenshot of `http://localhost:4200/carga-masiva` at `1365x768`, but the browser crashed (SIGSEGV) and the run failed.
- No other automated tests were executed; therefore no passing test results are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c04922b3883208f5fc226cdc37835)