### PR TITLE
Fix tipo archivo detection checks in carga-masiva and remove duplicate members in ExcelValidationService

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -134,7 +134,7 @@
           <p class="carga__detalle-metadata">
             Peso: {{ resultado.archivo.sizeKb }} KB · Última modificación: {{ resultado.archivo.lastModified | date:'short' }}
           </p>
-          <p class="carga__detalle-metadata" *ngIf="resultado.tipoDetectado && resultado.tipoDetectado !== 'desconocido'">
+          <p class="carga__detalle-metadata" *ngIf="resultado.tipoDetectado">
             Archivo detectado: {{ obtenerEtiquetaTipo(resultado.tipoDetectado) }}
           </p>
         </div>

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -228,7 +228,7 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       const tipoArchivo = await this.excelValidationService.detectarTipoArchivo(buffer);
       resultadoArchivo.tipoDetectado = tipoArchivo;
 
-      if (tipoArchivo === 'desconocido') {
+      if (!tipoArchivo) {
         resultadoArchivo.mensajeInformativo = 'No se reconoció el formato.';
         this.actualizarErrores(resultadoArchivo, [
           'No se reconoció el formato. Verifica que sea una plantilla válida de Preescolar, Primaria o Secundaria.'
@@ -695,7 +695,7 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
   }
 
   private construirMensajeDeteccion(tipo: TipoArchivoCarga | null, error?: string): string {
-    if (!tipo || tipo === 'desconocido') {
+    if (!tipo) {
       return 'No se reconoció el formato.';
     }
 

--- a/web/frontend/src/app/services/excel-validation.service.ts
+++ b/web/frontend/src/app/services/excel-validation.service.ts
@@ -82,12 +82,6 @@ export class ExcelValidationService {
     'O',
     'P'
   ];
-  private readonly hojasPorNivel: Record<TipoArchivoCarga, string[]> = {
-    preescolar: ['ESC', 'TERCERO'],
-    primaria: ['ESC', 'PRIMERO', 'SEGUNDO', 'TERCERO', 'CUARTO', 'QUINTO', 'SEXTO'],
-    secundaria: ['ESC', 'PRIMERO', 'SEGUNDO', 'TERCERO']
-  };
-
   async detectarTipoArchivo(buffer: ArrayBuffer): Promise<TipoArchivoCarga | null> {
     const xlsx = await this.cargarXlsx();
     const workbook = xlsx.read(buffer, { type: 'array' });
@@ -184,98 +178,6 @@ export class ExcelValidationService {
     const hojasNormalizadas = this.normalizarHojas(hojas);
     const hojasRequeridas = this.hojasPorNivel.primaria;
     const grados = ['PRIMERO', 'SEGUNDO', 'TERCERO', 'CUARTO', 'QUINTO', 'SEXTO'];
-
-    if (!this.contieneTodasLasHojas(hojasNormalizadas, hojasRequeridas)) {
-      const faltantes = this.obtenerHojasFaltantes(hojasNormalizadas, hojasRequeridas);
-      errores.push(`Faltan hojas requeridas: ${faltantes.join(', ')}.`);
-    }
-
-    if (!escSheet) {
-      errores.push('Falta la hoja ESC en el archivo.');
-    }
-
-    const resultado: ResultadoValidacion = {
-      ok: false,
-      errores,
-      advertencias,
-      hojasEncontradas: hojas
-    };
-
-    if (errores.length) {
-      return resultado;
-    }
-
-    const esc = this.validarEsc(escSheet);
-    resultado.errores.push(...esc.errores);
-    if (esc.advertencia) {
-      resultado.advertencias.push(esc.advertencia);
-    }
-
-    const alumnos = this.validarHojaAlumnos(xlsx, terceroSheet, 'TERCERO');
-    resultado.errores.push(...alumnos.errores);
-
-    if (!resultado.errores.length) {
-      resultado.ok = true;
-      resultado.esc = esc.datos!;
-      resultado.alumnos = alumnos.registros;
-    }
-
-    return resultado;
-  }
-
-  private validarPrimariaWorkbook(xlsx: any, workbook: any, hojas: string[]): ResultadoValidacion {
-    const errores: string[] = [];
-    const advertencias: string[] = [];
-    const escSheet = workbook.Sheets['ESC'];
-    const hojasNormalizadas = this.normalizarHojas(hojas);
-    const hojasRequeridas = this.hojasPorNivel.primaria;
-    const grados = ['PRIMERO', 'SEGUNDO', 'TERCERO', 'CUARTO', 'QUINTO', 'SEXTO'];
-
-    if (!this.contieneTodasLasHojas(hojasNormalizadas, hojasRequeridas)) {
-      const faltantes = this.obtenerHojasFaltantes(hojasNormalizadas, hojasRequeridas);
-      errores.push(`Faltan hojas requeridas: ${faltantes.join(', ')}.`);
-    }
-
-    if (!escSheet) {
-      errores.push('Falta la hoja ESC en el archivo.');
-    }
-
-    const resultado: ResultadoValidacion = {
-      ok: false,
-      errores,
-      advertencias,
-      hojasEncontradas: hojas
-    };
-
-    if (errores.length) {
-      return resultado;
-    }
-
-    const esc = this.validarEsc(escSheet);
-    resultado.errores.push(...esc.errores);
-    if (esc.advertencia) {
-      resultado.advertencias.push(esc.advertencia);
-    }
-
-    const alumnos = this.validarHojasPorNombre(xlsx, workbook, grados);
-    resultado.errores.push(...alumnos.errores);
-
-    if (!resultado.errores.length) {
-      resultado.ok = true;
-      resultado.esc = esc.datos!;
-      resultado.alumnos = alumnos.registros;
-    }
-
-    return resultado;
-  }
-
-  private validarSecundariaWorkbook(xlsx: any, workbook: any, hojas: string[]): ResultadoValidacion {
-    const errores: string[] = [];
-    const advertencias: string[] = [];
-    const escSheet = workbook.Sheets['ESC'];
-    const hojasNormalizadas = this.normalizarHojas(hojas);
-    const hojasRequeridas = this.hojasPorNivel.secundaria;
-    const grados = ['PRIMERO', 'SEGUNDO', 'TERCERO'];
 
     if (!this.contieneTodasLasHojas(hojasNormalizadas, hojasRequeridas)) {
       const faltantes = this.obtenerHojasFaltantes(hojasNormalizadas, hojasRequeridas);
@@ -710,18 +612,6 @@ export class ExcelValidationService {
       .replace(/\s+/g, ' ')
       .trim()
       .toUpperCase();
-  }
-
-  private normalizarHoja(nombre: string): string {
-    return (nombre ?? '').toString().trim().toUpperCase();
-  }
-
-  private contieneTodasLasHojas(hojas: Set<string>, requeridas: string[]): boolean {
-    return requeridas.every((hoja) => hojas.has(hoja));
-  }
-
-  private obtenerHojasFaltantes(hojas: Set<string>, requeridas: string[]): string[] {
-    return requeridas.filter((hoja) => !hojas.has(hoja));
   }
 
   private primeraCeldaNoVacia(sheet: any, celdas: string[]): string {


### PR DESCRIPTION
### Motivation
- Eliminar advertencias y duplicados en `ExcelValidationService` que provocaban warnings en tiempo de compilación.
- Corregir errores de tipos de TypeScript/Angular derivados de comparar `TipoArchivoCarga` con la cadena no tipada `'desconocido'`.
- Representar la detección "desconocida" como `null` para que el tipo `TipoArchivoCarga | null` sea consistente con las comprobaciones.
- Simplificar la lógica del template para evitar comparaciones de tipos incompatibles en la plantilla de `carga-masiva`.

### Description
- Se eliminaron implementaciones duplicadas en `web/frontend/src/app/services/excel-validation.service.ts`, consolidando métodos como `hojasPorNivel`, `validarPrimariaWorkbook`, `validarSecundariaWorkbook`, `normalizarHoja`, `contieneTodasLasHojas` y `obtenerHojasFaltantes` (duplicados removidos y la lógica central preservada).
- En `web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts` se cambió la comprobación de tipo detectado de `tipoArchivo === 'desconocido'` a `!tipoArchivo` y se ajustó `construirMensajeDeteccion` para usar `if (!tipo)` tratando la detección desconocida como `null`.
- En la plantilla `web/frontend/src/app/components/carga-masiva/carga-masiva.component.html` se simplificó la condición a `*ngIf="resultado.tipoDetectado"` para evitar comparar con la cadena `'desconocido'`.
- Pequeños ajustes de mensajes informativos y flujo de validación para usar la representación `null` cuando el tipo no se reconoce.

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio.
- No se informó de builds o checks de CI automáticos en esta PR.
- Cambios verificados localmente mediante inspección de código y commits, sin compilación automatizada.
- Recomendado ejecutar `ng build --prod` o la suite de TypeScript/Angular en CI para validar la ausencia de errores de tipo antes de desplegar.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c4cfe0eb08320b03489317d7cfd6d)