### PR TITLE
Admin panel: list Excel submissions, confirm PDF replacement and mark assigned status

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -21,11 +21,14 @@
         class="admin-panel__upload-input"
         [(ngModel)]="selectedExcelKey"
       >
-        <option value="" disabled>Selecciona una opción</option>
-        <option *ngFor="let excel of excelOptions" [value]="excel.key">
-          {{ excel.label }}
+        <option value="" disabled>Selecciona un Excel</option>
+        <option *ngFor="let excel of excelDisponibles" [value]="excel.key">
+          {{ excel.nombre }} · {{ excel.cct }} · {{ excel.correo }}
         </option>
       </select>
+      <p class="admin-panel__helper" *ngIf="!excelDisponibles.length">
+        Aún no hay Excels disponibles para asociar. Valida un archivo desde el módulo de carga.
+      </p>
 
       <label class="admin-panel__upload-label" for="pdf-upload">Selecciona un PDF</label>
       <input
@@ -50,6 +53,31 @@
         <span class="admin-panel__status-message">
           {{ feedbackMessage || 'Sin acciones por el momento.' }}
         </span>
+      </div>
+
+      <div class="admin-panel__excel-list" *ngIf="excelDisponibles.length">
+        <span class="admin-panel__history-title">Excels disponibles</span>
+        <div class="admin-panel__table">
+          <div class="admin-panel__table-row admin-panel__table-row--header">
+            <span>Nombre</span>
+            <span>CCT</span>
+            <span>Correo</span>
+            <span>Estatus</span>
+          </div>
+          <div class="admin-panel__table-row" *ngFor="let excel of excelDisponibles">
+            <span>{{ excel.nombre }}</span>
+            <span>{{ excel.cct }}</span>
+            <span>{{ excel.correo }}</span>
+            <span>
+              <span
+                class="admin-panel__badge"
+                [class.admin-panel__badge--assigned]="excel.estatus === 'asignado'"
+              >
+                {{ excel.estatus === 'asignado' ? 'Asignado' : 'Pendiente' }}
+              </span>
+            </span>
+          </div>
+        </div>
       </div>
 
       <div class="admin-panel__history" *ngIf="uploadHistory.length">

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -46,6 +46,12 @@
   gap: 0.75rem;
 }
 
