### PR TITLE
Add pagination controls to admin panel Excel list

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -35,26 +35,57 @@
 
       <div class="admin-panel__excel-list" *ngIf="excelDisponibles.length">
         <span class="admin-panel__history-title">Excels disponibles</span>
-        <div class="admin-panel__table">
-          <div class="admin-panel__table-row admin-panel__table-row--header">
-            <span>Nombre</span>
-            <span>CCT</span>
-            <span>Correo</span>
-            <span>Estatus</span>
-          </div>
-          <div class="admin-panel__table-row" *ngFor="let excel of excelDisponibles">
-            <span>{{ excel.nombre }}</span>
-            <span>{{ excel.cct }}</span>
-            <span>{{ excel.correo }}</span>
-            <span>
-              <span
-                class="admin-panel__badge"
-                [class.admin-panel__badge--assigned]="excel.estatus === 'asignado'"
-              >
-                {{ excel.estatus === 'asignado' ? 'Asignado' : 'Pendiente' }}
-              </span>
-            </span>
-          </div>
+        <table class="admin-panel__table">
+          <thead>
+            <tr>
+              <th scope="col">Nombre</th>
+              <th scope="col">CCT</th>
+              <th scope="col">Correo</th>
+              <th scope="col">Estatus</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let excel of excelDisponiblesPaginados">
+              <td>{{ excel.nombre }}</td>
+              <td>{{ excel.cct }}</td>
+              <td>{{ excel.correo }}</td>
+              <td>
+                <span
+                  class="admin-panel__badge"
+                  [class.admin-panel__badge--assigned]="excel.estatus === 'asignado'"
+                >
+                  {{ excel.estatus === 'asignado' ? 'Asignado' : 'Pendiente' }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="admin-panel__pagination" *ngIf="totalPaginas > 1">
+          <button
+            class="admin-panel__pagination-button"
+            type="button"
+            [disabled]="paginaActualDerivada === 1"
+            (click)="irAPagina(paginaActualDerivada - 1)"
+          >
+            Anterior
+          </button>
+          <button
+            class="admin-panel__pagination-button"
+            type="button"
+            *ngFor="let pagina of paginasDisponibles"
+            [class.admin-panel__pagination-button--active]="pagina === paginaActualDerivada"
+            (click)="irAPagina(pagina)"
+          >
+            {{ pagina }}
+          </button>
+          <button
+            class="admin-panel__pagination-button"
+            type="button"
+            [disabled]="paginaActualDerivada === totalPaginas"
+            (click)="irAPagina(paginaActualDerivada + 1)"
+          >
+            Siguiente
+          </button>
         </div>
       </div>
 

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -128,23 +128,20 @@
 }
 
 .admin-panel__table {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+  width: 100%;
+  border-collapse: collapse;
   font-size: 0.9rem;
 }
 
