### PR TITLE
Add PDF upload UI to admin panel (input, button, status & styles)

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -14,6 +14,30 @@
       </div>
     </ng-template>
 
+    <div class="admin-panel__upload">
+      <label class="admin-panel__upload-label" for="pdf-upload">Selecciona un PDF</label>
+      <input
+        id="pdf-upload"
+        class="admin-panel__upload-input"
+        type="file"
+        accept="application/pdf"
+      />
+      <button class="admin-panel__upload-button" type="button">Subir PDF</button>
+
+      <div
+        class="admin-panel__status"
+        [class.admin-panel__status--idle]="uploadStatus === 'idle'"
+        [class.admin-panel__status--uploading]="uploadStatus === 'uploading'"
+        [class.admin-panel__status--success]="uploadStatus === 'success'"
+        [class.admin-panel__status--error]="uploadStatus === 'error'"
+      >
+        <span class="admin-panel__status-label">Estado de carga:</span>
+        <span class="admin-panel__status-message">
+          {{ feedbackMessage || 'Sin acciones por el momento.' }}
+        </span>
+      </div>
+    </div>
+
     <a class="admin-panel__link" routerLink="/admin/login">Ir al login</a>
     <button class="admin-panel__logout" type="button" (click)="cerrarSesion()">Cerrar sesión</button>
   </div>

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -36,6 +36,81 @@
   text-decoration: none;
 }
 
+.admin-panel__upload {
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-panel__upload-label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.admin-panel__upload-input {
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  color: #0f172a;
+}
+
+.admin-panel__upload-button {
+  align-self: flex-start;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  border: none;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.admin-panel__status {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: #e2e8f0;
+  color: #0f172a;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.admin-panel__status--idle {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.admin-panel__status--uploading {
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.admin-panel__status--success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.admin-panel__status--error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.admin-panel__status-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.admin-panel__status-message {
+  font-size: 0.95rem;
+}
+
 .admin-panel__logout {
   align-self: flex-start;
   padding: 0.75rem 1.5rem;

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -11,6 +11,10 @@ import { AdminAuthService } from '../../services/admin-auth.service';
   styleUrl: './admin-panel.component.scss',
 })
 export class AdminPanelComponent {
+  selectedFile: File | null = null;
+  uploadStatus: 'idle' | 'uploading' | 'success' | 'error' = 'idle';
+  feedbackMessage = '';
+
   constructor(private readonly adminAuthService: AdminAuthService) {}
 
   obtenerToken(): string | null {


### PR DESCRIPTION
### Motivation
- Provide a UI for administrators to select and upload PDF files from the admin panel.
- Surface upload status and user feedback so admins know when an upload is in progress or completed.
- Keep the new upload block visually consistent with the existing card-based admin layout.

### Description
- Added a file selector (`<input type="file" accept="application/pdf">`), an upload button, and a status area to `web/frontend/src/app/components/admin-panel/admin-panel.component.html` with bindings to component state. 
- Introduced styles for the upload block and status variants in `web/frontend/src/app/components/admin-panel/admin-panel.component.scss` to match the current design. 
- Added component properties `selectedFile`, `uploadStatus: 'idle' | 'uploading' | 'success' | 'error'`, and `feedbackMessage` to `web/frontend/src/app/components/admin-panel/admin-panel.component.ts` for managing the upload UI state. 
- No upload logic or network calls were added in this change; these are UI placeholders ready for wiring to upload handlers.

### Testing
- No automated tests were executed for this change. 
- Files were lint/checked manually by inspecting the updated templates, styles, and component TypeScript. 
- The changes were staged and committed successfully with `git commit`.
- Runtime verification (app build/run) was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9d8273dc83208e7ec75d4c5075af)