### PR TITLE
Increase admin panel font sizes and add nivel filtering/metadata

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -19,7 +19,7 @@
       <select
         id="nivel-select"
         class="admin-panel__upload-input"
-        [(ngModel)]="selectedExcelKey"
+        [(ngModel)]="selectedNivel"
       >
         <option value="" disabled>Selecciona un nivel</option>
         <option value="preescolar">Preescolar</option>

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -1,11 +1,11 @@
 .admin-panel {
-  display: flex;
-  justify-content: center;
-  padding: 3rem 1.5rem;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
 }
 
 .admin-panel__card {
-  width: min(720px, 100%);
+  width: 100%;
   background: #ffffff;
   border-radius: 16px;
   padding: 2.5rem;
@@ -44,17 +44,19 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  font-size: 1rem;
 }
 
 .admin-panel__helper {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   color: #64748b;
 }
 
 .admin-panel__upload-label {
   font-weight: 600;
   color: #0f172a;
+  font-size: 1rem;
 }
 
 .admin-panel__upload-input {
@@ -63,6 +65,7 @@
   border: 1px solid #cbd5f5;
   background: #ffffff;
   color: #0f172a;
+  font-size: 1rem;
 }
 
 .admin-panel__upload-button {
@@ -138,7 +141,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  font-size: 0.85rem;
+  font-size: 0.95rem;
   color: #475569;
 }
 
@@ -152,12 +155,13 @@
   border: 1px solid #cbd5f5;
   background: #ffffff;
   color: #0f172a;
+  font-size: 1rem;
 }
 
 .admin-panel__table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.9rem;
+  font-size: 1rem;
 }
 
 .admin-panel__table th,
