### PR TITLE
Widen carga-masiva container and fix SheetNames typing in Excel validator

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
@@ -1,7 +1,7 @@
 .carga {
-  max-width: 880px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 3rem 1.5rem;
+  padding: 3rem 2rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;

--- a/web/frontend/src/app/services/excel-validation.service.ts
+++ b/web/frontend/src/app/services/excel-validation.service.ts
@@ -55,7 +55,7 @@ export class ExcelValidationService {
     const workbook = xlsx.read(buffer, { type: 'array' });
     const errores: string[] = [];
     const advertencias: string[] = [];
-    const hojas = workbook.SheetNames;
+    const hojas = workbook.SheetNames as string[];
 
     const escSheet = workbook.Sheets['ESC'];
     const terceroSheet = workbook.Sheets['TERCERO'];


### PR DESCRIPTION
### Motivation
- Reducir el espacio horizontal excesivo en la vista `carga-masiva` para que el contenido aproveche mejor pantallas grandes sin quedar full-width.
- Corregir un error de tipo TypeScript (`TS2345`) provocado por colecciones de nombres de hojas tipadas como `unknown` frente a `Set<string>`.
- Asegurar que las listas de nombres de hoja se traten como cadenas para que las validaciones de hojas funcionen sin advertencias de tipos.

### Description
- Actualizado `web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss` para aumentar `max-width` de `880px` a `1120px` y `padding` de `3rem 1.5rem` a `3rem 2rem`.
- En `web/frontend/src/app/services/excel-validation.service.ts` se casteó `workbook.SheetNames` a `string[]` dentro de `validarPreescolar` para mantener las colecciones de nombres de hoja tipadas como `string`.
- Los cambios están limitados a los dos archivos mencionados y buscan resolver la presentación y el error de tipos respectivamente.

### Testing
- No se ejecutaron pruebas automatizadas después de estos cambios.
- Una ejecución previa de Playwright para una verificación visual falló (el navegador se cayó con SIGSEGV) durante el intento de captura de `http://localhost:4200/carga-masiva` y por tanto no pasó.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c04922b3883208f5fc226cdc37835)