### PR TITLE
Add filters to admin panel Excel list

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -35,6 +35,39 @@
 
       <div class="admin-panel__excel-list" *ngIf="excelDisponibles.length">
         <span class="admin-panel__history-title">Excels disponibles</span>
+        <div class="admin-panel__filters">
+          <label class="admin-panel__filters-field">
+            <span class="admin-panel__filters-label">Buscar</span>
+            <input
+              class="admin-panel__filters-input"
+              type="text"
+              placeholder="Nombre, CCT o correo"
+              [(ngModel)]="filtroTexto"
+              (ngModelChange)="onFiltrosActualizados()"
+            />
+          </label>
+          <label class="admin-panel__filters-field">
+            <span class="admin-panel__filters-label">Estatus</span>
+            <select
+              class="admin-panel__filters-input"
+              [(ngModel)]="filtroEstatus"
+              (ngModelChange)="onFiltrosActualizados()"
+            >
+              <option value="todos">Todos</option>
+              <option value="asignado">Asignado</option>
+              <option value="pendiente">Pendiente</option>
+            </select>
+          </label>
+          <label class="admin-panel__filters-field">
+            <span class="admin-panel__filters-label">Fecha</span>
+            <input
+              class="admin-panel__filters-input"
+              type="date"
+              [(ngModel)]="filtroFecha"
+              (ngModelChange)="onFiltrosActualizados()"
+            />
+          </label>
+        </div>
         <table class="admin-panel__table">
           <thead>
             <tr>

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -127,6 +127,33 @@
   gap: 0.5rem;
 }
 
+.admin-panel__filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+}
+
+.admin-panel__filters-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.admin-panel__filters-label {
+  font-weight: 600;
+}
+
+.admin-panel__filters-input {
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  color: #0f172a;
+}
+
 .admin-panel__table {
   width: 100%;
   border-collapse: collapse;

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -20,6 +20,9 @@ export class AdminPanelComponent implements OnInit {
   feedbackMessage = '';
   uploadHistory: Array<{ name: string; size: number; uploadedAt: string }> = [];
   excelDisponibles: ExcelDisponible[] = [];
+  filtroTexto = '';
+  filtroEstatus: 'todos' | 'asignado' | 'pendiente' = 'todos';
+  filtroFecha = '';
   paginaActual = 1;
   tamanioPagina = 10;
   private readonly uploadHistoryKey = 'adminPanelPdfHistory';
@@ -136,7 +139,7 @@ export class AdminPanelComponent implements OnInit {
   }
 
   get excelDisponiblesFiltrados(): ExcelDisponible[] {
-    return this.excelDisponibles;
+    return this.aplicarFiltros(this.excelDisponibles);
   }
 
   get totalPaginas(): number {
@@ -159,6 +162,10 @@ export class AdminPanelComponent implements OnInit {
 
   irAPagina(pagina: number): void {
     this.paginaActual = Math.min(Math.max(pagina, 1), this.totalPaginas);
+  }
+
+  onFiltrosActualizados(): void {
+    this.paginaActual = 1;
   }
 
   private loadUploadHistory(): Array<{ name: string; size: number; uploadedAt: string }> {
@@ -192,7 +199,8 @@ export class AdminPanelComponent implements OnInit {
         nombre: registro.nombre,
         cct: registro.cct ?? '—',
         correo: registro.correo ?? '—',
-        estatus: this.existePdfParaExcel(key) ? 'asignado' : 'pendiente'
+        estatus: this.existePdfParaExcel(key) ? 'asignado' : 'pendiente',
+        fechaGuardado: registro.fechaGuardado
       };
     });
 
@@ -206,6 +214,32 @@ export class AdminPanelComponent implements OnInit {
       }
       return { ...excel, estatus: 'asignado' };
     });
+  }
+
+  private aplicarFiltros(listado: ExcelDisponible[]): ExcelDisponible[] {
+    const texto = this.filtroTexto.trim().toLowerCase();
+    const estatus = this.filtroEstatus;
+    const fecha = this.filtroFecha;
+
+    return listado.filter((excel) => {
+      const coincideTexto =
+        !texto ||
+        excel.nombre.toLowerCase().includes(texto) ||
+        excel.cct.toLowerCase().includes(texto) ||
+        excel.correo.toLowerCase().includes(texto);
+      const coincideEstatus = estatus === 'todos' || excel.estatus === estatus;
+      const coincideFecha = !fecha || this.obtenerFechaISO(excel.fechaGuardado) === fecha;
+
+      return coincideTexto && coincideEstatus && coincideFecha;
+    });
+  }
+
+  private obtenerFechaISO(fecha: string): string {
+    const fechaParsed = new Date(fecha);
+    if (Number.isNaN(fechaParsed.getTime())) {
+      return '';
+    }
+    return fechaParsed.toISOString().slice(0, 10);
   }
 
   private obtenerTotalPaginas(listado: ExcelDisponible[]): number {
@@ -263,4 +297,5 @@ interface ExcelDisponible {
   cct: string;
   correo: string;
   estatus: 'asignado' | 'pendiente';
+  fechaGuardado: string;
 }


### PR DESCRIPTION
### Motivation
- Provide filtering controls for the Excel list so admins can find entries by name, CCT, email, status or date. 
- Ensure pagination reflects the filtered dataset rather than the full list. 
- Reset pagination when filters change to avoid showing empty pages after filtering. 

### Description
- Added filter state properties `filtroTexto`, `filtroEstatus` and `filtroFecha` to `AdminPanelComponent` and included `fechaGuardado` in the `ExcelDisponible` model. 
- Implemented `aplicarFiltros` and `obtenerFechaISO` and updated the `excelDisponiblesFiltrados` / `excelDisponiblesPaginados` getters to paginate the filtered list. 
- Added `onFiltrosActualizados()` to reset `paginaActual` when filters change. 
- Added filter UI (text input, status select, date input) to `admin-panel.component.html` and styles in `admin-panel.component.scss`. 

### Testing
- Attempted to install frontend dependencies with `npm --prefix web/frontend install`, but it failed due to a `403 Forbidden` fetching `sweetalert2`, so build/test steps were not completed. 
- No automated unit tests or `ng build` were run after the change due to the dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea8485ff0832085db803e8dde96f2)