### PR TITLE
Arreglar layout móvil en la tabla de archivos guardados

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
@@ -200,18 +200,24 @@
   .archivos td {
     padding: 0.75rem 0.9rem;
     border-bottom: 1px solid #e5e7eb;
-    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
   }
 
   .archivos td::before {
     content: attr(data-label);
-    position: absolute;
-    left: 0.9rem;
-    top: 0.4rem;
+    position: static;
+    display: block;
     font-size: 1.25rem;
     font-weight: 700;
     text-transform: uppercase;
     color: #98989a;
+  }
+
+  .archivos__acciones {
+    flex-wrap: wrap;
+    row-gap: 0.4rem;
   }
 
   .archivos tr:last-child td:last-child {


### PR DESCRIPTION
### Motivation
- La vista móvil del componente de archivos mostraba etiquetas y campos amontonados dificultando la lectura en pantallas pequeñas.
- Se buscó apilar etiqueta y contenido y permitir que los botones de acción hagan wrap para mejorar la usabilidad en móviles.

### Description
- Se actualizó `web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss` para el media query `@media (max-width: 720px)`.
- Las celdas `td` ahora usan `display: flex` con `flex-direction: column` y `gap` para apilar etiqueta (`::before`) y contenido en móvil.
- Se cambió la pseudo-etiqueta `td::before` de posicionamiento absoluto a `position: static` y `display: block` para evitar solapamientos.
- Se añadió `flex-wrap: wrap` y `row-gap` a `.archivos__acciones` para permitir que los botones se distribuyan en varias filas en pantallas pequeñas.

### Testing
- Se inició el servidor de desarrollo con `npm --prefix web/frontend start` y la compilación de la aplicación completó correctamente.
- Se capturó una captura de pantalla móvil mediante Playwright navegando a `http://127.0.0.1:4200/archivos-preescolar` y el script finalizó con éxito (se generó el artefacto de imagen).
- No se ejecutaron pruebas unitarias automáticas adicionales sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fdeb7e8d48320985d7d98971ba41f)