### PR TITLE
Add AdminUploadService (mock PDF upload)

### DIFF
--- a/web/frontend/src/app/services/admin-upload.service.ts
+++ b/web/frontend/src/app/services/admin-upload.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+export interface RespuestaCargaPdf {
+  ok: boolean;
+  mensaje: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AdminUploadService {
+  private readonly endpointCarga = '/api/admin/pdf';
+
+  async subirPdf(file: File, token: string): Promise<RespuestaCargaPdf> {
+    const formData = new FormData();
+    formData.append('archivo', file, file.name);
+    formData.append('token', token);
+
+    // TODO: Reemplazar por el endpoint real cuando esté disponible.
+    // return firstValueFrom(
+    //   this.http.post<RespuestaCargaPdf>(this.endpointCarga, formData, {
+    //     headers: { Authorization: `Bearer ${token}` }
+    //   })
+    // );
+
+    return {
+      ok: true,
+      mensaje: `Carga simulada: el PDF fue adjuntado al FormData en modo mock (${this.endpointCarga}).`
+    };
+  }
+}


### PR DESCRIPTION
### Motivation
- Añadir un servicio en el frontend para soportar la carga de PDFs desde la sección administrativa. 
- Preparar la estructura de `FormData` y la firma del método de subida para integrar autenticación por `token`. 
- Dejar la llamada HTTP en modo mock hasta contar con el endpoint real del backend. 

### Description
- Se creó el archivo `web/frontend/src/app/services/admin-upload.service.ts` con la interfaz `RespuestaCargaPdf` y la clase `AdminUploadService` registrada como `@Injectable`.
- Se añadió el método `subirPdf(file: File, token: string)` que construye un `FormData` y agrega `archivo` y `token` al payload. 
- Se incluyó una plantilla comentada para la llamada HTTP real (ej. `firstValueFrom(this.http.post(...))` con header `Authorization: Bearer`).
- El método devuelve actualmente una respuesta simulada con un mensaje que incluye el `endpointCarga` para facilitar la migración a la implementación real. 

### Testing
- No se ejecutaron pruebas automatizadas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da160908483208d01f14ec061a0fe)