@@ -171,7 +175,7 @@
 .admin-panel__table th {
   font-weight: 700;
   text-transform: uppercase;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   letter-spacing: 0.05em;
   color: #475569;
   border-bottom: 1px solid #cbd5f5;
@@ -190,7 +194,7 @@
   background: #e2e8f0;
   color: #475569;
   font-weight: 600;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
 }
 
 .admin-panel__badge--assigned {

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -15,7 +15,7 @@ import Swal from 'sweetalert2';
 })
 export class AdminPanelComponent implements OnInit {
   selectedFile: File | null = null;
-  selectedExcelKey = '';
+  selectedNivel = '';
   uploadStatus: 'idle' | 'uploading' | 'success' | 'error' = 'idle';
   feedbackMessage = '';
   uploadHistory: Array<{ name: string; size: number; uploadedAt: string }> = [];
@@ -52,9 +52,9 @@ export class AdminPanelComponent implements OnInit {
   }
 
   async subirPdf(): Promise<void> {
-    if (!this.selectedExcelKey) {
+    if (!this.selectedNivel) {
       this.uploadStatus = 'error';
-      this.feedbackMessage = 'Selecciona el Excel asociado antes de subir el PDF.';
+      this.feedbackMessage = 'Selecciona el nivel asociado antes de subir el PDF.';
       return;
     }
 
@@ -78,7 +78,7 @@ export class AdminPanelComponent implements OnInit {
     this.feedbackMessage = 'Cargando archivo...';
 
     const fileToUpload = this.selectedFile;
-    const excelKey = this.selectedExcelKey;
+    const excelKey = this.selectedNivel;
     const excelSeleccionado = this.excelDisponibles.find((excel) => excel.key === excelKey);
 
     if (this.existePdfParaExcel(excelKey)) {
@@ -194,13 +194,17 @@ export class AdminPanelComponent implements OnInit {
     const registros = this.archivoStorageService.obtenerTodosRegistros();
     this.excelDisponibles = registros.map((registro) => {
       const key = this.obtenerClaveExcel(registro);
+      const nivel = this.obtenerNivelRegistro(registro);
+      const fecha = registro.fechaGuardado || new Date().toISOString();
+      const estatus = registro.estatus ?? (this.existePdfParaExcel(key) ? 'asignado' : 'pendiente');
       return {
         key,
         nombre: registro.nombre,
         cct: registro.cct ?? '—',
         correo: registro.correo ?? '—',
-        estatus: this.existePdfParaExcel(key) ? 'asignado' : 'pendiente',
-        fechaGuardado: registro.fechaGuardado
+        estatus,
+        fecha,
+        nivel
       };
     });
 
@@ -220,6 +224,7 @@ export class AdminPanelComponent implements OnInit {
     const texto = this.filtroTexto.trim().toLowerCase();
     const estatus = this.filtroEstatus;
     const fecha = this.filtroFecha;
+    const nivel = this.selectedNivel;
 
     return listado.filter((excel) => {
       const coincideTexto =
@@ -228,9 +233,10 @@ export class AdminPanelComponent implements OnInit {
         excel.cct.toLowerCase().includes(texto) ||
         excel.correo.toLowerCase().includes(texto);
       const coincideEstatus = estatus === 'todos' || excel.estatus === estatus;
-      const coincideFecha = !fecha || this.obtenerFechaISO(excel.fechaGuardado) === fecha;
+      const coincideFecha = !fecha || this.obtenerFechaISO(excel.fecha) === fecha;
+      const coincideNivel = !nivel || excel.nivel === nivel;
 
-      return coincideTexto && coincideEstatus && coincideFecha;
+      return coincideTexto && coincideEstatus && coincideFecha && coincideNivel;
     });
   }
 
@@ -275,6 +281,25 @@ export class AdminPanelComponent implements OnInit {
     return `${cct}|${correo}|${registro.nombre}|${registro.fechaGuardado}`;
   }
 
+  private obtenerNivelRegistro(registro: RegistroArchivo): string {
+    if (registro.nivel) {
+      return registro.nivel;
+    }
+
+    const ruta = registro.ruta?.toLowerCase() ?? '';
+    if (ruta.includes('/primaria/')) {
+      return 'primaria';
+    }
+    if (ruta.includes('/secundaria/')) {
+      return 'secundaria';
+    }
+    if (ruta.includes('/preescolar/')) {
+      return 'preescolar';
+    }
+
+    return 'preescolar';
+  }
+
   private readPdfAsBase64(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
@@ -297,5 +322,6 @@ interface ExcelDisponible {
   cct: string;
   correo: string;
   estatus: 'asignado' | 'pendiente';
-  fechaGuardado: string;
+  fecha: string;
+  nivel: string;
 }

--- a/web/frontend/src/app/services/admin-upload.service.ts
+++ b/web/frontend/src/app/services/admin-upload.service.ts
@@ -5,6 +5,16 @@ export interface RespuestaCargaPdf {
   mensaje: string;
 }
 
+export interface ExcelDisponibleDto {
+  key: string;
+  nombre: string;
+  cct: string;
+  correo: string;
+  nivel: string;
+  fecha: string;
+  estatus: 'asignado' | 'pendiente';
+}
+
 @Injectable({ providedIn: 'root' })
 export class AdminUploadService {
   private readonly endpointCarga = '/api/admin/pdf';

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -10,6 +10,8 @@ export interface RegistroArchivo {
   claveEstable: string;
   cct?: string;
   correo?: string;
+  nivel?: string;
+  estatus?: 'asignado' | 'pendiente';
 }
 
 export interface ResultadoGuardado {
@@ -67,7 +69,8 @@ export class ArchivoStorageService {
       hash,
       claveEstable,
       cct: parametros?.cct,
-      correo: emailNormalizado || undefined
+      correo: emailNormalizado || undefined,
+      nivel: 'preescolar'
     };
 
     const duplicado = registros.find(


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad de la sección del panel de administrador aumentando tamaños de fuente y controles.
- Permitir asociar y filtrar PDFs por nivel educativo añadiendo metadatos (`nivel`, `fecha`, `estatus`) a los listados de Excel disponibles.
- Mantener consistencia entre almacenamiento y UI añadiendo campos opcionales en los registros y mapeando valores por defecto en el cliente.
- Preparar la forma de datos del cliente para una futura respuesta backend mediante un DTO para entradas de Excel.

### Description
- Ajusté el layout del panel (`admin-panel.component.scss`) a `max-width: 1120px` y aumenté tamaños de fuente de inputs, etiquetas, tabla y badges para mejorar la legibilidad. 
- Reemplacé `selectedExcelKey` por `selectedNivel` y añadí filtrado por nivel en `aplicarFiltros`, junto con `obtenerNivelRegistro` y mapeo de `nivel`, `fecha` y `estatus` en `cargarExcelDisponibles` dentro de `admin-panel.component.ts`.
- Añadí la interfaz `ExcelDisponibleDto` en `admin-upload.service.ts` para preparar la forma de respuesta backend esperada.
- Extendí `RegistroArchivo` en `archivo-storage.service.ts` con campos opcionales `nivel` y `estatus` y establecí `nivel: 'preescolar'` por defecto al guardar archivos preescolares.

### Testing
- Ejecuté `npm --prefix web/frontend start -- --host 0.0.0.0 --port 4200`, pero la compilación falló por falta del módulo/decl. de tipos `sweetalert2` (fallido).
- Intenté una captura automatizada de `/admin/panel` con Playwright, pero no se completó porque el servidor dev no quedó disponible tras el fallo de build (fallido).
- No se ejecutaron pruebas unitarias automáticas en esta ronda.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb2ea5ddc8320b856606cec25357f)