### PR TITLE
Actualizar estilos de login, mostrar credenciales y limpiar estado del panel

### DIFF
--- a/web/frontend/src/app/components/admin-login/admin-login.component.html
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.html
@@ -2,6 +2,17 @@
   <div class="admin-login__card">
     <h1>Acceso administrador</h1>
     <p>Ingresa el correo y contraseña asignados para la carga de PDFs.</p>
+    <div class="admin-login__credenciales">
+      <span class="admin-login__credenciales-title">Credenciales de acceso</span>
+      <div class="admin-login__credenciales-item">
+        <span class="admin-login__credenciales-label">Correo:</span>
+        <span class="admin-login__credenciales-value">admin@sep.mx</span>
+      </div>
+      <div class="admin-login__credenciales-item">
+        <span class="admin-login__credenciales-label">Contraseña:</span>
+        <span class="admin-login__credenciales-value">admin123</span>
+      </div>
+    </div>
 
     <form (ngSubmit)="iniciarSesion()" #loginForm="ngForm" novalidate>
       <label for="correo-admin">Correo</label>

--- a/web/frontend/src/app/components/admin-login/admin-login.component.scss
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: center;
   padding: 3rem 1.5rem;
+  color: #13322e;
 }
 
 .admin-login__card {
@@ -9,35 +10,73 @@
   background: #ffffff;
   border-radius: 16px;
   padding: 2.5rem;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 20px 40px rgba(97, 18, 50, 0.12);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .admin-login__card h1 {
   margin: 0;
-  font-size: 1.6rem;
-  color: #1b2e4b;
+  font-size: 2rem;
+  color: #611232;
 }
 
 .admin-login__card p {
   margin: 0 0 1.5rem;
-  color: #4b5563;
+  color: #13322e;
+  font-size: 1.1rem;
+  line-height: 1.5;
+}
+
+.admin-login__credenciales {
+  background: #f8f8f8;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.admin-login__credenciales-title {
+  font-weight: 700;
+  color: #611232;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.85rem;
+}
+
+.admin-login__credenciales-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 1.05rem;
+}
+
+.admin-login__credenciales-label {
+  font-weight: 600;
+  color: #13322e;
+}
+
+.admin-login__credenciales-value {
+  font-weight: 700;
+  color: #9d2449;
 }
 
 .admin-login__card label {
   font-weight: 600;
   margin-top: 0.75rem;
-  color: #1f2937;
+  color: #13322e;
+  font-size: 1.1rem;
 }
 
 .admin-login__card input {
   margin-top: 0.35rem;
-  padding: 0.75rem 1rem;
+  padding: 0.85rem 1.1rem;
   border-radius: 10px;
-  border: 1px solid #d1d5db;
-  font-size: 1rem;
+  border: 1px solid #a57f2c;
+  font-size: 1.1rem;
   width: 100%;
 }
 
@@ -46,7 +85,7 @@
   padding: 0.75rem 1rem;
   border-radius: 10px;
   background: #ffe4e6;
-  color: #9f1239;
+  color: #611232;
 }
 
 .admin-login__submit {
@@ -54,9 +93,10 @@
   padding: 0.85rem 1.5rem;
   border: none;
   border-radius: 999px;
-  background: #1d4ed8;
+  background: #9d2449;
   color: #ffffff;
   font-weight: 600;
+  font-size: 1.1rem;
   cursor: pointer;
 }
 
@@ -68,6 +108,31 @@
 .admin-login__link {
   margin-top: 1rem;
   text-align: center;
-  color: #1d4ed8;
+  color: #611232;
+  font-weight: 600;
   text-decoration: none;
+}
+
+@media (max-width: 540px) {
+  .admin-login {
+    padding: 2rem 1rem;
+  }
+
+  .admin-login__card {
+    padding: 2rem 1.5rem;
+  }
+
+  .admin-login__card h1 {
+    font-size: 1.7rem;
+  }
+
+  .admin-login__card p {
+    font-size: 1rem;
+  }
+
+  .admin-login__card label,
+  .admin-login__card input,
+  .admin-login__submit {
+    font-size: 1rem;
+  }
 }

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -88,8 +88,8 @@
                     name="excelSeleccionado"
                     [checked]="excelSeleccionado?.key === excel.key"
                     (change)="seleccionarExcel(excel)"
+                    aria-label="Seleccionar registro"
                   />
-                  <span>Seleccionar</span>
                 </label>
               </td>
               <td>{{ excel.nombre }}</td>

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -2,6 +2,7 @@
   max-width: 1120px;
   margin: 0 auto;
   padding: 3rem 2rem;
