### PR TITLE
Agregar columna “Resultados” y descarga de PDF asociada

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
@@ -24,6 +24,7 @@
           <th>Fecha de guardado</th>
           <th>Ruta de referencia</th>
           <th>Acciones</th>
+          <th>Resultados</th>
         </tr>
       </thead>
       <tbody>
@@ -57,6 +58,18 @@
                 </svg>
               </button>
             </div>
+          </td>
+          <td data-label="Resultados">
+            <ng-container *ngIf="obtenerPdfPorRegistro(registro) as resultadoPdf; else pendienteResultado">
+              <button
+                type="button"
+                class="archivos__accion"
+                (click)="descargarResultados(registro)"
+              >
+                Descargar resultados
+              </button>
+            </ng-container>
+            <ng-template #pendienteResultado>Pendiente</ng-template>
           </td>
         </tr>
       </tbody>

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -20,6 +20,8 @@ export class ArchivosGuardadosComponent implements OnInit {
   mensajeInfo: string | null = null;
   mensajeError: string | null = null;
   correoActivo: string | null = null;
+  private readonly pdfKeys = ['preescolar', 'primaria', 'secundaria'];
+  private resultadosPdf: Record<string, PdfMetadata> = {};
 
   constructor(
     private readonly archivoStorageService: ArchivoStorageService,
@@ -34,6 +36,7 @@ export class ArchivosGuardadosComponent implements OnInit {
     }
 
     this.correoActivo = this.authService.obtenerCredenciales()?.correo ?? null;
+    this.cargarResultadosPdf();
     this.cargarRegistros();
   }
 
@@ -93,4 +96,68 @@ export class ArchivosGuardadosComponent implements OnInit {
       });
     }
   }
+
+  descargarResultados(registro: RegistroArchivo): void {
+    const pdf = this.obtenerPdfPorRegistro(registro);
+    if (!pdf) {
+      return;
+    }
+
+    const enlace = document.createElement('a');
+    enlace.href = pdf.pdfBase64;
+    enlace.download = pdf.pdfName ?? 'resultados.pdf';
+    enlace.style.display = 'none';
+
+    document.body.appendChild(enlace);
+    enlace.click();
+    document.body.removeChild(enlace);
+  }
+
+  obtenerPdfPorRegistro(registro: RegistroArchivo): PdfMetadata | null {
+    const claveExcel = this.obtenerClaveExcel(registro);
+    if (!claveExcel) {
+      return null;
+    }
+    return this.resultadosPdf[claveExcel] ?? null;
+  }
+
+  private cargarResultadosPdf(): void {
+    this.resultadosPdf = {};
+    this.pdfKeys.forEach((clave) => {
+      const data = localStorage.getItem(clave);
+      if (!data) {
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(data) as PdfMetadata;
+        if (parsed?.pdfBase64) {
+          this.resultadosPdf[clave] = parsed;
+        }
+      } catch (error) {
+        return;
+      }
+    });
+  }
+
+  private obtenerClaveExcel(registro: RegistroArchivo): string | null {
+    const ruta = (registro.ruta ?? '').toLowerCase();
+    if (ruta.includes('/preescolar/')) {
+      return 'preescolar';
+    }
+    if (ruta.includes('/primaria/')) {
+      return 'primaria';
+    }
+    if (ruta.includes('/secundaria/')) {
+      return 'secundaria';
+    }
+    return null;
+  }
+}
+
+interface PdfMetadata {
+  excelKey: string;
+  pdfName: string;
+  pdfBase64: string;
+  fecha: string;
 }


### PR DESCRIPTION
### Motivation
- Mostrar en la tabla de archivos guardados si existen resultados en PDF asociados al Excel y ofrecer su descarga desde la vista de `archivos-guardados`.
- Buscar el PDF asociado por la clave del Excel (p. ej. `preescolar`, `primaria`, `secundaria`) almacenada en `localStorage` y habilitar la acción sólo cuando exista.

### Description
- Agregada la columna `Resultados` en `web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html` con botón `Descargar resultados` o el estado `Pendiente`.
- Implementada la carga de metadatos de PDF desde `localStorage` por claves `preescolar|primaria|secundaria` y mapeo en `resultadosPdf` dentro de `archivos-guardados.component.ts`.
- Añadidos métodos `cargarResultadosPdf()`, `obtenerClaveExcel()`, `obtenerPdfPorRegistro()` y `descargarResultados()` y la interfaz `PdfMetadata` para manejar la descarga basada en `pdfBase64`.

### Testing
- Intenté levantar el servidor de desarrollo con `npm start -- --host 0.0.0.0 --port 4200`, el build falló con errores TypeScript `TS2307: Cannot find module 'sweetalert2'` por dependencias de varios componentes.
- Debido al fallo de build no se pudieron ejecutar verificaciones automáticas ni confirmar visualmente la UI (no se corrieron tests unitarios en este cambio).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dab6a0f9c8320a5e856e9d070ea4b)