### PR TITLE
Detectar tipo de XLSX antes de validación de carga masiva

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
@@ -21,7 +21,19 @@ const resultadoValido: ResultadoValidacion = {
 class ExcelValidationServiceStub {
   resultado: ResultadoValidacion = resultadoValido;
 
+  detectarTipoArchivo(): Promise<'preescolar'> {
+    return Promise.resolve('preescolar');
+  }
+
   validarPreescolar(): Promise<ResultadoValidacion> {
+    return Promise.resolve(this.resultado);
+  }
+
+  validarPrimaria(): Promise<ResultadoValidacion> {
+    return Promise.resolve(this.resultado);
+  }
+
+  validarSecundaria(): Promise<ResultadoValidacion> {
     return Promise.resolve(this.resultado);
   }
 }

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -2,7 +2,11 @@ import { CommonModule } from '@angular/common';
 import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
-import { ExcelValidationService, ResultadoValidacion } from '../../services/excel-validation.service';
+import {
+  ExcelValidationService,
+  ResultadoValidacion,
+  TipoArchivoCarga
+} from '../../services/excel-validation.service';
 import {
   ArchivoDuplicadoError,
   ArchivoStorageService,
@@ -209,7 +213,17 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
 
     try {
       const buffer = await file.arrayBuffer();
-      const resultado = await this.excelValidationService.validarPreescolar(buffer);
+      const tipoArchivo = await this.excelValidationService.detectarTipoArchivo(buffer);
+
+      if (tipoArchivo === 'desconocido') {
+        resultadoArchivo.errores = [
+          'No pudimos identificar el tipo de archivo. Verifica que sea un formato válido de Preescolar, Primaria o Secundaria.'
+        ];
+        await this.finalizarConError(resultadoArchivo);
+        return;
+      }
+
+      const resultado = await this.validarPorTipo(tipoArchivo, buffer);
       await this.procesarResultado(resultado, resultadoArchivo);
     } catch (error) {
       resultadoArchivo.errores = [
@@ -381,6 +395,23 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     this.actualizarEstadoSesion();
 
     await this.generarPdfExito(resultadoArchivo, resultado.esc, fechaDisponible, resultado.alumnos?.length ?? 0);
+  }
+
+  private validarPorTipo(tipo: TipoArchivoCarga, buffer: ArrayBuffer): Promise<ResultadoValidacion> {
+    switch (tipo) {
+      case 'preescolar':
+        return this.excelValidationService.validarPreescolar(buffer);
+      case 'primaria':
+        return this.excelValidationService.validarPrimaria(buffer);
+      case 'secundaria':
+        return this.excelValidationService.validarSecundaria(buffer);
+      default:
+        return Promise.resolve({
+          ok: false,
+          errores: ['No se pudo determinar el tipo de archivo para validarlo.'],
+          advertencias: []
+        });
+    }
   }
 
   private calcularFechaDisponible(): Date {

--- a/web/frontend/src/app/services/excel-validation.service.ts
+++ b/web/frontend/src/app/services/excel-validation.service.ts
@@ -25,6 +25,8 @@ export interface ResultadoValidacion {
   hojasEncontradas?: string[];
 }
 
+export type TipoArchivoCarga = 'preescolar' | 'primaria' | 'secundaria' | 'desconocido';
+
 @Injectable({ providedIn: 'root' })
 export class ExcelValidationService {
   private xlsxPromise: Promise<any> | null = null;
@@ -49,6 +51,39 @@ export class ExcelValidationService {
     'O',
     'P'
   ];
+
+  async detectarTipoArchivo(buffer: ArrayBuffer): Promise<TipoArchivoCarga> {
+    const xlsx = await this.cargarXlsx();
+    const workbook = xlsx.read(buffer, { type: 'array' });
+    const hojasNormalizadas = new Set(workbook.SheetNames.map((hoja: string) => this.normalizarHoja(hoja)));
+
+    const hojasPreescolar = ['ESC', 'TERCERO'];
+    const hojasPrimaria = ['ESC', 'PRIMERO', 'SEGUNDO', 'TERCERO', 'CUARTO', 'QUINTO', 'SEXTO'];
+    const hojasSecundaria = ['ESC', 'PRIMERO', 'SEGUNDO', 'TERCERO'];
+
+    if (this.contieneTodasLasHojas(hojasNormalizadas, hojasPrimaria)) {
+      return 'primaria';
+    }
+
+    if (
+      this.contieneTodasLasHojas(hojasNormalizadas, hojasSecundaria) &&
+      !hojasNormalizadas.has('CUARTO') &&
+      !hojasNormalizadas.has('QUINTO') &&
+      !hojasNormalizadas.has('SEXTO')
+    ) {
+      return 'secundaria';
+    }
+
+    if (
+      this.contieneTodasLasHojas(hojasNormalizadas, hojasPreescolar) &&
+      !hojasNormalizadas.has('PRIMERO') &&
+      !hojasNormalizadas.has('SEGUNDO')
+    ) {
+      return 'preescolar';
+    }
+
+    return 'desconocido';
+  }
 
   async validarPreescolar(buffer: ArrayBuffer): Promise<ResultadoValidacion> {
     const xlsx = await this.cargarXlsx();
@@ -91,6 +126,96 @@ export class ExcelValidationService {
       resultado.ok = true;
       resultado.esc = esc.datos!;
       resultado.alumnos = alumnos.registros;
+    }
+
+    return resultado;
+  }
+
+  async validarPrimaria(buffer: ArrayBuffer): Promise<ResultadoValidacion> {
+    const xlsx = await this.cargarXlsx();
+    const workbook = xlsx.read(buffer, { type: 'array' });
+    const errores: string[] = [];
+    const advertencias: string[] = [];
+    const hojas = workbook.SheetNames;
+    const hojasNormalizadas = new Set(hojas.map((hoja) => this.normalizarHoja(hoja)));
+    const hojasRequeridas = ['ESC', 'PRIMERO', 'SEGUNDO', 'TERCERO', 'CUARTO', 'QUINTO', 'SEXTO'];
+
+    const hojasFaltantes = this.obtenerHojasFaltantes(hojasNormalizadas, hojasRequeridas);
+    if (hojasFaltantes.length) {
+      errores.push(`Faltan las hojas ${hojasFaltantes.join(', ')} en el archivo.`);
+    }
+
+    const resultado: ResultadoValidacion = {
+      ok: false,
+      errores,
+      advertencias,
+      hojasEncontradas: hojas
+    };
+
+    if (errores.length) {
+      return resultado;
+    }
+
+    const escSheet = workbook.Sheets['ESC'];
+    if (!escSheet) {
+      resultado.errores.push('Falta la hoja ESC en el archivo.');
+      return resultado;
+    }
+
+    const esc = this.validarEsc(escSheet);
+    resultado.errores.push(...esc.errores);
+    if (esc.advertencia) {
+      resultado.advertencias.push(esc.advertencia);
+    }
+
+    if (!resultado.errores.length) {
+      resultado.ok = true;
+      resultado.esc = esc.datos!;
+    }
+
+    return resultado;
+  }
+
+  async validarSecundaria(buffer: ArrayBuffer): Promise<ResultadoValidacion> {
+    const xlsx = await this.cargarXlsx();
+    const workbook = xlsx.read(buffer, { type: 'array' });
+    const errores: string[] = [];
+    const advertencias: string[] = [];
+    const hojas = workbook.SheetNames;
+    const hojasNormalizadas = new Set(hojas.map((hoja) => this.normalizarHoja(hoja)));
+    const hojasRequeridas = ['ESC', 'PRIMERO', 'SEGUNDO', 'TERCERO'];
+
+    const hojasFaltantes = this.obtenerHojasFaltantes(hojasNormalizadas, hojasRequeridas);
+    if (hojasFaltantes.length) {
+      errores.push(`Faltan las hojas ${hojasFaltantes.join(', ')} en el archivo.`);
+    }
+
+    const resultado: ResultadoValidacion = {
+      ok: false,
+      errores,
+      advertencias,
+      hojasEncontradas: hojas
+    };
+
+    if (errores.length) {
+      return resultado;
+    }
+
+    const escSheet = workbook.Sheets['ESC'];
+    if (!escSheet) {
+      resultado.errores.push('Falta la hoja ESC en el archivo.');
+      return resultado;
+    }
+
+    const esc = this.validarEsc(escSheet);
+    resultado.errores.push(...esc.errores);
+    if (esc.advertencia) {
+      resultado.advertencias.push(esc.advertencia);
+    }
+
+    if (!resultado.errores.length) {
+      resultado.ok = true;
+      resultado.esc = esc.datos!;
     }
 
     return resultado;
@@ -234,6 +359,18 @@ export class ExcelValidationService {
 
   private limpiarTexto(valor: any): string {
     return (valor ?? '').toString().trim();
+  }
+
+  private normalizarHoja(nombre: string): string {
+    return (nombre ?? '').toString().trim().toUpperCase();
+  }
+
+  private contieneTodasLasHojas(hojas: Set<string>, requeridas: string[]): boolean {
+    return requeridas.every((hoja) => hojas.has(hoja));
+  }
+
+  private obtenerHojasFaltantes(hojas: Set<string>, requeridas: string[]): string[] {
+    return requeridas.filter((hoja) => !hojas.has(hoja));
   }
 
   private primeraCeldaNoVacia(sheet: any, celdas: string[]): string {


### PR DESCRIPTION
### Motivation
- Diferenciar automáticamente los formatos de libro Excel (Preescolar / Primaria / Secundaria) antes de validar su contenido para enrutar la validación correcta.
- Evitar validaciones equivocadas y dar un mensaje claro cuando el archivo no corresponde a ninguna plantilla conocida.
- Preparar el servicio de validación para soportar múltiples plantillas con entradas específicas por nivel.
- Mantener la UX consistente mostrando errores de tipo antes de procesar el contenido del archivo.

### Description
- Se agregó el tipo `TipoArchivoCarga` y la función `detectarTipoArchivo(buffer)` en `ExcelValidationService` que inspecciona los nombres de hojas para devolver `preescolar`, `primaria`, `secundaria` o `desconocido`.
- Se añadieron los métodos de validación `validarPrimaria` y `validarSecundaria` en `ExcelValidationService` y helpers `normalizarHoja`, `contieneTodasLasHojas` y `obtenerHojasFaltantes` para facilitar la detección y verificación de hojas requeridas.
- `CargaMasivaComponent` ahora llama a `detectarTipoArchivo` antes de validar, muestra un error claro cuando el tipo es `desconocido` y enruta a la validación correspondiente mediante `validarPorTipo` que invoca `validarPreescolar`/`validarPrimaria`/`validarSecundaria`.
- Se actualizó el stub de pruebas en `carga-masiva.component.spec.ts` para incluir `detectarTipoArchivo`, `validarPrimaria` y `validarSecundaria`.

### Testing
- No se ejecutaron pruebas automáticas en CI en este cambio.
- El archivo de pruebas `web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts` fue actualizado con stubs para el detector y validadores, pero no se ejecutaron las pruebas.
- Se solicitó verificación manual en UI subiendo los archivos de ejemplo de Preescolar, Primaria y Secundaria para confirmar la detección correcta (no automatizado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c3be9da0c8320b0c8a51126c8e65c)