### PR TITLE
Mejorar formulario de login: toggle contraseña, aviso de credenciales guardadas y validación

### DIFF
--- a/web/frontend/src/app/components/login/login.component.html
+++ b/web/frontend/src/app/components/login/login.component.html
@@ -11,30 +11,42 @@
         type="email"
         required
         [(ngModel)]="correo"
+        #correoModel="ngModel"
         autocomplete="email"
         placeholder="correo@dominio.com"
       />
 
       <label for="contrasena">Contraseña</label>
-      <input
-        id="contrasena"
-        name="contrasena"
-        type="password"
-        required
-        [(ngModel)]="contrasena"
-        autocomplete="current-password"
-        placeholder="Clave enviada en tu primer carga"
-      />
+      <div class="login__password-field">
+        <input
+          id="contrasena"
+          name="contrasena"
+          [type]="mostrarContrasena ? 'text' : 'password'"
+          required
+          [(ngModel)]="contrasena"
+          #contrasenaModel="ngModel"
+          autocomplete="current-password"
+          placeholder="Clave enviada en tu primer carga"
+        />
+        <button class="login__toggle" type="button" (click)="mostrarContrasena = !mostrarContrasena">
+          {{ mostrarContrasena ? 'Ocultar' : 'Mostrar' }}
+        </button>
+      </div>
+      <p class="login__hint">Usa la contraseña generada en tu primer envío.</p>
 
-      <div class="login__alerta" *ngIf="contrasenaGuardada">
-        Ya existe una contraseña guardada para {{ correo }}. La llenamos por ti para que puedas continuar con tus cargas sin
-        generar una nueva clave.
+      <div class="login__alerta" *ngIf="credencialesGuardadas">
+        Ya existen credenciales guardadas para {{ correo }}. Si es necesario, puedes actualizar la contraseña antes de
+        continuar.
       </div>
 
       <div class="login__error" *ngIf="error">{{ error }}</div>
 
-      <button class="login__submit" type="submit" [disabled]="loginForm.invalid || autenticando">
-        {{ autenticando ? 'Validando...' : 'Iniciar sesión' }}
+      <button
+        class="login__submit"
+        type="submit"
+        [disabled]="correoModel.invalid || contrasenaModel.invalid || autenticando"
+      >
+        {{ autenticando ? 'Validando...' : 'Ingresar' }}
       </button>
     </form>
 

--- a/web/frontend/src/app/components/login/login.component.scss
+++ b/web/frontend/src/app/components/login/login.component.scss
@@ -69,6 +69,38 @@ input:focus {
   font-size: 1.25rem;
 }
 
+.login__password-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.login__password-field input {
+  padding-right: 5.5rem;
+}
+
+.login__toggle {
+  position: absolute;
+  right: 0.75rem;
+  background: transparent;
+  border: none;
+  color: #2e7d32;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.login__toggle:focus {
+  outline: 2px solid rgba(46, 125, 50, 0.4);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.login__hint {
+  margin: -0.5rem 0 1rem;
+  color: #718096;
+  font-size: 0.95rem;
+}
+
 .login__submit {
   width: 100%;
   background: #2e7d32;

--- a/web/frontend/src/app/components/login/login.component.ts
+++ b/web/frontend/src/app/components/login/login.component.ts
@@ -20,6 +20,8 @@ export class LoginComponent implements OnInit {
   autenticando = false;
   redirect = '/carga-masiva';
   contrasenaGuardada: string | null = null;
+  credencialesGuardadas = false;
+  mostrarContrasena = false;
 
   constructor(
     private readonly authService: AuthService,
@@ -29,7 +31,8 @@ export class LoginComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const credenciales = this.estadoCredencialesService.obtener() ?? this.authService.obtenerCredenciales();
+    const credencialesPersistidas = this.authService.obtenerCredenciales();
+    const credenciales = this.estadoCredencialesService.obtener() ?? credencialesPersistidas;
 
     if (!credenciales) {
       void this.router.navigate(['/carga-masiva']);
@@ -38,7 +41,8 @@ export class LoginComponent implements OnInit {
 
     this.redirect = this.route.snapshot.queryParamMap.get('redirect') ?? this.redirect;
     this.correo = credenciales.correo;
-    this.contrasenaGuardada = credenciales.contrasena;
+    this.contrasenaGuardada = credencialesPersistidas?.contrasena ?? null;
+    this.credencialesGuardadas = Boolean(credencialesPersistidas);
     if (!this.contrasena) {
       this.contrasena = credenciales.contrasena;
     }
@@ -59,7 +63,8 @@ export class LoginComponent implements OnInit {
       });
       await this.router.navigateByUrl(this.redirect);
     } catch (error) {
-      this.error = error instanceof Error ? error.message : 'No fue posible iniciar sesión.';
+      const mensajeError = error instanceof Error ? error.message : 'Ocurrió un error inesperado.';
+      this.error = `No se pudo iniciar sesión. ${mensajeError}`;
       await Swal.fire({
         icon: 'error',
         title: 'No se pudo iniciar sesión',


### PR DESCRIPTION
### Motivation
- Detectar y avisar cuando ya existen credenciales guardadas usando `AuthService.obtenerCredenciales()` para facilitar reingresos.
- Permitir al usuario ver u ocultar la contraseña y añadir microtexto de ayuda para evitar confusiones con la clave generada en el primer envío.
- Evitar envíos inválidos deshabilitando el botón hasta que correo y contraseña sean válidos.
- Mostrar un mensaje de error más claro usando el mensaje específico del error lanzado.

### Description
- Usar `authService.obtenerCredenciales()` y `estadoCredencialesService.obtener()` para poblar el formulario y exponer `credencialesGuardadas` y `contrasenaGuardada`.
- Añadir `mostrarContrasena` y un botón toggle que cambia el `type` del input entre `password` y `text` en la plantilla. 
- Reemplazar el input simple de contraseña por una estructura con clase `login__password-field`, microtexto `login__hint` y estilos nuevos en `login.component.scss`.
- Mejorar la lógica de error en `iniciarSesion()` para incluir el mensaje lanzado y deshabilitar el botón con la condición `correoModel.invalid || contrasenaModel.invalid || autenticando`.

### Testing
- Intenté instalar dependencias con `npm install` en `web/frontend`, pero falló con `403 Forbidden` al descargar `sweetalert2`, por lo que no se pudieron ejecutar tests de la app.
- No se ejecutó `npm test` debido al fallo de instalación de dependencias.
- Los cambios fueron formateados y aplicados a los archivos `login.component.ts`, `login.component.html` y `login.component.scss` y se confirmó el commit local.
- Revisión estática de la plantilla y del TypeScript realizada durante el desarrollo (no es una prueba automatizada registrada).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ffccf59008320a24ee7aac4fe4f06)