+.admin-panel__helper {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
 .admin-panel__upload-label {
   font-weight: 600;
   color: #0f172a;
@@ -109,6 +115,63 @@
 
 .admin-panel__status-message {
   font-size: 0.95rem;
+}
+
+.admin-panel__excel-list {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-panel__table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.admin-panel__table-row {
+  display: grid;
+  grid-template-columns: 1.4fr 0.7fr 1.4fr 0.7fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid #e2e8f0;
+  color: #0f172a;
+}
+
+.admin-panel__table-row--header {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: #475569;
+  border-bottom: 1px solid #cbd5f5;
+}
+
+.admin-panel__table-row:last-child {
+  border-bottom: none;
+}
+
+.admin-panel__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #475569;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.admin-panel__badge--assigned {
+  background: #dcfce7;
+  color: #166534;
 }
 
 .admin-panel__history {

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -3,6 +3,8 @@ import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { AdminAuthService } from '../../services/admin-auth.service';
+import { ArchivoStorageService, RegistroArchivo } from '../../services/archivo-storage.service';
+import Swal from 'sweetalert2';
 
 @Component({
   selector: 'app-admin-panel',
@@ -17,17 +19,18 @@ export class AdminPanelComponent implements OnInit {
   uploadStatus: 'idle' | 'uploading' | 'success' | 'error' = 'idle';
   feedbackMessage = '';
   uploadHistory: Array<{ name: string; size: number; uploadedAt: string }> = [];
+  excelDisponibles: ExcelDisponible[] = [];
   private readonly uploadHistoryKey = 'adminPanelPdfHistory';
-  readonly excelOptions = [
-    { key: 'preescolar', label: 'Excel Preescolar' },
-    { key: 'primaria', label: 'Excel Primaria' },
-    { key: 'secundaria', label: 'Excel Secundaria' },
-  ];
+  private readonly pdfStoragePrefix = 'pdf-resultados';
 
-  constructor(private readonly adminAuthService: AdminAuthService) {}
+  constructor(
+    private readonly adminAuthService: AdminAuthService,
+    private readonly archivoStorageService: ArchivoStorageService
+  ) {}
 
   ngOnInit(): void {
     this.uploadHistory = this.loadUploadHistory();
+    this.cargarExcelDisponibles();
   }
 
   seleccionarArchivo(event: Event): void {
@@ -43,7 +46,7 @@ export class AdminPanelComponent implements OnInit {
     this.feedbackMessage = `Archivo seleccionado: ${this.selectedFile.name}`;
   }
 
-  subirPdf(): void {
+  async subirPdf(): Promise<void> {
     if (!this.selectedExcelKey) {
       this.uploadStatus = 'error';
       this.feedbackMessage = 'Selecciona el Excel asociado antes de subir el PDF.';
@@ -71,6 +74,26 @@ export class AdminPanelComponent implements OnInit {
 
     const fileToUpload = this.selectedFile;
     const excelKey = this.selectedExcelKey;
+    const excelSeleccionado = this.excelDisponibles.find((excel) => excel.key === excelKey);
+
+    if (this.existePdfParaExcel(excelKey)) {
+      const confirmacion = await Swal.fire({
+        title: '¿Reemplazar PDF existente?',
+        text: `Ya hay un PDF asignado a ${excelSeleccionado?.nombre ?? 'este Excel'} (${
+          excelSeleccionado?.cct ?? 'CCT no registrada'
+        }, ${excelSeleccionado?.correo ?? 'correo no registrado'}).`,
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Sí, reemplazar',
+        cancelButtonText: 'Cancelar'
+      });
+
+      if (!confirmacion.isConfirmed) {
+        this.uploadStatus = 'idle';
+        this.feedbackMessage = 'Carga cancelada. Se mantuvo el PDF anterior.';
+        return;
+      }
+    }
 
     this.readPdfAsBase64(fileToUpload)
       .then((pdfBase64) => {
@@ -81,7 +104,7 @@ export class AdminPanelComponent implements OnInit {
           fecha: new Date().toISOString(),
         };
 
-        localStorage.setItem(excelKey, JSON.stringify(metadata));
+        localStorage.setItem(this.obtenerPdfStorageKey(excelKey), JSON.stringify(metadata));
 
         this.uploadStatus = 'success';
         this.feedbackMessage = 'PDF cargado correctamente.';
@@ -94,6 +117,7 @@ export class AdminPanelComponent implements OnInit {
 
         this.uploadHistory = [historyEntry, ...this.uploadHistory].slice(0, 5);
         this.saveUploadHistory();
+        this.actualizarEstadoExcel(excelKey);
       })
       .catch(() => {
         this.uploadStatus = 'error';
@@ -131,6 +155,47 @@ export class AdminPanelComponent implements OnInit {
     localStorage.setItem(this.uploadHistoryKey, JSON.stringify(this.uploadHistory));
   }
 
+  private cargarExcelDisponibles(): void {
+    const registros = this.archivoStorageService.obtenerTodosRegistros();
+    this.excelDisponibles = registros.map((registro) => {
+      const key = this.obtenerClaveExcel(registro);
+      return {
+        key,
+        nombre: registro.nombre,
+        cct: registro.cct ?? '—',
+        correo: registro.correo ?? '—',
+        estatus: this.existePdfParaExcel(key) ? 'asignado' : 'pendiente'
+      };
+    });
+  }
+
+  private actualizarEstadoExcel(excelKey: string): void {
+    this.excelDisponibles = this.excelDisponibles.map((excel) => {
+      if (excel.key !== excelKey) {
+        return excel;
+      }
+      return { ...excel, estatus: 'asignado' };
+    });
+  }
+
+  private existePdfParaExcel(excelKey: string): boolean {
+    return !!localStorage.getItem(this.obtenerPdfStorageKey(excelKey));
+  }
+
+  private obtenerPdfStorageKey(excelKey: string): string {
+    return `${this.pdfStoragePrefix}:${excelKey}`;
+  }
+
+  private obtenerClaveExcel(registro: RegistroArchivo): string {
+    if (registro.claveEstable) {
+      return registro.claveEstable;
+    }
+
+    const cct = (registro.cct ?? '').trim();
+    const correo = (registro.correo ?? '').trim().toLowerCase();
+    return `${cct}|${correo}|${registro.nombre}|${registro.fechaGuardado}`;
+  }
+
   private readPdfAsBase64(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
@@ -145,4 +210,12 @@ export class AdminPanelComponent implements OnInit {
       reader.readAsDataURL(file);
     });
   }
+}
+
+interface ExcelDisponible {
+  key: string;
+  nombre: string;
+  cct: string;
+  correo: string;
+  estatus: 'asignado' | 'pendiente';
 }

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
@@ -64,7 +64,7 @@
               <button
                 type="button"
                 class="archivos__accion"
-                (click)="descargarResultados(resultadoPdf.excelKey)"
+                (click)="descargarResultados(resultadoPdf.storageKey)"
               >
                 Descargar resultados
               </button>

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -20,8 +20,8 @@ export class ArchivosGuardadosComponent implements OnInit {
   mensajeInfo: string | null = null;
   mensajeError: string | null = null;
   correoActivo: string | null = null;
-  private readonly pdfKeys = ['preescolar', 'primaria', 'secundaria'];
-  private resultadosPdf: Record<string, PdfMetadata> = {};
+  private readonly pdfStoragePrefix = 'pdf-resultados';
+  private resultadosPdf: Record<string, PdfMetadataConStorage> = {};
 
   constructor(
     private readonly archivoStorageService: ArchivoStorageService,
@@ -36,13 +36,13 @@ export class ArchivosGuardadosComponent implements OnInit {
     }
 
     this.correoActivo = this.authService.obtenerCredenciales()?.correo ?? null;
-    this.cargarResultadosPdf();
     this.cargarRegistros();
   }
 
   cargarRegistros(): void {
     this.mensajeError = null;
     this.registros = this.archivoStorageService.obtenerRegistros(this.correoActivo);
+    this.cargarResultadosPdf();
 
     if (this.registros.length === 0) {
       this.mensajeInfo = 'Aún no has cargado archivos de Preescolar en este navegador.';
@@ -97,8 +97,8 @@ export class ArchivosGuardadosComponent implements OnInit {
     }
   }
 
-  descargarResultados(excelKey: string): void {
-    const data = localStorage.getItem(excelKey);
+  descargarResultados(storageKey: string): void {
+    const data = localStorage.getItem(storageKey);
     if (!data) {
       return;
     }
@@ -138,18 +138,16 @@ export class ArchivosGuardadosComponent implements OnInit {
     }
   }
 
-  obtenerPdfPorRegistro(registro: RegistroArchivo): PdfMetadata | null {
-    const claveExcel = this.obtenerClaveExcel(registro);
-    if (!claveExcel) {
-      return null;
-    }
-    return this.resultadosPdf[claveExcel] ?? null;
+  obtenerPdfPorRegistro(registro: RegistroArchivo): PdfMetadataConStorage | null {
+    const storageKey = this.obtenerPdfStorageKey(registro);
+    return this.resultadosPdf[storageKey] ?? null;
   }
 
   private cargarResultadosPdf(): void {
     this.resultadosPdf = {};
-    this.pdfKeys.forEach((clave) => {
-      const data = localStorage.getItem(clave);
+    this.registros.forEach((registro) => {
+      const storageKey = this.obtenerPdfStorageKey(registro);
+      const data = localStorage.getItem(storageKey);
       if (!data) {
         return;
       }
@@ -157,7 +155,7 @@ export class ArchivosGuardadosComponent implements OnInit {
       try {
         const parsed = JSON.parse(data) as PdfMetadata;
         if (parsed?.pdfBase64) {
-          this.resultadosPdf[clave] = parsed;
+          this.resultadosPdf[storageKey] = { ...parsed, storageKey };
         }
       } catch (error) {
         return;
@@ -165,18 +163,13 @@ export class ArchivosGuardadosComponent implements OnInit {
     });
   }
 
-  private obtenerClaveExcel(registro: RegistroArchivo): string | null {
-    const ruta = (registro.ruta ?? '').toLowerCase();
-    if (ruta.includes('/preescolar/')) {
-      return 'preescolar';
-    }
-    if (ruta.includes('/primaria/')) {
-      return 'primaria';
-    }
-    if (ruta.includes('/secundaria/')) {
-      return 'secundaria';
-    }
-    return null;
+  private obtenerPdfStorageKey(registro: RegistroArchivo): string {
+    const claveEstable =
+      registro.claveEstable ??
+      `${(registro.cct ?? '').trim()}|${(registro.correo ?? '').trim().toLowerCase()}|${
+        registro.nombre
+      }|${registro.fechaGuardado}`;
+    return `${this.pdfStoragePrefix}:${claveEstable}`;
   }
 }
 
@@ -185,4 +178,8 @@ interface PdfMetadata {
   pdfName: string;
   pdfBase64: string;
   fecha: string;
+}
+
+interface PdfMetadataConStorage extends PdfMetadata {
+  storageKey: string;
 }

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -119,6 +119,13 @@ export class ArchivoStorageService {
     return registros[correoNormalizado] ?? [];
   }
 
+  obtenerTodosRegistros(): RegistroArchivo[] {
+    const registrosPorCorreo = this.obtenerMapaRegistros();
+    const registros = Object.values(registrosPorCorreo).flat();
+
+    return registros.sort((a, b) => b.fechaGuardado.localeCompare(a.fechaGuardado));
+  }
+
   descargarRegistro(registro: RegistroArchivo): void {
     const blob = this.base64ABlob(registro.contenidoBase64);
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
### Motivation
- Provide admins a way to see which Excel submissions exist (name, CCT, correo) so they can associate PDFs correctly.
- Prevent accidental overwrites by asking for confirmation when a PDF is already assigned to an Excel.
- Surface an “asignado”/“pendiente” status in the admin UI so assignment state is visible at a glance.

### Description
- Added `obtenerTodosRegistros()` to `ArchivoStorageService` to expose all saved Excel submissions and sorted them by `fechaGuardado` for the admin view.
- Updated `AdminPanelComponent` to load available Excels from storage, show `nombre · CCT · correo` in the select and a table, compute per-Excel keys, and store PDF metadata under keys prefixed with `pdf-resultados:` in `localStorage`.
- When uploading a PDF the admin panel now checks for an existing PDF for the selected Excel and uses `SweetAlert2` to confirm replacement before saving the new metadata and updating the status to `asignado`.
- Updated `ArchivosGuardadosComponent` to resolve and download PDF results using the same storage key scheme so the user-facing list links to the associated PDF if present.

### Testing
- Attempted to run the dev server with `npm --prefix web/frontend run start -- --host 0.0.0.0 --port 4200`, but the build failed due to missing `sweetalert2` module/type declarations in this environment, so the UI could not be fully verified.
- Playwright-driven screenshot attempts were not executed because the local dev server was not reachable.  
- No automated unit tests were executed as part of this rollout due to the build error preventing the dev server and test runner from running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dafcc448c83208ceaaa70c71cc217)