### PR TITLE
Detectar nivel del Excel por nombres de hojas y persistir `nivel` en registros

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
@@ -1,9 +1,9 @@
 <section class="archivos">
   <header class="archivos__encabezado">
-    <p class="archivos__eyebrow">Cargas realizadas · Preescolar</p>
+    <p class="archivos__eyebrow">Cargas realizadas</p>
     <h1 class="archivos__titulo">Archivos almacenados en este navegador</h1>
     <p class="archivos__descripcion">
-      Aquí podrás consultar los archivos que has validado y guardado desde el módulo de carga de Preescolar.
+      Aquí podrás consultar los archivos que has validado y guardado desde el módulo de carga.
       Los datos permanecen en el <strong>almacenamiento local del navegador</strong> y no se envían a un servidor.
     </p>
   </header>
@@ -18,6 +18,7 @@
       <thead>
         <tr>
           <th>Nombre</th>
+          <th>Nivel</th>
           <th>CCT</th>
           <th>Correo</th>
           <th>Peso (KB)</th>
@@ -30,6 +31,7 @@
       <tbody>
         <tr *ngFor="let registro of registros">
           <td data-label="Nombre">{{ registro.nombre }}</td>
+          <td data-label="Nivel">{{ obtenerEtiquetaNivel(registro.nivel) }}</td>
           <td data-label="CCT">{{ registro.cct || '—' }}</td>
           <td data-label="Correo">{{ registro.correo || '—' }}</td>
           <td data-label="Peso">{{ (registro.tamano / 1024) | number:'1.0-2' }}</td>

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -45,12 +45,12 @@ export class ArchivosGuardadosComponent implements OnInit {
     this.cargarResultadosPdf();
 
     if (this.registros.length === 0) {
-      this.mensajeInfo = 'Aún no has cargado archivos de Preescolar en este navegador.';
+      this.mensajeInfo = 'Aún no has cargado archivos en este navegador.';
       return;
     }
 
     this.mensajeInfo =
-      'Los archivos permanecen en el almacenamiento local del navegador. Copia el archivo a assets/archivos/preescolar/ dentro de tu proyecto si necesitas usarlo en otra sesión.';
+      'Los archivos permanecen en el almacenamiento local del navegador. Copia el archivo a assets/archivos/{nivel}/ dentro de tu proyecto si necesitas usarlo en otra sesión.';
   }
 
   descargar(registro: RegistroArchivo): void {
@@ -146,6 +146,19 @@ export class ArchivosGuardadosComponent implements OnInit {
   obtenerEtiquetaPdf(resultado: PdfMetadataConStorage): string {
     const nombre = resultado.pdfName?.trim();
     return nombre ? nombre : 'PDF asignado';
+  }
+
+  obtenerEtiquetaNivel(nivel?: string): string {
+    switch ((nivel ?? '').toLowerCase()) {
+      case 'primaria':
+        return 'Primaria';
+      case 'secundaria':
+        return 'Secundaria';
+      case 'preescolar':
+        return 'Preescolar';
+      default:
+        return 'No identificado';
+    }
   }
 
   private cargarResultadosPdf(): void {

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
@@ -21,8 +21,16 @@ const resultadoValido: ResultadoValidacion = {
 class ExcelValidationServiceStub {
   resultado: ResultadoValidacion = resultadoValido;
 
-  detectarTipoArchivo(): Promise<'preescolar'> {
-    return Promise.resolve('preescolar');
+  detectarNivelConDetalle(): Promise<{
+    nivel: 'preescolar';
+    hojas: string[];
+    mensajesError: string[];
+  }> {
+    return Promise.resolve({
+      nivel: 'preescolar',
+      hojas: ['ESC', 'TERCERO', 'INSTRUCCIONES'],
+      mensajesError: []
+    });
   }
 
   validarPreescolar(): Promise<ResultadoValidacion> {
@@ -41,7 +49,7 @@ class ExcelValidationServiceStub {
 class ArchivoStorageServiceStub {
   guardarArchivoPreescolar(
     _archivo: File,
-    _contexto?: { email: string; cct: string },
+    _contexto?: { email?: string; cct?: string; nivel?: string },
     _opciones?: { forzarReemplazo?: boolean }
   ): Promise<{ rutaVirtual: string; modo: 'localStorage'; nota: string }> {
     return Promise.resolve({

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -225,20 +225,25 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
 
     try {
       const buffer = await file.arrayBuffer();
-      const tipoArchivo = await this.excelValidationService.detectarTipoArchivo(buffer);
-      resultadoArchivo.tipoDetectado = tipoArchivo;
+      const deteccion = await this.excelValidationService.detectarNivelConDetalle(buffer);
+      resultadoArchivo.tipoDetectado = deteccion.nivel;
 
-      if (!tipoArchivo) {
-        resultadoArchivo.mensajeInformativo = 'No se reconoció el formato.';
-        this.actualizarErrores(resultadoArchivo, [
-          'No se reconoció el formato. Verifica que sea una plantilla válida de Preescolar, Primaria o Secundaria.'
-        ]);
+      if (!deteccion.nivel) {
+        resultadoArchivo.mensajeInformativo = 'No se reconoció el nivel del archivo.';
+        this.actualizarErrores(
+          resultadoArchivo,
+          deteccion.mensajesError.length
+            ? deteccion.mensajesError
+            : [
+                'No se reconoció el formato. Verifica que sea una plantilla válida de Preescolar, Primaria o Secundaria.'
+              ]
+        );
         await this.finalizarConError(resultadoArchivo);
         return;
       }
 
-      resultadoArchivo.mensajeInformativo = `Archivo detectado: ${this.obtenerEtiquetaTipo(tipoArchivo)}. Validando reglas específicas...`;
-      const resultado = await this.validarPorTipo(tipoArchivo, buffer);
+      resultadoArchivo.mensajeInformativo = `Archivo detectado: ${this.obtenerEtiquetaTipo(deteccion.nivel)}. Validando reglas específicas...`;
+      const resultado = await this.validarPorTipo(deteccion.nivel, buffer);
       await this.procesarResultado(resultado, resultadoArchivo);
     } catch (error) {
       this.actualizarErrores(resultadoArchivo, [
@@ -282,7 +287,8 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     try {
       const guardado = await this.archivoStorageService.guardarArchivoPreescolar(resultado.archivoOriginal, {
         cct: resultado.escDatos?.cct,
-        correo: this.correoControl.value
+        correo: this.correoControl.value,
+        nivel: resultado.tipoDetectado ?? undefined
       });
       await this.mostrarConfirmacionGuardado(guardado, 'guardado', resultado);
       if (resultado.escDatos && resultado.resultadoExito && resultado.pdfTipo !== 'exito') {
@@ -311,7 +317,8 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
               {
                 forzarReemplazo: true,
                 cct: resultado.escDatos?.cct,
-                correo: this.correoControl.value
+                correo: this.correoControl.value,
+                nivel: resultado.tipoDetectado ?? undefined
               }
             );
             await this.mostrarConfirmacionGuardado(resultadoReemplazo, 'reemplazo', resultado);
@@ -470,7 +477,8 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     resultadoArchivo.notaGuardado = resultado.nota;
     resultadoArchivo.guardado = true;
     resultadoArchivo.mensajeInformativo =
-      'El archivo se conservó en el almacenamiento local del navegador. Copia el archivo a assets/archivos/preescolar/ en tu proyecto si lo necesitas.';
+      'El archivo se conservó en el almacenamiento local del navegador. Copia el archivo a ' +
+      `${this.obtenerRutaReferencia(resultadoArchivo.tipoDetectado)} en tu proyecto si lo necesitas.`;
 
     const esReemplazo = tipo === 'reemplazo';
 
@@ -695,6 +703,11 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     }
 
     return error.trim();
+  }
+
+  private obtenerRutaReferencia(tipo: TipoArchivoCarga | null): string {
+    const nivel = tipo ?? 'preescolar';
+    return `assets/archivos/${nivel}/`;
   }
 
   obtenerEtiquetaTipo(tipo: TipoArchivoCarga | null): string {

--- a/web/frontend/src/app/services/archivo-storage.service.ts
+++ b/web/frontend/src/app/services/archivo-storage.service.ts
@@ -35,10 +35,17 @@ export class ArchivoStorageService {
 
   async guardarArchivoPreescolar(
     archivo: File,
-    parametros?: { forzarReemplazo?: boolean; cct?: string; correo?: string; email?: string },
+    parametros?: {
+      forzarReemplazo?: boolean;
+      cct?: string;
+      correo?: string;
+      email?: string;
+      nivel?: RegistroArchivo['nivel'];
+    },
     opciones?: { forzarReemplazo?: boolean }
   ): Promise<ResultadoGuardado> {
-    const rutaDestino = `assets/archivos/preescolar/${archivo.name}`;
+    const nivel = parametros?.nivel ?? 'preescolar';
+    const rutaDestino = `assets/archivos/${nivel}/${archivo.name}`;
     const buffer = await archivo.arrayBuffer();
     const hash = await this.calcularHash(buffer);
     const contenido = this.arrayBufferABase64(buffer);
@@ -70,7 +77,7 @@ export class ArchivoStorageService {
       claveEstable,
       cct: parametros?.cct,
       correo: emailNormalizado || undefined,
-      nivel: 'preescolar'
+      nivel
     };
 
     const duplicado = registros.find(

--- a/web/frontend/src/app/services/excel-validation.service.ts
+++ b/web/frontend/src/app/services/excel-validation.service.ts
@@ -27,12 +27,19 @@ export interface ResultadoValidacion {
 
 export type TipoArchivoCarga = 'preescolar' | 'primaria' | 'secundaria';
 
+export interface ResultadoDeteccionNivel {
+  nivel: TipoArchivoCarga | null;
+  hojas: string[];
+  mensajesError: string[];
+}
+
 @Injectable({ providedIn: 'root' })
 export class ExcelValidationService {
   private xlsxPromise: Promise<any> | null = null;
   // Hojas base (centralizadas para evitar duplicidad de nombres).
   private readonly hojasBase = {
     esc: 'ESC',
+    instrucciones: 'INSTRUCCIONES',
     primero: 'PRIMERO',
     segundo: 'SEGUNDO',
     tercero: 'TERCERO',
@@ -42,9 +49,10 @@ export class ExcelValidationService {
   };
   // Configuración por nivel (hojas requeridas por tipo de archivo).
   private readonly hojasPorNivel = {
-    preescolar: [this.hojasBase.esc, this.hojasBase.tercero],
+    preescolar: [this.hojasBase.esc, this.hojasBase.instrucciones, this.hojasBase.tercero],
     primaria: [
       this.hojasBase.esc,
+      this.hojasBase.instrucciones,
       this.hojasBase.primero,
       this.hojasBase.segundo,
       this.hojasBase.tercero,
@@ -52,7 +60,13 @@ export class ExcelValidationService {
       this.hojasBase.quinto,
       this.hojasBase.sexto
     ],
-    secundaria: [this.hojasBase.esc, this.hojasBase.primero, this.hojasBase.segundo, this.hojasBase.tercero]
+    secundaria: [
+      this.hojasBase.esc,
+      this.hojasBase.instrucciones,
+      this.hojasBase.primero,
+      this.hojasBase.segundo,
+      this.hojasBase.tercero
+    ]
   };
   // Encabezados base (centralizados por nivel/sección).
   private readonly encabezadosEscBase = {
@@ -386,10 +400,24 @@ export class ExcelValidationService {
     ]
   };
   async detectarTipoArchivo(buffer: ArrayBuffer): Promise<TipoArchivoCarga | null> {
+    const resultado = await this.detectarNivelConDetalle(buffer);
+    return resultado.nivel;
+  }
+
+  async detectarNivelConDetalle(buffer: ArrayBuffer): Promise<ResultadoDeteccionNivel> {
     const xlsx = await this.cargarXlsx();
     const workbook = xlsx.read(buffer, { type: 'array' });
     const hojas = workbook.SheetNames as string[];
-    return this.detectarNivel(this.normalizarHojas(hojas));
+    const hojasNormalizadas = this.normalizarHojas(hojas);
+    const nivel = this.detectarNivel(hojasNormalizadas);
+    if (!nivel) {
+      return {
+        nivel: null,
+        hojas,
+        mensajesError: this.construirMensajesNivelNoReconocido(hojasNormalizadas)
+      };
+    }
+    return { nivel, hojas, mensajesError: [] };
   }
 
   async validarArchivo(buffer: ArrayBuffer): Promise<ResultadoValidacion> {
@@ -402,7 +430,7 @@ export class ExcelValidationService {
     if (!nivel) {
       return {
         ok: false,
-        errores: ['No se reconoció el formato del archivo. Usa una plantilla oficial vigente.'],
+        errores: this.construirMensajesNivelNoReconocido(hojasNormalizadas),
         advertencias: [],
         hojasEncontradas: hojas
       };
@@ -903,6 +931,17 @@ export class ExcelValidationService {
       }
     }
     return faltantes;
+  }
+
+  private construirMensajesNivelNoReconocido(hojasNormalizadas: Set<string>): string[] {
+    const hojas = Array.from(hojasNormalizadas);
+    const hojasListado = hojas.length ? hojas.sort().join(', ') : 'ninguna';
+    return [
+      `No se pudo determinar el nivel con las hojas encontradas: ${hojasListado}.`,
+      'Patrones esperados: Preescolar (ESC, INSTRUCCIONES, TERCERO); ' +
+        'Primaria (ESC, INSTRUCCIONES, PRIMERO, SEGUNDO, TERCERO, CUARTO, QUINTO, SEXTO); ' +
+        'Secundaria (ESC, INSTRUCCIONES, PRIMERO, SEGUNDO, TERCERO).'
+    ];
   }
 
   private limpiarTexto(valor: any): string {


### PR DESCRIPTION
### Motivation

- Detectar automáticamente si un `.xlsx` es de Preescolar/Primaria/Secundaria leyendo los nombres de las hojas para evitar clasificaciones erróneas.  
- Incluir la hoja `INSTRUCCIONES` como parte de los patrones esperados para cada nivel.  
- Guardar el `nivel` detectado en el `RegistroArchivo` y usarlo para elegir la ruta sugerida al guardar.  
- Mostrar mensajes de error claros cuando el Excel no coincide con ningún patrón conocido.

### Description

- Se añadió la interfaz `ResultadoDeteccionNivel` y la función `detectarNivelConDetalle(buffer)` en `ExcelValidationService`, que devuelve el `nivel`, las `hojas` leídas y `mensajesError` detallados.  
- Se actualizó la lógica de detección para requerir la hoja `INSTRUCCIONES` en los patrones y se añadió `construirMensajesNivelNoReconocido` para mensajes claros cuando no se reconoce el nivel.  
- `CargaMasivaComponent` ahora usa `detectarNivelConDetalle` antes de validar y asigna `resultadoArchivo.tipoDetectado`, y se pasa `nivel` al llamar a `guardarArchivoPreescolar`.  
- `ArchivoStorageService` acepta ahora `parametros.nivel`, escribe la `ruta` basada en el `nivel` (`assets/archivos/{nivel}/...`) y almacena `registro.nivel`; además se actualizaron las vistas en `archivos-guardados` para mostrar el `nivel` y las instrucciones de ruta.

### Testing

- No se ejecutaron pruebas automáticas en este cambio (ninguna prueba corrida en el entorno de este rollout).  
- Se actualizaron los stubs en la prueba `carga-masiva.component.spec.ts` para usar `detectarNivelConDetalle` y la nueva firma de `guardarArchivoPreescolar`.  
- Los cambios compilaron localmente durante el desarrollo del parche (ediciones y commit realizados).  
- Recomiendo ejecutar la suite de unit tests (`ng test`) y validar manualmente la carga de ejemplos de plantillas para `Preescolar`, `Primaria` y `Secundaria`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f027e410c83209888db921b3c7214)