### PR TITLE
Agregar selector de Excel y guardar PDF en localStorage

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -15,6 +15,18 @@
     </ng-template>
 
     <div class="admin-panel__upload">
+      <label class="admin-panel__upload-label" for="excel-key">Selecciona el Excel asociado</label>
+      <select
+        id="excel-key"
+        class="admin-panel__upload-input"
+        [(ngModel)]="selectedExcelKey"
+      >
+        <option value="" disabled>Selecciona una opción</option>
+        <option *ngFor="let excel of excelOptions" [value]="excel.key">
+          {{ excel.label }}
+        </option>
+      </select>
+
       <label class="admin-panel__upload-label" for="pdf-upload">Selecciona un PDF</label>
       <input
         id="pdf-upload"

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -1,21 +1,28 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { AdminAuthService } from '../../services/admin-auth.service';
 
 @Component({
   selector: 'app-admin-panel',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './admin-panel.component.html',
   styleUrl: './admin-panel.component.scss',
 })
 export class AdminPanelComponent implements OnInit {
   selectedFile: File | null = null;
+  selectedExcelKey = '';
   uploadStatus: 'idle' | 'uploading' | 'success' | 'error' = 'idle';
   feedbackMessage = '';
   uploadHistory: Array<{ name: string; size: number; uploadedAt: string }> = [];
   private readonly uploadHistoryKey = 'adminPanelPdfHistory';
+  readonly excelOptions = [
+    { key: 'preescolar', label: 'Excel Preescolar' },
+    { key: 'primaria', label: 'Excel Primaria' },
+    { key: 'secundaria', label: 'Excel Secundaria' },
+  ];
 
   constructor(private readonly adminAuthService: AdminAuthService) {}
 
@@ -37,6 +44,12 @@ export class AdminPanelComponent implements OnInit {
   }
 
   subirPdf(): void {
+    if (!this.selectedExcelKey) {
+      this.uploadStatus = 'error';
+      this.feedbackMessage = 'Selecciona el Excel asociado antes de subir el PDF.';
+      return;
+    }
+
     if (!this.selectedFile) {
       this.uploadStatus = 'error';
       this.feedbackMessage = 'No se ha seleccionado ningún archivo.';
@@ -56,19 +69,36 @@ export class AdminPanelComponent implements OnInit {
     this.uploadStatus = 'uploading';
     this.feedbackMessage = 'Cargando archivo...';
 
-    setTimeout(() => {
-      this.uploadStatus = 'success';
-      this.feedbackMessage = 'PDF cargado correctamente.';
+    const fileToUpload = this.selectedFile;
+    const excelKey = this.selectedExcelKey;
 
-      const metadata = {
-        name: this.selectedFile?.name ?? 'PDF',
-        size: this.selectedFile?.size ?? 0,
-        uploadedAt: new Date().toISOString(),
-      };
+    this.readPdfAsBase64(fileToUpload)
+      .then((pdfBase64) => {
+        const metadata = {
+          excelKey,
+          pdfName: fileToUpload.name,
+          pdfBase64,
+          fecha: new Date().toISOString(),
+        };
 
-      this.uploadHistory = [metadata, ...this.uploadHistory].slice(0, 5);
-      this.saveUploadHistory();
-    }, 1500);
+        localStorage.setItem(excelKey, JSON.stringify(metadata));
+
+        this.uploadStatus = 'success';
+        this.feedbackMessage = 'PDF cargado correctamente.';
+
+        const historyEntry = {
+          name: fileToUpload.name,
+          size: fileToUpload.size,
+          uploadedAt: metadata.fecha,
+        };
+
+        this.uploadHistory = [historyEntry, ...this.uploadHistory].slice(0, 5);
+        this.saveUploadHistory();
+      })
+      .catch(() => {
+        this.uploadStatus = 'error';
+        this.feedbackMessage = 'No se pudo leer el PDF. Intenta nuevamente.';
+      });
   }
 
   obtenerToken(): string | null {
@@ -99,5 +129,20 @@ export class AdminPanelComponent implements OnInit {
 
   private saveUploadHistory(): void {
     localStorage.setItem(this.uploadHistoryKey, JSON.stringify(this.uploadHistory));
+  }
+
+  private readPdfAsBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === 'string') {
+          resolve(reader.result);
+          return;
+        }
+        reject(new Error('Formato inválido'));
+      };
+      reader.onerror = () => reject(new Error('Error al leer archivo'));
+      reader.readAsDataURL(file);
+    });
   }
 }


### PR DESCRIPTION
### Motivation
- Permitir asociar manualmente un PDF a uno de los Excel manejados desde el panel de administrador antes de subirlo.
- Mantener un historial de subidas y almacenar el PDF (datos + blob en base64) para referencia local sin backend adicional.

### Description
- Se añadió un dropdown en `admin-panel.component.html` vinculado a `selectedExcelKey` y la lista `excelOptions` para elegir el Excel asociado.
- Se importó `FormsModule` en `AdminPanelComponent` y se validó que `selectedExcelKey` esté presente antes de iniciar la subida en `subirPdf()`.
- El PDF se lee como base64 con `readPdfAsBase64()` (usa `FileReader.readAsDataURL`) y se guarda en `localStorage` bajo la clave seleccionada con la estructura `{ excelKey, pdfName, pdfBase64, fecha }`.
- Se actualiza el `uploadHistory` (carga/guardado en `adminPanelPdfHistory`) para mostrar hasta 5 entradas recientes y se preservó la lógica de carga/guardado existente.

### Testing
- Intenté preparar dependencias con `npm install` en `web/frontend` pero la instalación falló con un `403 Forbidden` al descargar `sweetalert2` por lo que no fue posible ejecutar pruebas automatizadas.
- No se corrieron `npm test` ni `ng serve` debido al fallo de instalación, por lo que no hay resultados de tests automatizados disponibles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695daa17fda4832086c4b0a0ba9b5ace)