### PR TITLE
Add stable localStorage keys for saved Excel files

### DIFF
--- a/web/frontend/src/app/services/archivo-storage.service.spec.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.spec.ts
@@ -39,6 +39,11 @@ describe('ArchivoStorageService', () => {
     const registros = service.obtenerRegistros('demo@correo.mx');
     expect(registros.length).toBe(2);
     expect(registros.map((registro) => registro.cct)).toEqual(['DEF9876543', 'ABC1234567']);
+    registros.forEach((registro) => {
+      expect(registro.claveEstable).toBe(
+        `${registro.cct}|${registro.correo}|${registro.nombre}|${registro.fechaGuardado}`
+      );
+    });
   });
 
   it('should replace duplicates when forcing replacement for the same email and CCT', async () => {

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -7,6 +7,7 @@ export interface RegistroArchivo {
   ruta: string;
   contenidoBase64: string;
   hash: string;
+  claveEstable: string;
   cct?: string;
   correo?: string;
 }
@@ -50,13 +51,21 @@ export class ArchivoStorageService {
       localStorage.setItem(this.storageKey, JSON.stringify(registrosPorCorreo));
     }
 
+    const fechaGuardado = new Date().toISOString();
+    const claveEstable = this.construirClaveEstable({
+      cct: parametros?.cct,
+      correo: emailNormalizado,
+      nombre: archivo.name,
+      fechaGuardado
+    });
     const registro: RegistroArchivo = {
       nombre: archivo.name,
       tamano: archivo.size,
-      fechaGuardado: new Date().toISOString(),
+      fechaGuardado,
       ruta: rutaDestino,
       contenidoBase64: contenido,
       hash,
+      claveEstable,
       cct: parametros?.cct,
       correo: emailNormalizado || undefined
     };
@@ -153,6 +162,16 @@ export class ArchivoStorageService {
         registro.hash = await this.calcularHash(buffer);
         actualizado = true;
       }
+
+      if (!registro.claveEstable) {
+        registro.claveEstable = this.construirClaveEstable({
+          cct: registro.cct,
+          correo: registro.correo,
+          nombre: registro.nombre,
+          fechaGuardado: registro.fechaGuardado
+        });
+        actualizado = true;
+      }
     }
 
     return actualizado;
@@ -215,5 +234,16 @@ export class ArchivoStorageService {
 
   private normalizarCorreo(correo: string): string {
     return (correo ?? '').trim().toLowerCase();
+  }
+
+  private construirClaveEstable(params: {
+    cct?: string;
+    correo?: string;
+    nombre: string;
+    fechaGuardado: string;
+  }): string {
+    const cct = (params.cct ?? '').trim();
+    const correo = this.normalizarCorreo(params.correo ?? '');
+    return `${cct}|${correo}|${params.nombre}|${params.fechaGuardado}`;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a stable, human-readable identifier for each saved Excel so other screens can reference files reliably.
- Make the key include provenance data to distinguish files across CCTs, emails and save times.
- Ensure legacy records stored previously in `localStorage` receive the new key automatically.

### Description
- Add `claveEstable: string` to the `RegistroArchivo` shape and populate it when saving in `guardarArchivoPreescolar`.
- Introduce `construirClaveEstable` which returns `${cct}|${correo}|${nombre}|${fechaGuardado}` and use it when creating records.
- Backfill missing `claveEstable` values inside `agregarHashesFaltantes` for older records read from `localStorage`.
- Extend `web/frontend/src/app/services/archivo-storage.service.spec.ts` to assert the new `claveEstable` formatting.

### Testing
- Unit test file `web/frontend/src/app/services/archivo-storage.service.spec.ts` was updated to assert `claveEstable` but no automated tests were executed in this rollout.
- No CI or test runner output was produced during the change, so no pass/fail status to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da763349083208a31cb30de49c68b)