-.admin-panel__table-row {
-  display: grid;
-  grid-template-columns: 1.4fr 0.7fr 1.4fr 0.7fr;
-  gap: 0.75rem;
-  align-items: center;
-  padding: 0.4rem 0;
+.admin-panel__table th,
+.admin-panel__table td {
+  text-align: left;
+  padding: 0.5rem 0.25rem;
   border-bottom: 1px solid #e2e8f0;
   color: #0f172a;
 }
 
-.admin-panel__table-row--header {
+.admin-panel__table th {
   font-weight: 700;
   text-transform: uppercase;
   font-size: 0.75rem;
@@ -153,7 +150,7 @@
   border-bottom: 1px solid #cbd5f5;
 }
 
-.admin-panel__table-row:last-child {
+.admin-panel__table tbody tr:last-child td {
   border-bottom: none;
 }
 
@@ -172,6 +169,36 @@
 .admin-panel__badge--assigned {
   background: #dcfce7;
   color: #166534;
+}
+
+.admin-panel__pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  padding-top: 0.5rem;
+}
+
+.admin-panel__pagination-button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  color: #1e293b;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.admin-panel__pagination-button--active {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+  color: #ffffff;
+}
+
+.admin-panel__pagination-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .admin-panel__history {

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -20,6 +20,8 @@ export class AdminPanelComponent implements OnInit {
   feedbackMessage = '';
   uploadHistory: Array<{ name: string; size: number; uploadedAt: string }> = [];
   excelDisponibles: ExcelDisponible[] = [];
+  paginaActual = 1;
+  tamanioPagina = 10;
   private readonly uploadHistoryKey = 'adminPanelPdfHistory';
   private readonly pdfStoragePrefix = 'pdf-resultados';
 
@@ -133,6 +135,32 @@ export class AdminPanelComponent implements OnInit {
     this.adminAuthService.cerrarSesion();
   }
 
+  get excelDisponiblesFiltrados(): ExcelDisponible[] {
+    return this.excelDisponibles;
+  }
+
+  get totalPaginas(): number {
+    return this.obtenerTotalPaginas(this.excelDisponiblesFiltrados);
+  }
+
+  get paginaActualDerivada(): number {
+    return this.obtenerPaginaActualDesdeListado(this.excelDisponiblesFiltrados);
+  }
+
+  get excelDisponiblesPaginados(): ExcelDisponible[] {
+    const paginaActual = this.paginaActualDerivada;
+    const inicio = (paginaActual - 1) * this.tamanioPagina;
+    return this.excelDisponiblesFiltrados.slice(inicio, inicio + this.tamanioPagina);
+  }
+
+  get paginasDisponibles(): number[] {
+    return Array.from({ length: this.totalPaginas }, (_, index) => index + 1);
+  }
+
+  irAPagina(pagina: number): void {
+    this.paginaActual = Math.min(Math.max(pagina, 1), this.totalPaginas);
+  }
+
   private loadUploadHistory(): Array<{ name: string; size: number; uploadedAt: string }> {
     const storedHistory = localStorage.getItem(this.uploadHistoryKey);
     if (!storedHistory) {
@@ -167,6 +195,8 @@ export class AdminPanelComponent implements OnInit {
         estatus: this.existePdfParaExcel(key) ? 'asignado' : 'pendiente'
       };
     });
+
+    this.paginaActual = this.obtenerPaginaActualDesdeListado(this.excelDisponiblesFiltrados);
   }
 
   private actualizarEstadoExcel(excelKey: string): void {
@@ -176,6 +206,21 @@ export class AdminPanelComponent implements OnInit {
       }
       return { ...excel, estatus: 'asignado' };
     });
+  }
+
+  private obtenerTotalPaginas(listado: ExcelDisponible[]): number {
+    return Math.max(1, Math.ceil(listado.length / this.tamanioPagina));
+  }
+
+  private obtenerPaginaActualDesdeListado(listado: ExcelDisponible[]): number {
+    const totalPaginas = this.obtenerTotalPaginas(listado);
+    if (this.paginaActual > totalPaginas) {
+      return totalPaginas;
+    }
+    if (this.paginaActual < 1) {
+      return 1;
+    }
+    return this.paginaActual;
   }
 
   private existePdfParaExcel(excelKey: string): boolean {


### PR DESCRIPTION
### Motivation
- Introduce pagination to the admin panel to avoid rendering a long flat list of Excel entries and improve usability.
- Replace the informal list markup with a semantic table to better present columns (`Nombre`, `CCT`, `Correo`, `Estatus`).
- Provide navigation controls (previous/next and page numbers) so admins can move through pages of results.
- Add basic pagination styles so active/disabled states are visually clear.

### Description
- Added pagination state `paginaActual` and `tamanioPagina = 10` and derived helpers/getters `excelDisponiblesPaginados`, `paginasDisponibles`, `paginaActualDerivada`, and `totalPaginas` in `admin-panel.component.ts`.
- Implemented `irAPagina`, `obtenerTotalPaginas` and `obtenerPaginaActualDesdeListado`, and update `cargarExcelDisponibles` to adjust `paginaActual` after loading data in `admin-panel.component.ts`.
- Replaced the previous inline list with a semantic `<table>` and wired pagination controls (previous/next and numbered buttons) to the component in `admin-panel.component.html`.
- Converted the list layout to table styles and added pagination button styles plus active/disabled states in `admin-panel.component.scss`.

### Testing
- Attempted an automated Playwright screenshot of the running app at `http://localhost:4200`, but it failed with `net::ERR_EMPTY_RESPONSE` because the dev server was not available.
- No unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea5e3d53c83208af8fb327a71846b)