### PR TITLE
Mejorar UI de carga masiva: estado por archivo y limpiar resultados

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -99,6 +99,16 @@
   </div>
 
   <div class="carga__estado" *ngIf="resultados.length">
+    <div class="carga__estado-header">
+      <div>
+        <p class="carga__estado-eyebrow">Resultados de validación</p>
+        <h2 class="carga__estado-titulo">Estado de tus archivos</h2>
+      </div>
+      <button type="button" class="carga__boton-secundario carga__boton-limpiar" (click)="limpiarResultados()">
+        Limpiar resultados
+      </button>
+    </div>
+
     <section class="carga__credenciales" *ngIf="credencialesMostradas">
       <div class="carga__credenciales-header">
         <div class="carga__credenciales-icono" aria-hidden="true">🔑</div>
@@ -138,14 +148,19 @@
             Archivo detectado: {{ obtenerEtiquetaTipo(resultado.tipoDetectado) }}
           </p>
         </div>
-        <span
-          class="carga__chip"
-          [class.carga__chip--progreso]="resultado.estado === 'validando'"
-          [class.carga__chip--error]="resultado.estado === 'error'"
-          [class.carga__chip--exito]="resultado.estado === 'exito'"
-        >
-          {{ resultado.estado === 'validando' ? 'Validando' : resultado.estado === 'exito' ? 'Validado' : 'Con errores' }}
-        </span>
+        <div class="carga__detalle-status">
+          <span
+            class="carga__estado-indicador"
+            [class.carga__estado-indicador--progreso]="resultado.estado === 'validando'"
+            [class.carga__estado-indicador--error]="resultado.estado === 'error'"
+            [class.carga__estado-indicador--exito]="resultado.estado === 'exito'"
+          >
+            <span class="carga__estado-punto" aria-hidden="true"></span>
+            <span class="carga__estado-texto">
+              {{ resultado.estado === 'validando' ? 'Validando' : resultado.estado === 'exito' ? 'Validado' : 'Con errores' }}
+            </span>
+          </span>
+        </div>
       </header>
 
       <p

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
@@ -337,6 +337,29 @@
   gap: 1rem;
 }
 
+.carga__estado-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.carga__estado-eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+}
+
+.carga__estado-titulo {
+  margin: 0.2rem 0 0;
+  font-size: 1.25rem;
+  color: #111827;
+}
+
 .carga__detalle {
   background: #f9fafb;
   padding: 1rem;
@@ -384,6 +407,50 @@
   margin: 0;
   display: grid;
   gap: 0.3rem;
+}
+
+.carga__detalle-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.carga__estado-indicador {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  background: #f8fafc;
+}
+
+.carga__estado-punto {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.06);
+}
+
+.carga__estado-indicador--progreso {
+  color: #1d4ed8;
+  border-color: #bfdbfe;
+  background: #eff6ff;
+}
+
+.carga__estado-indicador--error {
+  color: #b91c1c;
+  border-color: #fecdd3;
+  background: #fef2f2;
+}
+
+.carga__estado-indicador--exito {
+  color: #047857;
+  border-color: #a7f3d0;
+  background: #ecfdf3;
 }
 
 .carga__chip {
@@ -576,6 +643,10 @@
 .carga__boton-secundario {
   background: #e5e7eb;
   color: #1f2937;
+}
+
+.carga__boton-limpiar {
+  border: 1px solid #cbd5e1;
 }
 
 .carga__boton-primario:hover,

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -304,7 +304,7 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
         const confirmacion = await Swal.fire({
           icon: 'question',
           title: 'Archivo ya existe',
-          text: 'Ya tienes una copia con el mismo contenido. ¿Quieres sustituirla?',
+          text: `Ya tienes una copia del archivo "${resultado.archivo.name}" con el mismo contenido. ¿Quieres sustituirla?`,
           showCancelButton: true,
           confirmButtonText: 'Sí, sustituir',
           cancelButtonText: 'Cancelar'
@@ -460,6 +460,10 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
 
   onEliminarResultado(resultado: ResultadoArchivo): void {
     this.resultados = this.resultados.filter((item) => item !== resultado);
+  }
+
+  limpiarResultados(): void {
+    this.resultados = [];
   }
 
   limpiarSeleccion(input: HTMLInputElement): void {


### PR DESCRIPTION
### Motivation
- Mostrar de forma clara el estado de cada archivo (validando, éxito, error) para facilitar la revisión de validaciones.
- Permitir limpiar fácilmente la lista de resultados con un botón `Limpiar resultados` que vacíe `resultados`.
- Evitar sobreescrituras sin confirmación al detectar archivos duplicados mostrando el nombre antes de forzar el reemplazo.
- Asegurar que la carga esté condicionada al correo válido mediante el `FormControl` existente (`correoControl`).

### Description
- Se añadió el método `limpiarResultados()` y el botón en la cabecera de resultados que invoca `limpiarResultados()` para vaciar `resultados`.
- Se reemplazó la chip anterior por un indicador visual por archivo (`carga__estado-indicador`) que muestra un punto y texto según el estado y se añadieron estilos SCSS relacionados.
- Se agregó una cabecera de sección de resultados con títulos y el botón `Limpiar resultados`, junto con estilos (`carga__estado-header`, `carga__estado-titulo`, etc.).
- Se mejoró el mensaje de confirmación al manejar `ArchivoDuplicadoError` para incluir el nombre del archivo (`resultado.archivo.name`) antes de preguntar por el reemplazo.

### Testing
- No automated tests were run as part of this change.
- Manual build/run was not executed in this environment (frontend UI changes only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fff85089483208514a173ef52c465)