### PR TITLE
Descarga de PDF de resultados desde localStorage

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
@@ -64,7 +64,7 @@
               <button
                 type="button"
                 class="archivos__accion"
-                (click)="descargarResultados(registro)"
+                (click)="descargarResultados(resultadoPdf.excelKey)"
               >
                 Descargar resultados
               </button>

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -97,20 +97,45 @@ export class ArchivosGuardadosComponent implements OnInit {
     }
   }
 
-  descargarResultados(registro: RegistroArchivo): void {
-    const pdf = this.obtenerPdfPorRegistro(registro);
-    if (!pdf) {
+  descargarResultados(excelKey: string): void {
+    const data = localStorage.getItem(excelKey);
+    if (!data) {
       return;
     }
 
-    const enlace = document.createElement('a');
-    enlace.href = pdf.pdfBase64;
-    enlace.download = pdf.pdfName ?? 'resultados.pdf';
-    enlace.style.display = 'none';
+    try {
+      const parsed = JSON.parse(data) as PdfMetadata;
+      if (!parsed?.pdfBase64) {
+        return;
+      }
 
-    document.body.appendChild(enlace);
-    enlace.click();
-    document.body.removeChild(enlace);
+      const [header, base64Data] = parsed.pdfBase64.split(',');
+      if (!base64Data) {
+        return;
+      }
+
+      const mimeMatch = header?.match(/data:(.*?);base64/);
+      const mimeType = mimeMatch?.[1] ?? 'application/pdf';
+      const byteString = atob(base64Data);
+      const bytes = new Uint8Array(byteString.length);
+      for (let i = 0; i < byteString.length; i += 1) {
+        bytes[i] = byteString.charCodeAt(i);
+      }
+
+      const blob = new Blob([bytes], { type: mimeType });
+      const url = URL.createObjectURL(blob);
+      const enlace = document.createElement('a');
+      enlace.href = url;
+      enlace.download = parsed.pdfName ?? 'resultados.pdf';
+      enlace.style.display = 'none';
+
+      document.body.appendChild(enlace);
+      enlace.click();
+      document.body.removeChild(enlace);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      return;
+    }
   }
 
   obtenerPdfPorRegistro(registro: RegistroArchivo): PdfMetadata | null {


### PR DESCRIPTION
### Motivation
- Permitir descargar el PDF de resultados almacenado en `localStorage` con nombre y tipo correctos en lugar de usar el enlace base64 directo.
- Asegurar que el botón de descarga solo esté visible cuando haya metadatos de PDF asociados al registro.

### Description
- Reemplaza `descargarResultados(registro: RegistroArchivo)` por `descargarResultados(excelKey: string)` que lee la entrada de `localStorage` y parsea `PdfMetadata` desde la clave seleccionada.
- Convierte la cadena data URL base64 a un `Blob` y genera un `ObjectURL` para forzar la descarga con el nombre adecuado (`pdfName`) y tipo MIME detectado.
- Actualiza la plantilla para pasar `resultadoPdf.excelKey` desde el `*ngIf="obtenerPdfPorRegistro(registro) as resultadoPdf"` al invocar `descargarResultados`, manteniendo la visibilidad condicional del botón.
- Archivos modificados: `web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts` y `web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html`.

### Testing
- No se ejecutaron pruebas automatizadas en este cambio.
- Se realizó verificación estática de que la plantilla usa `obtenerPdfPorRegistro` para condicionar la aparición del botón y que el método nuevo maneja errores de parseo y formatos inválidos.
- No se reportaron fallos en la edición y compilación local no solicitada.
- Para validar manualmente, subir un PDF desde el panel de admin y luego usar la tabla de `Archivos guardados` para descargarlo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dadf871288320b200df2db98836fc)