### PR TITLE
Add admin auth flow, role support and guarded PDF upload (backend + frontend)

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Post, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('admin/pdfs')
+@UseGuards(JwtAuthGuard, AdminGuard)
+export class AdminController {
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file'))
+  uploadPdf(@UploadedFile() file?: Express.Multer.File) {
+    return {
+      ok: true,
+      filename: file?.originalname ?? null,
+      message: file ? 'PDF recibido.' : 'No se recibió archivo.',
+    };
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+
+@Module({
+  controllers: [AdminController],
+})
+export class AdminModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,9 +4,15 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), UsersModule, AuthModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    UsersModule,
+    AuthModule,
+    AdminModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -23,4 +23,18 @@ export class AuthController {
 
     return this.authService.login(user);
   }
+
+  @Post('admin/login')
+  async adminLogin(@Body() loginDto: LoginDto) {
+    const adminUser = await this.authService.validateAdminCredentials(
+      loginDto.email,
+      loginDto.password,
+    );
+
+    if (!adminUser) {
+      throw new UnauthorizedException('Credenciales inválidas');
+    }
+
+    return this.authService.login(adminUser);
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,6 +9,11 @@ export class AuthService {
     private readonly jwtService: JwtService,
   ) {}
 
+  private readonly adminCredentials = {
+    email: 'admin@plataforma.local',
+    password: 'admin123',
+  };
+
   async validateUser(
     email: string,
     password: string,
@@ -21,10 +26,30 @@ export class AuthService {
     return this.usersService.sanitizeUser(user);
   }
 
+  async validateAdminCredentials(
+    email: string,
+    password: string,
+  ): Promise<Omit<User, 'password'> | null> {
+    if (
+      email !== this.adminCredentials.email ||
+      password !== this.adminCredentials.password
+    ) {
+      return null;
+    }
+
+    return {
+      id: 999,
+      email: this.adminCredentials.email,
+      name: 'Administrador',
+      role: 'admin',
+    };
+  }
+
   async login(user: User | Omit<User, 'password'>) {
-    const payload = { sub: user.id, email: user.email };
+    const payload = { sub: user.id, email: user.email, role: user.role };
     return {
       access_token: this.jwtService.sign(payload),
+      role: user.role,
     };
   }
 }

--- a/src/auth/guards/admin.guard.ts
+++ b/src/auth/guards/admin.guard.ts
@@ -1,0 +1,15 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (user?.role === 'admin') {
+      return true;
+    }
+
+    throw new ForbiddenException('Acceso exclusivo para administradores.');
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -6,6 +6,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 export interface JwtPayload {
   sub: number;
   email: string;
+  role: 'admin' | 'teacher';
 }
 
 @Injectable()
@@ -19,6 +20,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload) {
-    return { id: payload.sub, email: payload.email };
+    return {
+      id: payload.sub,
+      email: payload.email,
+      role: payload.role,
+      isAdmin: payload.role === 'admin',
+    };
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -5,6 +5,7 @@ export interface User {
   email: string;
   password: string;
   name: string;
+  role: 'admin' | 'teacher';
 }
 
 @Injectable()
@@ -15,6 +16,14 @@ export class UsersService {
       email: 'admin@example.com',
       password: 'changeme',
       name: 'Administrador',
+      role: 'admin',
+    },
+    {
+      id: 2,
+      email: 'profesor@example.com',
+      password: 'changeme',
+      name: 'Profesor',
+      role: 'teacher',
     },
   ];
 

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -4,6 +4,8 @@ import { CargaMasivaComponent } from './components/carga-masiva/carga-masiva.com
 import { ArchivosGuardadosComponent } from './components/archivos-guardados/archivos-guardados.component';
 import { LoginComponent } from './components/login/login.component';
 import { DescargasComponent } from './components/descargas/descargas.component';
+import { AdminLoginComponent } from './components/admin-login/admin-login.component';
+import { AdminPanelComponent } from './components/admin-panel/admin-panel.component';
 
 
 export const routes: Routes = [
@@ -40,6 +42,16 @@ export const routes: Routes = [
   {
     path: 'login',
     component: LoginComponent,
+    pathMatch: 'full'
+  },
+  {
+    path: 'admin/login',
+    component: AdminLoginComponent,
+    pathMatch: 'full'
+  },
+  {
+    path: 'admin/panel',
+    component: AdminPanelComponent,
     pathMatch: 'full'
   },
   {

--- a/web/frontend/src/app/components/admin-login/admin-login.component.html
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.html
@@ -1,0 +1,38 @@
+<section class="admin-login">
+  <div class="admin-login__card">
+    <h1>Acceso administrador</h1>
+    <p>Ingresa el correo y contraseña asignados para la carga de PDFs.</p>
+
+    <form (ngSubmit)="iniciarSesion()" #loginForm="ngForm" novalidate>
+      <label for="correo-admin">Correo</label>
+      <input
+        id="correo-admin"
+        name="correo"
+        type="email"
+        required
+        [(ngModel)]="correo"
+        autocomplete="email"
+        placeholder="admin@plataforma.local"
+      />
+
+      <label for="contrasena-admin">Contraseña</label>
+      <input
+        id="contrasena-admin"
+        name="contrasena"
+        type="password"
+        required
+        [(ngModel)]="contrasena"
+        autocomplete="current-password"
+        placeholder="********"
+      />
+
+      <div class="admin-login__error" *ngIf="error">{{ error }}</div>
+
+      <button class="admin-login__submit" type="submit" [disabled]="loginForm.invalid || autenticando">
+        {{ autenticando ? 'Validando...' : 'Iniciar sesión' }}
+      </button>
+    </form>
+
+    <a class="admin-login__link" routerLink="/inicio">Volver al inicio</a>
+  </div>
+</section>

--- a/web/frontend/src/app/components/admin-login/admin-login.component.scss
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.scss
@@ -1,0 +1,73 @@
+.admin-login {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+}
+
+.admin-login__card {
+  width: min(520px, 100%);
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-login__card h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #1b2e4b;
+}
+
+.admin-login__card p {
+  margin: 0 0 1.5rem;
+  color: #4b5563;
+}
+
+.admin-login__card label {
+  font-weight: 600;
+  margin-top: 0.75rem;
+  color: #1f2937;
+}
+
+.admin-login__card input {
+  margin-top: 0.35rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+  width: 100%;
+}
+
+.admin-login__error {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: #ffe4e6;
+  color: #9f1239;
+}
+
+.admin-login__submit {
+  margin-top: 1.5rem;
+  padding: 0.85rem 1.5rem;
+  border: none;
+  border-radius: 999px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.admin-login__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.admin-login__link {
+  margin-top: 1rem;
+  text-align: center;
+  color: #1d4ed8;
+  text-decoration: none;
+}

--- a/web/frontend/src/app/components/admin-login/admin-login.component.ts
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.ts
@@ -1,0 +1,51 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import Swal from 'sweetalert2';
+import { AdminAuthService } from '../../services/admin-auth.service';
+
+@Component({
+  selector: 'app-admin-login',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './admin-login.component.html',
+  styleUrl: './admin-login.component.scss',
+})
+export class AdminLoginComponent {
+  correo = '';
+  contrasena = '';
+  error: string | null = null;
+  autenticando = false;
+
+  constructor(
+    private readonly adminAuthService: AdminAuthService,
+    private readonly router: Router,
+  ) {}
+
+  async iniciarSesion(): Promise<void> {
+    this.error = null;
+    this.autenticando = true;
+
+    try {
+      await this.adminAuthService.iniciarSesion(this.correo, this.contrasena);
+      await Swal.fire({
+        icon: 'success',
+        title: 'Sesión de administrador iniciada',
+        text: 'Ya puedes acceder al panel de carga de PDFs.',
+        timer: 2500,
+        timerProgressBar: true,
+      });
+      await this.router.navigateByUrl('/admin/panel');
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'No fue posible iniciar sesión.';
+      await Swal.fire({
+        icon: 'error',
+        title: 'No se pudo iniciar sesión',
+        text: this.error,
+      });
+    } finally {
+      this.autenticando = false;
+    }
+  }
+}

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -1,0 +1,20 @@
+<section class="admin-panel">
+  <div class="admin-panel__card">
+    <h1>Panel de administrador</h1>
+    <p>Token activo para la carga de PDFs.</p>
+
+    <div class="admin-panel__token" *ngIf="obtenerToken(); else sinSesion">
+      <span>Token almacenado:</span>
+      <code>{{ obtenerToken() }}</code>
+    </div>
+
+    <ng-template #sinSesion>
+      <div class="admin-panel__token admin-panel__token--warning">
+        No hay sesión activa. Vuelve al login para obtener un token.
+      </div>
+    </ng-template>
+
+    <a class="admin-panel__link" routerLink="/admin/login">Ir al login</a>
+    <button class="admin-panel__logout" type="button" (click)="cerrarSesion()">Cerrar sesión</button>
+  </div>
+</section>

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -1,0 +1,48 @@
+.admin-panel {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+}
+
+.admin-panel__card {
+  width: min(720px, 100%);
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin-panel__token {
+  padding: 1rem;
+  border-radius: 12px;
+  background: #f1f5f9;
+  color: #0f172a;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  word-break: break-all;
+}
+
+.admin-panel__token--warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.admin-panel__link {
+  color: #1d4ed8;
+  text-decoration: none;
+}
+
+.admin-panel__logout {
+  align-self: flex-start;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: #ef4444;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { AdminAuthService } from '../../services/admin-auth.service';
+
+@Component({
+  selector: 'app-admin-panel',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './admin-panel.component.html',
+  styleUrl: './admin-panel.component.scss',
+})
+export class AdminPanelComponent {
+  constructor(private readonly adminAuthService: AdminAuthService) {}
+
+  obtenerToken(): string | null {
+    return this.adminAuthService.obtenerToken();
+  }
+
+  cerrarSesion(): void {
+    this.adminAuthService.cerrarSesion();
+  }
+}

--- a/web/frontend/src/app/services/admin-auth.service.ts
+++ b/web/frontend/src/app/services/admin-auth.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+interface AdminLoginResponse {
+  access_token: string;
+  role?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AdminAuthService {
+  private readonly tokenKey = 'admin-session-token';
+
+  constructor(private readonly http: HttpClient) {}
+
+  async iniciarSesion(correo: string, contrasena: string): Promise<void> {
+    const respuesta = await firstValueFrom(
+      this.http.post<AdminLoginResponse>('/auth/admin/login', {
+        email: correo,
+        password: contrasena,
+      }),
+    );
+
+    if (!respuesta?.access_token) {
+      throw new Error('No se recibió un token válido.');
+    }
+
+    localStorage.setItem(this.tokenKey, respuesta.access_token);
+  }
+
+  obtenerToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  cerrarSesion(): void {
+    localStorage.removeItem(this.tokenKey);
+  }
+
+  estaAutenticado(): boolean {
+    return !!this.obtenerToken();
+  }
+}


### PR DESCRIPTION
### Motivation
- Add an administrator login flow that issues a JWT and distinguishes admin users from teachers.
- Provide a clear role/flag for users so backend routes can be restricted to administrators.
- Protect PDF upload endpoints so only authenticated admins can upload PDFs.
- Offer a minimal frontend admin login and panel that stores the admin token for use by the panel.

### Description
- Add `role` to the `User` interface and seed `admin` and `teacher` users in `src/users/users.service.ts`.
- Implement a hardcoded admin credential check in `src/auth/auth.service.ts` with `validateAdminCredentials`, include `role` in the JWT payload, and return `role` in the login response.
- Add `POST /auth/admin/login` in `src/auth/auth.controller.ts` to issue admin tokens and update `JwtStrategy` to include `role` and an `isAdmin` flag in the validated user object.
- Add `AdminGuard` (`src/auth/guards/admin.guard.ts`) and an `AdminController` (`src/admin/admin.controller.ts`) exposing `POST /admin/pdfs/upload` protected by `JwtAuthGuard` and `AdminGuard`, and register `AdminModule` in `AppModule`.
- Add frontend pieces in `web/frontend`: `AdminAuthService` to call `/auth/admin/login` and persist the token, `admin-login` and `admin-panel` components, and routes `/admin/login` and `/admin/panel`.

### Testing
- Attempted to install frontend dependencies with `npm install` in `web/frontend`, which failed with a `403 Forbidden` from the npm registry so the frontend build/run could not be executed. 
- No automated unit or e2e tests were executed as part of this change.
- Backend changes were implemented and compiled locally as source edits, but no automated test suite was run against the Nest app in this rollout.
- Manual API/runtime validation was not performed due to the above dependency/install issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8d8c1d1083208a77375a6ec301cd)