### PR TITLE
Mostrar estado del PDF en resultados guardados

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
@@ -61,13 +61,18 @@
           </td>
           <td data-label="Resultados">
             <ng-container *ngIf="obtenerPdfPorRegistro(registro) as resultadoPdf; else pendienteResultado">
-              <button
-                type="button"
-                class="archivos__accion"
-                (click)="descargarResultados(resultadoPdf.storageKey)"
-              >
-                Descargar resultados
-              </button>
+              <div class="archivos__resultado">
+                <span class="archivos__resultado-nombre">
+                  {{ obtenerEtiquetaPdf(resultadoPdf) }}
+                </span>
+                <button
+                  type="button"
+                  class="archivos__accion"
+                  (click)="descargarResultados(resultadoPdf.storageKey)"
+                >
+                  Descargar resultados
+                </button>
+              </div>
             </ng-container>
             <ng-template #pendienteResultado>Pendiente</ng-template>
           </td>

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
@@ -143,6 +143,18 @@
   height: 1.15rem;
 }
 
+.archivos__resultado {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.archivos__resultado-nombre {
+  font-weight: 600;
+  color: #1e293b;
+  font-size: 0.9rem;
+}
+
 .archivos__vacio {
   text-align: center;
   padding: 2rem 1rem;

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -143,6 +143,11 @@ export class ArchivosGuardadosComponent implements OnInit {
     return this.resultadosPdf[storageKey] ?? null;
   }
 
+  obtenerEtiquetaPdf(resultado: PdfMetadataConStorage): string {
+    const nombre = resultado.pdfName?.trim();
+    return nombre ? nombre : 'PDF asignado';
+  }
+
   private cargarResultadosPdf(): void {
     this.resultadosPdf = {};
     this.registros.forEach((registro) => {


### PR DESCRIPTION
### Motivation
- Mostrar en la tabla de `Archivos guardados` si existe un PDF de resultados vinculado a cada registro y su nombre cuando esté disponible.
- Permitir descargar el PDF asociado directamente desde la columna `Resultados` sin modificar el flujo de carga/reescritura existente.
- Indicar claramente cuando un registro tiene un PDF sin nombre con la etiqueta `PDF asignado` para mejorar la experiencia de usuario.
- Mantener la clave de almacenamiento (`pdf-resultados:<clave>`) y la lógica de lectura desde `localStorage` ya existentes.

### Description
- Agregado el helper `obtenerEtiquetaPdf` en `web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts` para devolver el nombre del PDF o `PDF asignado` si está vacío.
- Actualizada la plantilla `archivos-guardados.component.html` para mostrar la etiqueta del PDF junto al botón `Descargar resultados` cuando exista metadata en `localStorage`.
- Añadidos estilos en `archivos-guardados.component.scss` para presentar el bloque de resultado (`.archivos__resultado` y `.archivos__resultado-nombre`).
- El componente sigue usando la carga existente de metadata (`cargarResultadosPdf`) y la función de descarga `descargarResultados` que leen las claves con prefijo `pdf-resultados` en `localStorage`.

### Testing
- No se ejecutaron pruebas automatizadas en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed255b6d08320826562cb7c950b15)