+  color: #13322e;
 }
 
 .admin-panel__card {
@@ -9,7 +10,7 @@
   background: #ffffff;
   border-radius: 16px;
   padding: 2.5rem;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 20px 40px rgba(97, 18, 50, 0.12);
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -18,8 +19,8 @@
 .admin-panel__token {
   padding: 1rem;
   border-radius: 12px;
-  background: #f1f5f9;
-  color: #0f172a;
+  background: #f8f8f8;
+  color: #13322e;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -27,20 +28,20 @@
 }
 
 .admin-panel__token--warning {
-  background: #fef3c7;
-  color: #92400e;
+  background: #f2f2f2;
+  color: #611232;
 }
 
 .admin-panel__link {
-  color: #1d4ed8;
+  color: #9d2449;
   text-decoration: none;
 }
 
 .admin-panel__upload {
   padding: 1.5rem;
   border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  background: #f8f8f8;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -50,21 +51,21 @@
 .admin-panel__helper {
   margin: 0;
   font-size: 1.5rem;
-  color: #64748b;
+  color: #13322e;
 }
 
 .admin-panel__upload-label {
   font-weight: 600;
-  color: #0f172a;
+  color: #13322e;
   font-size: 1.5rem;
 }
 
 .admin-panel__upload-input {
   padding: 0.65rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid #cbd5f5;
+  border: 1px solid #a57f2c;
   background: #ffffff;
-  color: #0f172a;
+  color: #13322e;
   font-size: 1.5rem;
 }
 
@@ -73,7 +74,7 @@
   padding: 0.75rem 1.75rem;
   border-radius: 999px;
   border: none;
-  background: #1d4ed8;
+  background: #9d2449;
   color: #ffffff;
   font-weight: 600;
   cursor: pointer;
@@ -82,31 +83,31 @@
 .admin-panel__status {
   padding: 0.75rem 1rem;
   border-radius: 12px;
-  background: #e2e8f0;
-  color: #0f172a;
+  background: #f2f2f2;
+  color: #13322e;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
 
 .admin-panel__status--idle {
-  background: #e2e8f0;
-  color: #475569;
+  background: #f2f2f2;
+  color: #611232;
 }
 
 .admin-panel__status--uploading {
-  background: #dbeafe;
-  color: #1e3a8a;
+  background: #f8f8f8;
+  color: #611232;
 }
 
 .admin-panel__status--success {
-  background: #dcfce7;
-  color: #166534;
+  background: #f8f8f8;
+  color: #13322e;
 }
 
 .admin-panel__status--error {
-  background: #fee2e2;
-  color: #991b1b;
+  background: #f6e8e8;
+  color: #611232;
 }
 
 .admin-panel__status-label {
@@ -124,7 +125,7 @@
   padding: 0.75rem 1rem;
   border-radius: 12px;
   background: #ffffff;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #e5e7eb;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -142,7 +143,7 @@
   flex-direction: column;
   gap: 0.35rem;
   font-size: 1.5rem;
-  color: #475569;
+  color: #13322e;
 }
 
 .admin-panel__filters-label {
@@ -152,9 +153,9 @@
 .admin-panel__filters-input {
   padding: 0.55rem 0.65rem;
   border-radius: 10px;
-  border: 1px solid #cbd5f5;
+  border: 1px solid #a57f2c;
   background: #ffffff;
-  color: #0f172a;
+  color: #13322e;
   font-size: 1.5rem;
 }
 
@@ -168,8 +169,8 @@
 .admin-panel__table td {
   text-align: left;
   padding: 0.5rem 0.25rem;
-  border-bottom: 1px solid #e2e8f0;
-  color: #0f172a;
+  border-bottom: 1px solid #e5e7eb;
+  color: #13322e;
 }
 
 .admin-panel__table th {
@@ -177,8 +178,8 @@
   text-transform: uppercase;
   font-size: 1.25rem;
   letter-spacing: 0.05em;
-  color: #475569;
-  border-bottom: 1px solid #cbd5f5;
+  color: #611232;
+  border-bottom: 1px solid #a57f2c;
 }
 
 .admin-panel__table tbody tr:last-child td {
@@ -191,15 +192,15 @@
   justify-content: center;
   padding: 0.2rem 0.6rem;
   border-radius: 999px;
-  background: #e2e8f0;
-  color: #475569;
+  background: #f2f2f2;
+  color: #611232;
   font-weight: 600;
   font-size: 1.25rem;
 }
 
 .admin-panel__badge--assigned {
-  background: #dcfce7;
-  color: #166534;
+  background: #f8f8f8;
+  color: #13322e;
 }
 
 .admin-panel__pagination {
@@ -213,17 +214,17 @@
 .admin-panel__pagination-button {
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid #cbd5f5;
+  border: 1px solid #a57f2c;
   background: #ffffff;
-  color: #1e293b;
+  color: #13322e;
   font-size: 1.25rem;
   font-weight: 600;
   cursor: pointer;
 }
 
 .admin-panel__pagination-button--active {
-  background: #1d4ed8;
-  border-color: #1d4ed8;
+  background: #611232;
+  border-color: #611232;
   color: #ffffff;
 }
 
@@ -236,7 +237,7 @@
   padding: 0.75rem 1rem;
   border-radius: 12px;
   background: #ffffff;
-  border: 1px dashed #cbd5f5;
+  border: 1px dashed #a57f2c;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -247,7 +248,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #1e293b;
+  color: #611232;
 }
 
 .admin-panel__history-list {
@@ -263,7 +264,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
-  color: #334155;
+  color: #13322e;
 }
 
 .admin-panel__history-name {
@@ -272,7 +273,7 @@
 
 .admin-panel__history-meta {
   font-size: 1.25rem;
-  color: #64748b;
+  color: #98989a;
 }
 
 .admin-panel__logout {
@@ -280,8 +281,66 @@
   padding: 0.75rem 1.5rem;
   border-radius: 999px;
   border: none;
-  background: #ef4444;
+  background: #611232;
   color: #ffffff;
   font-weight: 600;
   cursor: pointer;
+}
+
+@media (max-width: 540px) {
+  .admin-panel {
+    padding: 1.5rem 1rem;
+  }
+
+  .admin-panel__card {
+    padding: 1.5rem;
+    gap: 1rem;
+  }
+
+  .admin-panel__upload {
+    padding: 1.1rem;
+    font-size: 1rem;
+  }
+
+  .admin-panel__helper,
+  .admin-panel__upload-label,
+  .admin-panel__upload-input,
+  .admin-panel__filters-field,
+  .admin-panel__filters-input,
+  .admin-panel__status-label {
+    font-size: 1rem;
+  }
+
+  .admin-panel__status-message,
+  .admin-panel__table,
+  .admin-panel__table th,
+  .admin-panel__table td,
+  .admin-panel__pagination-button,
+  .admin-panel__badge,
+  .admin-panel__history-title,
+  .admin-panel__history-meta {
+    font-size: 0.95rem;
+  }
+
+  .admin-panel__table {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .admin-panel__table th,
+  .admin-panel__table td {
+    white-space: nowrap;
+  }
+
+  .admin-panel__filters {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-panel__upload-button,
+  .admin-panel__logout {
+    width: 100%;
+    text-align: center;
+  }
 }

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { AdminAuthService } from '../../services/admin-auth.service';
 import { ArchivoStorageService, RegistroArchivo } from '../../services/archivo-storage.service';
 import Swal from 'sweetalert2';
@@ -31,7 +31,8 @@ export class AdminPanelComponent implements OnInit {
 
   constructor(
     private readonly adminAuthService: AdminAuthService,
-    private readonly archivoStorageService: ArchivoStorageService
+    private readonly archivoStorageService: ArchivoStorageService,
+    private readonly router: Router
   ) {}
 
   ngOnInit(): void {
@@ -137,6 +138,12 @@ export class AdminPanelComponent implements OnInit {
 
   cerrarSesion(): void {
     this.adminAuthService.cerrarSesion();
+    this.selectedFile = null;
+    this.excelSeleccionado = null;
+    this.selectedNivel = '';
+    this.uploadStatus = 'idle';
+    this.feedbackMessage = '';
+    void this.router.navigate(['/admin/login']);
   }
 
   get excelDisponiblesFiltrados(): ExcelDisponible[] {

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
@@ -3,7 +3,8 @@
   margin: 0 auto;
   padding: 2rem 1.5rem 3rem;
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
-  color: #0f172a;
+  color: #13322e;
+  font-size: 1.05rem;
 }
 
 .archivos__encabezado {
@@ -13,22 +14,23 @@
 .archivos__eyebrow {
   text-transform: uppercase;
   font-weight: 700;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   letter-spacing: 0.08em;
-  color: #2563eb;
+  color: #611232;
   margin: 0 0 0.35rem;
 }
 
 .archivos__titulo {
   margin: 0.2rem 0;
-  font-size: 1.6rem;
+  font-size: 1.9rem;
   font-weight: 700;
 }
 
 .archivos__descripcion {
   margin: 0;
-  color: #475569;
+  color: #13322e;
   line-height: 1.5;
+  font-size: 1.05rem;
 }
 
 .archivos__mensajes {
@@ -43,23 +45,24 @@
   border-radius: 12px;
   font-weight: 600;
   line-height: 1.4;
+  font-size: 1rem;
 }
 
 .archivos__mensaje--info {
-  background: #eff6ff;
-  color: #1d4ed8;
-  border: 1px solid #bfdbfe;
+  background: #f2f2f2;
+  color: #611232;
+  border: 1px solid #a57f2c;
 }
 
 .archivos__mensaje--error {
-  background: #fef2f2;
-  color: #b91c1c;
-  border: 1px solid #fecdd3;
+  background: #f6e8e8;
+  color: #611232;
+  border: 1px solid #9d2449;
 }
 
 .archivos__tabla {
   background: #ffffff;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #e5e7eb;
   border-radius: 16px;
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
   overflow: hidden;
@@ -71,20 +74,20 @@
 }
 
 .archivos thead {
-  background: #f8fafc;
+  background: #f6eddc;
 }
 
 .archivos th,
 .archivos td {
   padding: 0.9rem 1rem;
   text-align: left;
-  font-size: 0.95rem;
+  font-size: 1.05rem;
 }
 
 .archivos th {
   font-weight: 700;
-  color: #1e293b;
-  border-bottom: 1px solid #e2e8f0;
+  color: #13322e;
+  border-bottom: 1px solid #e5e7eb;
 }
 
 .archivos tbody tr:nth-child(even) {
@@ -92,7 +95,7 @@
 }
 
 .archivos tbody tr:hover {
-  background: #f1f5f9;
+  background: #f6eddc;
 }
 
 .archivos__acciones {
@@ -104,8 +107,8 @@
 .archivos__accion {
   padding: 0.45rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid #2563eb;
-  background: #2563eb;
+  border: 1px solid #611232;
+  background: #9d2449;
   color: #fff;
   cursor: pointer;
   font-weight: 600;
@@ -113,8 +116,8 @@
 }
 
 .archivos__accion:hover {
-  background: #1d4ed8;
-  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
+  background: #611232;
+  box-shadow: 0 8px 20px rgba(97, 18, 50, 0.25);
   transform: translateY(-1px);
 }
 
@@ -123,9 +126,9 @@
 }
 
 .archivos__accion--peligro {
-  background: #fee2e2;
-  border-color: #fca5a5;
-  color: #b91c1c;
+  background: #f6e8e8;
+  border-color: #9d2449;
+  color: #611232;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -133,8 +136,8 @@
 }
 
 .archivos__accion--peligro:hover {
-  background: #fecdd3;
-  box-shadow: 0 8px 20px rgba(248, 113, 113, 0.25);
+  background: #f0d7d7;
+  box-shadow: 0 8px 20px rgba(97, 18, 50, 0.2);
   transform: translateY(-1px);
 }
 
@@ -151,21 +154,22 @@
 
 .archivos__resultado-nombre {
   font-weight: 600;
-  color: #1e293b;
-  font-size: 0.9rem;
+  color: #13322e;
+  font-size: 1rem;
 }
 
 .archivos__vacio {
   text-align: center;
   padding: 2rem 1rem;
-  background: #f8fafc;
-  border: 1px dashed #cbd5e1;
+  background: #f6eddc;
+  border: 1px dashed #a57f2c;
   border-radius: 16px;
-  color: #475569;
+  color: #13322e;
+  font-size: 1.05rem;
 }
 
 .archivos__link {
-  color: #2563eb;
+  color: #9d2449;
   font-weight: 700;
   text-decoration: none;
 }
@@ -195,7 +199,7 @@
 
   .archivos td {
     padding: 0.75rem 0.9rem;
-    border-bottom: 1px solid #e2e8f0;
+    border-bottom: 1px solid #e5e7eb;
     position: relative;
   }
 
@@ -204,10 +208,10 @@
     position: absolute;
     left: 0.9rem;
     top: 0.4rem;
-    font-size: 0.78rem;
+    font-size: 0.85rem;
     font-weight: 700;
     text-transform: uppercase;
-    color: #64748b;
+    color: #98989a;
   }
 
   .archivos tr:last-child td:last-child {


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad y aspecto del formulario de login con tipografía y paleta actualizadas.
- Proveer un recordatorio visible de las credenciales administrativas solicitadas para acceso rápido.
- Asegurar que al cerrar sesión el estado del panel quede limpio y se redirija al login.
- Arreglar pequeñas mejoras de accesibilidad y responsive en vistas administrativas.

### Description
- Añadido un bloque de credenciales hardcodeadas en `admin-login.component.html` que muestra `admin@sep.mx` y `admin123` para referencia rápida.  
- Renovadas las reglas en `admin-login.component.scss` para una paleta más cálida, tipografías más grandes y ajustes responsive; además se aplicaron cambios de estilo similares en `admin-panel.component.scss` y `archivos-guardados.component.scss` para coherencia visual.  
- En `admin-panel.component.ts` se inyectó `Router` y se actualizó `cerrarSesion()` para limpiar `selectedFile`, `excelSeleccionado`, `selectedNivel`, `uploadStatus` y `feedbackMessage`, y luego navegar con `router.navigate(['/admin/login'])`.  
- Pequeñas mejoras adicionales: se añadió `aria-label=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ecfe949708320948087d1ac17f968)