### PR TITLE
Add inicio quick steps and status summary

### DIFF
--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -56,6 +56,7 @@ export class ArchivosGuardadosComponent implements OnInit {
   descargar(registro: RegistroArchivo): void {
     try {
       this.archivoStorageService.descargarRegistro(registro);
+      this.registrarDescarga(registro.nombre);
       this.mensajeError = null;
     } catch (error) {
       this.mensajeError =
@@ -133,6 +134,7 @@ export class ArchivosGuardadosComponent implements OnInit {
       enlace.click();
       document.body.removeChild(enlace);
       URL.revokeObjectURL(url);
+      this.registrarDescarga(enlace.download);
     } catch (error) {
       return;
     }
@@ -188,6 +190,14 @@ export class ArchivosGuardadosComponent implements OnInit {
         registro.nombre
       }|${registro.fechaGuardado}`;
     return `${this.pdfStoragePrefix}:${claveEstable}`;
+  }
+
+  private registrarDescarga(nombre: string): void {
+    const payload = {
+      nombre,
+      fecha: new Date().toISOString()
+    };
+    localStorage.setItem('ultima-descarga', JSON.stringify(payload));
   }
 }
 

--- a/web/frontend/src/app/components/inicio/inicio.component.html
+++ b/web/frontend/src/app/components/inicio/inicio.component.html
@@ -75,6 +75,38 @@
 
   </section>
 
+  <section class="flujo-rapido mt-4 mb-5">
+    <div class="flujo-rapido__encabezado">
+      <h3 class="flujo-rapido__titulo">Flujo rápido para subir y descargar resultados</h3>
+      <p class="flujo-rapido__descripcion">
+        Sigue estos pasos para completar tu envío y consultar el estado más reciente en tu navegador.
+      </p>
+    </div>
+    <ol class="flujo-rapido__pasos">
+      <li>Descargar plantilla</li>
+      <li>Validar archivo</li>
+      <li>Descargar resultados</li>
+    </ol>
+    <div class="flujo-rapido__acciones">
+      <a class="flujo-rapido__boton flujo-rapido__boton--primario" routerLink="/carga-masiva">
+        Cargar archivo
+      </a>
+      <a class="flujo-rapido__boton flujo-rapido__boton--secundario" routerLink="/archivos-preescolar">
+        Ver archivos guardados
+      </a>
+    </div>
+    <div class="flujo-rapido__estado">
+      <div class="flujo-rapido__tarjeta">
+        <span class="flujo-rapido__etiqueta">{{ resumenCarga.etiqueta }}</span>
+        <p class="flujo-rapido__detalle">{{ resumenCarga.detalle }}</p>
+      </div>
+      <div class="flujo-rapido__tarjeta">
+        <span class="flujo-rapido__etiqueta">{{ resumenDescarga.etiqueta }}</span>
+        <p class="flujo-rapido__detalle">{{ resumenDescarga.detalle }}</p>
+      </div>
+    </div>
+  </section>
+
   <section class="acciones-captura mt-5 mb-10">
     <h3 class="acciones-captura__titulo">Elige cómo registrar tus movimientos</h3>
     <p class="acciones-captura__descripcion">

--- a/web/frontend/src/app/components/inicio/inicio.component.scss
+++ b/web/frontend/src/app/components/inicio/inicio.component.scss
@@ -275,6 +275,150 @@ $gray-light: #f7f7f7;
 }
 
 /* ==========================================================================
+   FLUJO RÁPIDO
+   ========================================================================== */
+
+.flujo-rapido {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  @media (max-width: 768px) {
+    padding: 2rem 1.5rem;
+  }
+}
+
+.flujo-rapido__encabezado {
+  text-align: center;
+}
+
+.flujo-rapido__titulo {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: $dark-green-color;
+  margin-bottom: 0.5rem;
+}
+
+.flujo-rapido__descripcion {
+  font-size: 1.5rem;
+  color: #374151;
+  margin: 0;
+}
+
+.flujo-rapido__pasos {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  counter-reset: pasos;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+  }
+
+  li {
+    position: relative;
+    background: #f8fafc;
+    border-radius: 16px;
+    padding: 1.25rem 1.5rem 1.25rem 4rem;
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: #111827;
+    counter-increment: pasos;
+
+    &::before {
+      content: counter(pasos);
+      position: absolute;
+      left: 1.5rem;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      background: $sep-burgundy;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 1.1rem;
+    }
+  }
+}
+
+.flujo-rapido__acciones {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.flujo-rapido__boton {
+  border-radius: 999px;
+  padding: 0.85rem 2.5rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
+  }
+}
+
+.flujo-rapido__boton--primario {
+  background: $sep-burgundy;
+  color: #fff;
+}
+
+.flujo-rapido__boton--secundario {
+  background: #fff;
+  color: $sep-burgundy;
+  border: 2px solid $sep-burgundy;
+}
+
+.flujo-rapido__estado {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.flujo-rapido__tarjeta {
+  background: #fef7f4;
+  border-radius: 16px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.flujo-rapido__etiqueta {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: $sep-burgundy;
+}
+
+.flujo-rapido__detalle {
+  font-size: 1.4rem;
+  color: #111827;
+  margin: 0;
+}
+
+/* ==========================================================================
    TARJETAS
    ========================================================================== */
 

--- a/web/frontend/src/app/components/inicio/inicio.component.ts
+++ b/web/frontend/src/app/components/inicio/inicio.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 
 @Component({
@@ -8,7 +8,9 @@ import { Router, RouterModule } from '@angular/router';
   templateUrl: './inicio.component.html',
   styleUrl: './inicio.component.scss'
 })
-export class InicioComponent {
+export class InicioComponent implements OnInit {
+  readonly resumenCarga = this.crearResumenVacio('Última carga');
+  readonly resumenDescarga = this.crearResumenVacio('Última descarga');
 
   usuarioAutenticado = false;
   readonly llaveMxImage =
@@ -18,6 +20,14 @@ export class InicioComponent {
 
   constructor(private readonly router: Router) {}
 
+  ngOnInit(): void {
+    const ultimaCarga = this.obtenerUltimaCarga();
+    const ultimaDescarga = this.obtenerUltimaDescarga();
+
+    this.resumenCarga.detalle = ultimaCarga;
+    this.resumenDescarga.detalle = ultimaDescarga;
+  }
+
   llaveMx(): void {
     // TODO: Integrar redirección a LlaveMX cuando esté disponible
     console.log('Redirigir a registro de LlaveMX');
@@ -26,5 +36,67 @@ export class InicioComponent {
   iniciarSesion(): void {
     void this.router.navigate(['/login'], { queryParams: { redirect: '/carga-masiva' } });
   }
-}
 
+  private obtenerUltimaCarga(): string {
+    const data = localStorage.getItem('archivos-preescolar');
+    if (!data) {
+      return 'Sin cargas registradas.';
+    }
+
+    try {
+      const registrosPorCorreo = JSON.parse(data) as Record<
+        string,
+        Array<{ nombre: string; fechaGuardado: string }>
+      >;
+      const registros = Object.values(registrosPorCorreo).flat();
+      if (!registros.length) {
+        return 'Sin cargas registradas.';
+      }
+
+      const ultimo = registros.reduce((actual, siguiente) =>
+        siguiente.fechaGuardado > actual.fechaGuardado ? siguiente : actual
+      );
+      return `${ultimo.nombre} • ${this.formatearFecha(ultimo.fechaGuardado)}`;
+    } catch (error) {
+      console.error('No se pudo leer el historial de cargas', error);
+      return 'No disponible.';
+    }
+  }
+
+  private obtenerUltimaDescarga(): string {
+    const data = localStorage.getItem('ultima-descarga');
+    if (!data) {
+      return 'Sin descargas registradas.';
+    }
+
+    try {
+      const parsed = JSON.parse(data) as { nombre?: string; fecha?: string };
+      const nombre = parsed?.nombre?.trim();
+      const fecha = parsed?.fecha;
+      if (!fecha) {
+        return 'Sin descargas registradas.';
+      }
+      const detalleFecha = this.formatearFecha(fecha);
+      return nombre ? `${nombre} • ${detalleFecha}` : detalleFecha;
+    } catch (error) {
+      console.error('No se pudo leer el historial de descargas', error);
+      return 'No disponible.';
+    }
+  }
+
+  private formatearFecha(fechaIso: string): string {
+    const fecha = new Date(fechaIso);
+    if (Number.isNaN(fecha.getTime())) {
+      return 'Fecha no válida';
+    }
+
+    return new Intl.DateTimeFormat('es-MX', {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(fecha);
+  }
+
+  private crearResumenVacio(etiqueta: string): { etiqueta: string; detalle: string } {
+    return { etiqueta, detalle: 'Cargando...' };
+  }
+}


### PR DESCRIPTION
### Motivation
- Proveer una sección de “flujo rápido” en la página de inicio que guíe al usuario con pasos numerados y accesos directos para `Cargar archivo` y `Ver archivos guardados`.
- Mostrar un resumen del estado más reciente de cargas/descargas leyendo del `localStorage` para dar retroalimentación inmediata sin backend.
- Registrar la última descarga en el navegador para poder mostrarla en el resumen de inicio.

### Description
- Se agregó la sección visual al inicio modificando `web/frontend/src/app/components/inicio/inicio.component.html` y sus estilos en `inicio.component.scss` con pasos numerados, botones y tarjetas de estado. 
- Se implementó la lectura de `localStorage` en `InicioComponent` (`inicio.component.ts`) para poblar `resumenCarga` usando la clave `archivos-preescolar` y `resumenDescarga` usando la clave `ultima-descarga` en `ngOnInit` y utilidades de formateo de fecha. 
- Se añadió la función `registrarDescarga` y llamadas a ella en `ArchivosGuardadosComponent` (`archivos-guardados.component.ts`) para almacenar `{ nombre, fecha }` en `localStorage` bajo `ultima-descarga` cada vez que se descarga un archivo o PDF. 
- Cambios de estilo y estructura HTML/TS relacionados para integrarlo con las rutas existentes (`/carga-masiva` y `/archivos-preescolar`) y mantener la experiencia responsive.

### Testing
- Intenté levantar la app con `npm run start -- --host 0.0.0.0 --port 4200` para verificar el build y la UI en caliente. 
- El build falló con errores `TS2307: Cannot find module 'sweetalert2'` durante la compilación del proyecto, por lo que no se completó el arranque del servidor. 
- No se ejecutaron pruebas unitarias automáticas adicionales durante esta verificación. 
- Los cambios de código fueron verificados localmente en los archivos modificados y compilación intentada pero bloqueada por la dependencia faltante.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69600111cd948320a668c6e4bba340a4)