### PR TITLE
Add admin panel PDF upload flow

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -21,8 +21,11 @@
         class="admin-panel__upload-input"
         type="file"
         accept="application/pdf"
+        (change)="seleccionarArchivo($event)"
       />
-      <button class="admin-panel__upload-button" type="button">Subir PDF</button>
+      <button class="admin-panel__upload-button" type="button" (click)="subirPdf()">
+        Subir PDF
+      </button>
 
       <div
         class="admin-panel__status"
@@ -35,6 +38,19 @@
         <span class="admin-panel__status-message">
           {{ feedbackMessage || 'Sin acciones por el momento.' }}
         </span>
+      </div>
+
+      <div class="admin-panel__history" *ngIf="uploadHistory.length">
+        <span class="admin-panel__history-title">Historial reciente</span>
+        <ul class="admin-panel__history-list">
+          <li class="admin-panel__history-item" *ngFor="let item of uploadHistory">
+            <span class="admin-panel__history-name">{{ item.name }}</span>
+            <span class="admin-panel__history-meta">
+              {{ item.size / 1024 | number : '1.0-0' }} KB ·
+              {{ item.uploadedAt | date : 'short' }}
+            </span>
+          </li>
+        </ul>
       </div>
     </div>
 

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -111,6 +111,49 @@
   font-size: 0.95rem;
 }
 
+.admin-panel__history {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: #ffffff;
+  border: 1px dashed #cbd5f5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-panel__history-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #1e293b;
+}
+
+.admin-panel__history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-panel__history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  color: #334155;
+}
+
+.admin-panel__history-name {
+  font-weight: 600;
+}
+
+.admin-panel__history-meta {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
 .admin-panel__logout {
   align-self: flex-start;
   padding: 0.75rem 1.5rem;

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { AdminAuthService } from '../../services/admin-auth.service';
 
@@ -10,12 +10,66 @@ import { AdminAuthService } from '../../services/admin-auth.service';
   templateUrl: './admin-panel.component.html',
   styleUrl: './admin-panel.component.scss',
 })
-export class AdminPanelComponent {
+export class AdminPanelComponent implements OnInit {
   selectedFile: File | null = null;
   uploadStatus: 'idle' | 'uploading' | 'success' | 'error' = 'idle';
   feedbackMessage = '';
+  uploadHistory: Array<{ name: string; size: number; uploadedAt: string }> = [];
+  private readonly uploadHistoryKey = 'adminPanelPdfHistory';
 
   constructor(private readonly adminAuthService: AdminAuthService) {}
+
+  ngOnInit(): void {
+    this.uploadHistory = this.loadUploadHistory();
+  }
+
+  seleccionarArchivo(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.selectedFile = input.files?.[0] ?? null;
+    if (!this.selectedFile) {
+      this.uploadStatus = 'idle';
+      this.feedbackMessage = 'Selecciona un archivo PDF para comenzar.';
+      return;
+    }
+
+    this.uploadStatus = 'idle';
+    this.feedbackMessage = `Archivo seleccionado: ${this.selectedFile.name}`;
+  }
+
+  subirPdf(): void {
+    if (!this.selectedFile) {
+      this.uploadStatus = 'error';
+      this.feedbackMessage = 'No se ha seleccionado ningún archivo.';
+      return;
+    }
+
+    const isPdf =
+      this.selectedFile.type === 'application/pdf' ||
+      this.selectedFile.name.toLowerCase().endsWith('.pdf');
+
+    if (!isPdf) {
+      this.uploadStatus = 'error';
+      this.feedbackMessage = 'El archivo seleccionado no es un PDF válido.';
+      return;
+    }
+
+    this.uploadStatus = 'uploading';
+    this.feedbackMessage = 'Cargando archivo...';
+
+    setTimeout(() => {
+      this.uploadStatus = 'success';
+      this.feedbackMessage = 'PDF cargado correctamente.';
+
+      const metadata = {
+        name: this.selectedFile?.name ?? 'PDF',
+        size: this.selectedFile?.size ?? 0,
+        uploadedAt: new Date().toISOString(),
+      };
+
+      this.uploadHistory = [metadata, ...this.uploadHistory].slice(0, 5);
+      this.saveUploadHistory();
+    }, 1500);
+  }
 
   obtenerToken(): string | null {
     return this.adminAuthService.obtenerToken();
@@ -23,5 +77,27 @@ export class AdminPanelComponent {
 
   cerrarSesion(): void {
     this.adminAuthService.cerrarSesion();
+  }
+
+  private loadUploadHistory(): Array<{ name: string; size: number; uploadedAt: string }> {
+    const storedHistory = localStorage.getItem(this.uploadHistoryKey);
+    if (!storedHistory) {
+      return [];
+    }
+
+    try {
+      const parsedHistory = JSON.parse(storedHistory);
+      if (Array.isArray(parsedHistory)) {
+        return parsedHistory;
+      }
+    } catch (error) {
+      return [];
+    }
+
+    return [];
+  }
+
+  private saveUploadHistory(): void {
+    localStorage.setItem(this.uploadHistoryKey, JSON.stringify(this.uploadHistory));
   }
 }


### PR DESCRIPTION
### Motivation

- Habilitar en el panel de administrador la selección y carga de archivos PDF con validación y mensajes de estado.
- Proveer una experiencia de carga simulada para mostrar estados `uploading`/`success`/`error` sin backend.
- Mantener un historial básico de las cargas en el navegador para referencia rápida.

### Description

- Agrega los métodos `seleccionarArchivo()` y `subirPdf()` en `AdminPanelComponent` para manejar selección, validación de `.pdf`, y una carga simulada con `setTimeout`.
- Guarda metadatos de las últimas cargas en `localStorage` bajo la clave `adminPanelPdfHistory` y los carga en `ngOnInit` para mostrar un historial local (`uploadHistory`).
- Conecta la UI al componente actualizando el input con `(change)="seleccionarArchivo($event)"` y el botón con `(click)="subirPdf()"`, y añade markup para mostrar el historial en `admin-panel.component.html`.
- Añade estilos para el bloque de historial en `admin-panel.component.scss` y mantiene la retroalimentación visual mediante la propiedad `uploadStatus` y `feedbackMessage`.

### Testing

- Intenté preparar dependencias ejecutando `npm install` en `web/frontend`, pero la instalación falló con un error 403 al descargar `sweetalert2` desde el registro, por lo que no se pudo levantar el frontend.
- No se ejecutó la suite de pruebas automatizadas (`npm test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9f1b3f508320ae6bc5c054e5befb)