### PR TITLE
Apply design palette to admin panel and archivos page; remove redundant radio label

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -88,8 +88,8 @@
                     name="excelSeleccionado"
                     [checked]="excelSeleccionado?.key === excel.key"
                     (change)="seleccionarExcel(excel)"
+                    aria-label="Seleccionar registro"
                   />
-                  <span>Seleccionar</span>
                 </label>
               </td>
               <td>{{ excel.nombre }}</td>

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -2,6 +2,7 @@
   max-width: 1120px;
   margin: 0 auto;
   padding: 3rem 2rem;
+  color: #13322e;
 }
 
 .admin-panel__card {
@@ -9,7 +10,7 @@
   background: #ffffff;
   border-radius: 16px;
   padding: 2.5rem;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 20px 40px rgba(97, 18, 50, 0.12);
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -18,8 +19,8 @@
 .admin-panel__token {
   padding: 1rem;
   border-radius: 12px;
-  background: #f1f5f9;
-  color: #0f172a;
+  background: #f6eddc;
+  color: #13322e;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -27,20 +28,20 @@
 }
 
 .admin-panel__token--warning {
-  background: #fef3c7;
-  color: #92400e;
+  background: #ddc9a3;
+  color: #611232;
 }
 
 .admin-panel__link {
-  color: #1d4ed8;
+  color: #9d2449;
   text-decoration: none;
 }
 
 .admin-panel__upload {
   padding: 1.5rem;
   border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
+  border: 1px solid #ddc9a3;
+  background: #f6eddc;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -50,21 +51,21 @@
 .admin-panel__helper {
   margin: 0;
   font-size: 1.5rem;
-  color: #64748b;
+  color: #13322e;
 }
 
 .admin-panel__upload-label {
   font-weight: 600;
-  color: #0f172a;
+  color: #13322e;
   font-size: 1.5rem;
 }
 
 .admin-panel__upload-input {
   padding: 0.65rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid #cbd5f5;
+  border: 1px solid #a57f2c;
   background: #ffffff;
-  color: #0f172a;
+  color: #13322e;
   font-size: 1.5rem;
 }
 
@@ -73,7 +74,7 @@
   padding: 0.75rem 1.75rem;
   border-radius: 999px;
   border: none;
-  background: #1d4ed8;
+  background: #9d2449;
   color: #ffffff;
   font-weight: 600;
   cursor: pointer;
@@ -82,31 +83,31 @@
 .admin-panel__status {
   padding: 0.75rem 1rem;
   border-radius: 12px;
-  background: #e2e8f0;
-  color: #0f172a;
+  background: #ddc9a3;
+  color: #13322e;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
 
 .admin-panel__status--idle {
-  background: #e2e8f0;
-  color: #475569;
+  background: #ddc9a3;
+  color: #611232;
 }
 
 .admin-panel__status--uploading {
-  background: #dbeafe;
-  color: #1e3a8a;
+  background: #f6eddc;
+  color: #611232;
 }
 
 .admin-panel__status--success {
-  background: #dcfce7;
-  color: #166534;
+  background: #f6eddc;
+  color: #13322e;
 }
 
 .admin-panel__status--error {
-  background: #fee2e2;
-  color: #991b1b;
+  background: #f6e8e8;
+  color: #611232;
 }
 
 .admin-panel__status-label {
@@ -124,7 +125,7 @@
   padding: 0.75rem 1rem;
   border-radius: 12px;
   background: #ffffff;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #ddc9a3;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -142,7 +143,7 @@
   flex-direction: column;
   gap: 0.35rem;
   font-size: 1.5rem;
-  color: #475569;
+  color: #13322e;
 }
 
 .admin-panel__filters-label {
@@ -152,9 +153,9 @@
 .admin-panel__filters-input {
   padding: 0.55rem 0.65rem;
   border-radius: 10px;
-  border: 1px solid #cbd5f5;
+  border: 1px solid #a57f2c;
   background: #ffffff;
-  color: #0f172a;
+  color: #13322e;
   font-size: 1.5rem;
 }
 
@@ -168,8 +169,8 @@
 .admin-panel__table td {
   text-align: left;
   padding: 0.5rem 0.25rem;
-  border-bottom: 1px solid #e2e8f0;
-  color: #0f172a;
+  border-bottom: 1px solid #ddc9a3;
+  color: #13322e;
 }
 
 .admin-panel__table th {
@@ -177,8 +178,8 @@
   text-transform: uppercase;
   font-size: 1.25rem;
   letter-spacing: 0.05em;
-  color: #475569;
-  border-bottom: 1px solid #cbd5f5;
+  color: #611232;
+  border-bottom: 1px solid #a57f2c;
 }
 
 .admin-panel__table tbody tr:last-child td {
@@ -191,15 +192,15 @@
   justify-content: center;
   padding: 0.2rem 0.6rem;
   border-radius: 999px;
-  background: #e2e8f0;
-  color: #475569;
+  background: #ddc9a3;
+  color: #611232;
   font-weight: 600;
   font-size: 1.25rem;
 }
 
 .admin-panel__badge--assigned {
-  background: #dcfce7;
-  color: #166534;
+  background: #f6eddc;
+  color: #13322e;
 }
 
 .admin-panel__pagination {
@@ -213,17 +214,17 @@
 .admin-panel__pagination-button {
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid #cbd5f5;
+  border: 1px solid #a57f2c;
   background: #ffffff;
-  color: #1e293b;
+  color: #13322e;
   font-size: 1.25rem;
   font-weight: 600;
   cursor: pointer;
 }
 
 .admin-panel__pagination-button--active {
-  background: #1d4ed8;
-  border-color: #1d4ed8;
+  background: #611232;
+  border-color: #611232;
   color: #ffffff;
 }
 
@@ -236,7 +237,7 @@
   padding: 0.75rem 1rem;
   border-radius: 12px;
   background: #ffffff;
-  border: 1px dashed #cbd5f5;
+  border: 1px dashed #a57f2c;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -247,7 +248,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #1e293b;
+  color: #611232;
 }
 
 .admin-panel__history-list {
@@ -263,7 +264,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
-  color: #334155;
+  color: #13322e;
 }
 
 .admin-panel__history-name {
@@ -272,7 +273,7 @@
 
 .admin-panel__history-meta {
   font-size: 1.25rem;
-  color: #64748b;
+  color: #98989a;
 }
 
 .admin-panel__logout {
@@ -280,7 +281,7 @@
   padding: 0.75rem 1.5rem;
   border-radius: 999px;
   border: none;
-  background: #ef4444;
+  background: #611232;
   color: #ffffff;
   font-weight: 600;
   cursor: pointer;

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
@@ -3,7 +3,8 @@
   margin: 0 auto;
   padding: 2rem 1.5rem 3rem;
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
-  color: #0f172a;
+  color: #13322e;
+  font-size: 1.05rem;
 }
 
 .archivos__encabezado {
@@ -13,22 +14,23 @@
 .archivos__eyebrow {
   text-transform: uppercase;
   font-weight: 700;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   letter-spacing: 0.08em;
-  color: #2563eb;
+  color: #611232;
   margin: 0 0 0.35rem;
 }
 
 .archivos__titulo {
   margin: 0.2rem 0;
-  font-size: 1.6rem;
+  font-size: 1.9rem;
   font-weight: 700;
 }
 
 .archivos__descripcion {
   margin: 0;
-  color: #475569;
+  color: #13322e;
   line-height: 1.5;
+  font-size: 1.05rem;
 }
 
 .archivos__mensajes {
@@ -43,23 +45,24 @@
   border-radius: 12px;
   font-weight: 600;
   line-height: 1.4;
+  font-size: 1rem;
 }
 
 .archivos__mensaje--info {
-  background: #eff6ff;
-  color: #1d4ed8;
-  border: 1px solid #bfdbfe;
+  background: #ddc9a3;
+  color: #611232;
+  border: 1px solid #a57f2c;
 }
 
 .archivos__mensaje--error {
-  background: #fef2f2;
-  color: #b91c1c;
-  border: 1px solid #fecdd3;
+  background: #f6e8e8;
+  color: #611232;
+  border: 1px solid #9d2449;
 }
 
 .archivos__tabla {
   background: #ffffff;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #ddc9a3;
   border-radius: 16px;
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
   overflow: hidden;
@@ -71,20 +74,20 @@
 }
 
 .archivos thead {
-  background: #f8fafc;
+  background: #f6eddc;
 }
 
 .archivos th,
 .archivos td {
   padding: 0.9rem 1rem;
   text-align: left;
-  font-size: 0.95rem;
+  font-size: 1.05rem;
 }
 
 .archivos th {
   font-weight: 700;
-  color: #1e293b;
-  border-bottom: 1px solid #e2e8f0;
+  color: #13322e;
+  border-bottom: 1px solid #ddc9a3;
 }
 
 .archivos tbody tr:nth-child(even) {
@@ -92,7 +95,7 @@
 }
 
 .archivos tbody tr:hover {
-  background: #f1f5f9;
+  background: #f6eddc;
 }
 
 .archivos__acciones {
@@ -104,8 +107,8 @@
 .archivos__accion {
   padding: 0.45rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid #2563eb;
-  background: #2563eb;
+  border: 1px solid #611232;
+  background: #9d2449;
   color: #fff;
   cursor: pointer;
   font-weight: 600;
@@ -113,8 +116,8 @@
 }
 
 .archivos__accion:hover {
-  background: #1d4ed8;
-  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
+  background: #611232;
+  box-shadow: 0 8px 20px rgba(97, 18, 50, 0.25);
   transform: translateY(-1px);
 }
 
@@ -123,9 +126,9 @@
 }
 
 .archivos__accion--peligro {
-  background: #fee2e2;
-  border-color: #fca5a5;
-  color: #b91c1c;
+  background: #f6e8e8;
+  border-color: #9d2449;
+  color: #611232;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -133,8 +136,8 @@
 }
 
 .archivos__accion--peligro:hover {
-  background: #fecdd3;
-  box-shadow: 0 8px 20px rgba(248, 113, 113, 0.25);
+  background: #f0d7d7;
+  box-shadow: 0 8px 20px rgba(97, 18, 50, 0.2);
   transform: translateY(-1px);
 }
 
@@ -151,21 +154,22 @@
 
 .archivos__resultado-nombre {
   font-weight: 600;
-  color: #1e293b;
-  font-size: 0.9rem;
+  color: #13322e;
+  font-size: 1rem;
 }
 
 .archivos__vacio {
   text-align: center;
   padding: 2rem 1rem;
-  background: #f8fafc;
-  border: 1px dashed #cbd5e1;
+  background: #f6eddc;
+  border: 1px dashed #a57f2c;
   border-radius: 16px;
-  color: #475569;
+  color: #13322e;
+  font-size: 1.05rem;
 }
 
 .archivos__link {
-  color: #2563eb;
+  color: #9d2449;
   font-weight: 700;
   text-decoration: none;
 }
@@ -195,7 +199,7 @@
 
   .archivos td {
     padding: 0.75rem 0.9rem;
-    border-bottom: 1px solid #e2e8f0;
+    border-bottom: 1px solid #ddc9a3;
     position: relative;
   }
 
@@ -204,10 +208,10 @@
     position: absolute;
     left: 0.9rem;
     top: 0.4rem;
-    font-size: 0.78rem;
+    font-size: 0.85rem;
     font-weight: 700;
     text-transform: uppercase;
-    color: #64748b;
+    color: #98989a;
   }
 
   .archivos tr:last-child td:last-child {


### PR DESCRIPTION
### Motivation
- Align the admin panel visuals with the project's provided color palette for a consistent UI.
- Reduce repeated text in the admin table by removing the visible "Seleccionar" label next to radio buttons while preserving accessibility.
- Bring the `archivos` page into the same visual language and improve readability by increasing base typography.

### Description
- Updated `web/frontend/src/app/components/admin-panel/admin-panel.component.scss` to swap blues/greys for the palette colors (`#611232`, `#9d2449`, `#13322e`, `#ddc9a3`, etc.), adjust borders, shadows, badges, pagination and status backgrounds.
- Modified `web/frontend/src/app/components/admin-panel/admin-panel.component.html` to remove the visible `Seleccionar` text and add `aria-label="Seleccionar registro"` to the radio input for accessibility.
- Adjusted `web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss` to use the same palette, increase typography sizes, and update action/button styles to match the new theme.

### Testing
- No automated tests (`ng test` / build) were run in this environment. 
- Changes were verified via static inspection and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ecfe949708320948087d1ac17f968)