### PR TITLE
Require excel selection before uploading PDFs in admin panel

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -27,7 +27,8 @@
         <option value="secundaria">Secundaria</option>
       </select>
       <p class="admin-panel__helper">
-        El listado de Excels depende del nivel seleccionado.
+        El listado de Excels depende del nivel seleccionado. Primero selecciona un registro y luego
+        sube el PDF correspondiente.
       </p>
       <p class="admin-panel__helper" *ngIf="!excelDisponibles.length">
         Aún no hay Excels disponibles para asociar. Valida un archivo desde el módulo de carga.
@@ -71,6 +72,7 @@
         <table class="admin-panel__table">
           <thead>
             <tr>
+              <th scope="col">Seleccionar</th>
               <th scope="col">Nombre</th>
               <th scope="col">CCT</th>
               <th scope="col">Correo</th>
@@ -79,6 +81,17 @@
           </thead>
           <tbody>
             <tr *ngFor="let excel of excelDisponiblesPaginados">
+              <td>
+                <label class="admin-panel__select">
+                  <input
+                    type="radio"
+                    name="excelSeleccionado"
+                    [checked]="excelSeleccionado?.key === excel.key"
+                    (change)="seleccionarExcel(excel)"
+                  />
+                  <span>Seleccionar</span>
+                </label>
+              </td>
               <td>{{ excel.nombre }}</td>
               <td>{{ excel.cct }}</td>
               <td>{{ excel.correo }}</td>
@@ -123,6 +136,9 @@
       </div>
 
       <label class="admin-panel__upload-label" for="pdf-upload">Selecciona un PDF</label>
+      <p class="admin-panel__helper" *ngIf="!excelSeleccionado">
+        Selecciona un registro de Excel para habilitar la carga del PDF.
+      </p>
       <input
         id="pdf-upload"
         class="admin-panel__upload-input"
@@ -130,7 +146,12 @@
         accept="application/pdf"
         (change)="seleccionarArchivo($event)"
       />
-      <button class="admin-panel__upload-button" type="button" (click)="subirPdf()">
+      <button
+        class="admin-panel__upload-button"
+        type="button"
+        (click)="subirPdf()"
+        [disabled]="!excelSeleccionado"
+      >
         Subir PDF
       </button>
 

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -20,6 +20,7 @@ export class AdminPanelComponent implements OnInit {
   feedbackMessage = '';
   uploadHistory: Array<{ name: string; size: number; uploadedAt: string }> = [];
   excelDisponibles: ExcelDisponible[] = [];
+  excelSeleccionado: ExcelDisponible | null = null;
   filtroTexto = '';
   filtroEstatus: 'todos' | 'asignado' | 'pendiente' = 'todos';
   filtroFecha = '';
@@ -52,9 +53,9 @@ export class AdminPanelComponent implements OnInit {
   }
 
   async subirPdf(): Promise<void> {
-    if (!this.selectedNivel) {
+    if (!this.excelSeleccionado) {
       this.uploadStatus = 'error';
-      this.feedbackMessage = 'Selecciona el nivel asociado antes de subir el PDF.';
+      this.feedbackMessage = 'Selecciona un registro de Excel antes de subir el PDF.';
       return;
     }
 
@@ -78,8 +79,8 @@ export class AdminPanelComponent implements OnInit {
     this.feedbackMessage = 'Cargando archivo...';
 
     const fileToUpload = this.selectedFile;
-    const excelKey = this.selectedNivel;
-    const excelSeleccionado = this.excelDisponibles.find((excel) => excel.key === excelKey);
+    const excelKey = this.excelSeleccionado.key;
+    const excelSeleccionado = this.excelSeleccionado;
 
     if (this.existePdfParaExcel(excelKey)) {
       const confirmacion = await Swal.fire({
@@ -166,6 +167,12 @@ export class AdminPanelComponent implements OnInit {
 
   onFiltrosActualizados(): void {
     this.paginaActual = 1;
+  }
+
+  seleccionarExcel(excel: ExcelDisponible): void {
+    this.excelSeleccionado = excel;
+    this.uploadStatus = 'idle';
+    this.feedbackMessage = `Registro seleccionado: ${excel.nombre}.`;
   }
 
   private loadUploadHistory(): Array<{ name: string; size: number; uploadedAt: string }> {


### PR DESCRIPTION
### Motivation
- Prevent uploading a PDF without associating it to an existing Excel record so uploads are linked correctly.
- Make the UI guidance clearer about the intended flow: select a record first, then upload the PDF.

### Description
- Add a per-row selection control in the Excel table and update helper text in `admin-panel.component.html`.
- Introduce `excelSeleccionado: ExcelDisponible | null` and a `seleccionarExcel` handler in `admin-panel.component.ts` to store the chosen record.
- Require the selected Excel in `subirPdf()` and use its `key` when storing the PDF metadata, and disable the `Subir PDF` button when none is selected.

### Testing
- Ran `npm --prefix web/frontend install`, which failed with a `403 Forbidden` while fetching `sweetalert2`, so the app was not built or started.
- No unit or integration tests were executed due to the dependency install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed11f0fcc83208108fb0f561c3463)