### PR TITLE
Widen admin panel layout; add nivel/fecha/estatus and nivel filter

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -19,7 +19,7 @@
       <select
         id="nivel-select"
         class="admin-panel__upload-input"
-        [(ngModel)]="selectedExcelKey"
+        [(ngModel)]="selectedNivel"
       >
         <option value="" disabled>Selecciona un nivel</option>
         <option value="preescolar">Preescolar</option>

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -1,11 +1,11 @@
 .admin-panel {
-  display: flex;
-  justify-content: center;
-  padding: 3rem 1.5rem;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
 }
 
 .admin-panel__card {
-  width: min(720px, 100%);
+  width: 100%;
   background: #ffffff;
   border-radius: 16px;
   padding: 2.5rem;

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -15,7 +15,7 @@ import Swal from 'sweetalert2';
 })
 export class AdminPanelComponent implements OnInit {
   selectedFile: File | null = null;
-  selectedExcelKey = '';
+  selectedNivel = '';
   uploadStatus: 'idle' | 'uploading' | 'success' | 'error' = 'idle';
   feedbackMessage = '';
   uploadHistory: Array<{ name: string; size: number; uploadedAt: string }> = [];
@@ -52,9 +52,9 @@ export class AdminPanelComponent implements OnInit {
   }
 
   async subirPdf(): Promise<void> {
-    if (!this.selectedExcelKey) {
+    if (!this.selectedNivel) {
       this.uploadStatus = 'error';
-      this.feedbackMessage = 'Selecciona el Excel asociado antes de subir el PDF.';
+      this.feedbackMessage = 'Selecciona el nivel asociado antes de subir el PDF.';
       return;
     }
 
@@ -78,7 +78,7 @@ export class AdminPanelComponent implements OnInit {
     this.feedbackMessage = 'Cargando archivo...';
 
     const fileToUpload = this.selectedFile;
-    const excelKey = this.selectedExcelKey;
+    const excelKey = this.selectedNivel;
     const excelSeleccionado = this.excelDisponibles.find((excel) => excel.key === excelKey);
 
     if (this.existePdfParaExcel(excelKey)) {
@@ -194,13 +194,17 @@ export class AdminPanelComponent implements OnInit {
     const registros = this.archivoStorageService.obtenerTodosRegistros();
     this.excelDisponibles = registros.map((registro) => {
       const key = this.obtenerClaveExcel(registro);
+      const nivel = this.obtenerNivelRegistro(registro);
+      const fecha = registro.fechaGuardado || new Date().toISOString();
+      const estatus = registro.estatus ?? (this.existePdfParaExcel(key) ? 'asignado' : 'pendiente');
       return {
         key,
         nombre: registro.nombre,
         cct: registro.cct ?? '—',
         correo: registro.correo ?? '—',
-        estatus: this.existePdfParaExcel(key) ? 'asignado' : 'pendiente',
-        fechaGuardado: registro.fechaGuardado
+        estatus,
+        fecha,
+        nivel
       };
     });
 
@@ -220,6 +224,7 @@ export class AdminPanelComponent implements OnInit {
     const texto = this.filtroTexto.trim().toLowerCase();
     const estatus = this.filtroEstatus;
     const fecha = this.filtroFecha;
+    const nivel = this.selectedNivel;
 
     return listado.filter((excel) => {
       const coincideTexto =
@@ -228,9 +233,10 @@ export class AdminPanelComponent implements OnInit {
         excel.cct.toLowerCase().includes(texto) ||
         excel.correo.toLowerCase().includes(texto);
       const coincideEstatus = estatus === 'todos' || excel.estatus === estatus;
-      const coincideFecha = !fecha || this.obtenerFechaISO(excel.fechaGuardado) === fecha;
+      const coincideFecha = !fecha || this.obtenerFechaISO(excel.fecha) === fecha;
+      const coincideNivel = !nivel || excel.nivel === nivel;
 
-      return coincideTexto && coincideEstatus && coincideFecha;
+      return coincideTexto && coincideEstatus && coincideFecha && coincideNivel;
     });
   }
 
@@ -275,6 +281,25 @@ export class AdminPanelComponent implements OnInit {
     return `${cct}|${correo}|${registro.nombre}|${registro.fechaGuardado}`;
   }
 
+  private obtenerNivelRegistro(registro: RegistroArchivo): string {
+    if (registro.nivel) {
+      return registro.nivel;
+    }
+
+    const ruta = registro.ruta?.toLowerCase() ?? '';
+    if (ruta.includes('/primaria/')) {
+      return 'primaria';
+    }
+    if (ruta.includes('/secundaria/')) {
+      return 'secundaria';
+    }
+    if (ruta.includes('/preescolar/')) {
+      return 'preescolar';
+    }
+
+    return 'preescolar';
+  }
+
   private readPdfAsBase64(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
@@ -297,5 +322,6 @@ interface ExcelDisponible {
   cct: string;
   correo: string;
   estatus: 'asignado' | 'pendiente';
-  fechaGuardado: string;
+  fecha: string;
+  nivel: string;
 }

--- a/web/frontend/src/app/services/admin-upload.service.ts
+++ b/web/frontend/src/app/services/admin-upload.service.ts
@@ -5,6 +5,16 @@ export interface RespuestaCargaPdf {
   mensaje: string;
 }
 
+export interface ExcelDisponibleDto {
+  key: string;
+  nombre: string;
+  cct: string;
+  correo: string;
+  nivel: string;
+  fecha: string;
+  estatus: 'asignado' | 'pendiente';
+}
+
 @Injectable({ providedIn: 'root' })
 export class AdminUploadService {
   private readonly endpointCarga = '/api/admin/pdf';

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -10,6 +10,8 @@ export interface RegistroArchivo {
   claveEstable: string;
   cct?: string;
   correo?: string;
+  nivel?: string;
+  estatus?: 'asignado' | 'pendiente';
 }
 
 export interface ResultadoGuardado {
@@ -67,7 +69,8 @@ export class ArchivoStorageService {
       hash,
       claveEstable,
       cct: parametros?.cct,
-      correo: emailNormalizado || undefined
+      correo: emailNormalizado || undefined,
+      nivel: 'preescolar'
     };
 
     const duplicado = registros.find(


### PR DESCRIPTION
### Motivation
- Reduce wasted side margins by making the admin panel container match the `carga-masiva` layout width and padding. 
- Surface `nivel`, `fecha` and `estatus` for stored Excel records so PDFs can be associated by level. 
- Keep storage and UI contracts consistent by adding optional `nivel`/`estatus` to stored records and mapping sensible defaults on the client. 
- Prepare client-side shape for a future backend response via a DTO for available Excel entries.

### Description
- Updated layout in `admin-panel.component.scss` to use `max-width: 1120px`, centered margins and `padding: 3rem 2rem`, and made `.admin-panel__card` occupy full width. 
- Changed the admin panel to use `selectedNivel` instead of `selectedExcelKey`, added level-aware filtering in `aplicarFiltros`, and included `nivel`, `fecha` and `estatus` on `ExcelDisponible` entries in `admin-panel.component.ts` along with `obtenerNivelRegistro`. 
- Added `ExcelDisponibleDto` to `admin-upload.service.ts` and extended `RegistroArchivo` with optional `nivel` and `estatus` in `archivo-storage.service.ts`, plus set `nivel: 'preescolar'` by default when saving preescolar files. 
- Adjusted the template `admin-panel.component.html` to bind the level selector to `selectedNivel` and updated messaging accordingly.

### Testing
- Attempted to run the dev server with `npm --prefix web/frontend start -- --host 0.0.0.0 --port 4200`, but the build failed due to missing `sweetalert2` type/module errors. (failed)
- Attempted an automated Playwright screenshot of `/admin/panel`, but it could not complete because the dev server was not available after the build failure. (failed)
- No unit tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb2ea5ddc8320b856606cec25357f)