### PR TITLE
Admin login: show/hide password, help message, disable submit when empty

### DIFF
--- a/web/frontend/src/app/components/admin-login/admin-login.component.html
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.html
@@ -27,19 +27,36 @@
       />
 
       <label for="contrasena-admin">Contraseña</label>
-      <input
-        id="contrasena-admin"
-        name="contrasena"
-        type="password"
-        required
-        [(ngModel)]="contrasena"
-        autocomplete="current-password"
-        placeholder="********"
-      />
+      <div class="admin-login__password">
+        <input
+          id="contrasena-admin"
+          name="contrasena"
+          [type]="mostrarContrasena ? 'text' : 'password'"
+          required
+          [(ngModel)]="contrasena"
+          autocomplete="current-password"
+          placeholder="********"
+        />
+        <button
+          class="admin-login__toggle"
+          type="button"
+          (click)="toggleMostrarContrasena()"
+          [attr.aria-pressed]="mostrarContrasena"
+        >
+          {{ mostrarContrasena ? 'Ocultar' : 'Mostrar' }}
+        </button>
+      </div>
 
       <div class="admin-login__error" *ngIf="error">{{ error }}</div>
+      <p class="admin-login__help" *ngIf="error">
+        Si las credenciales no son válidas, contacta al equipo de soporte para restablecer el acceso.
+      </p>
 
-      <button class="admin-login__submit" type="submit" [disabled]="loginForm.invalid || autenticando">
+      <button
+        class="admin-login__submit"
+        type="submit"
+        [disabled]="loginForm.invalid || !correo || !contrasena || autenticando"
+      >
         {{ autenticando ? 'Validando...' : 'Iniciar sesión' }}
       </button>
     </form>

--- a/web/frontend/src/app/components/admin-login/admin-login.component.scss
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.scss
@@ -80,12 +80,47 @@
   width: 100%;
 }
 
+.admin-login__password {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.admin-login__password input {
+  padding-right: 5.5rem;
+}
+
+.admin-login__toggle {
+  position: absolute;
+  right: 0.55rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  color: #611232;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+}
+
+.admin-login__toggle:focus-visible {
+  outline: 2px solid #9d2449;
+  outline-offset: 2px;
+}
+
 .admin-login__error {
   margin-top: 0.75rem;
   padding: 0.75rem 1rem;
   border-radius: 10px;
   background: #ffe4e6;
   color: #611232;
+}
+
+.admin-login__help {
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+  color: #4b5563;
 }
 
 .admin-login__submit {

--- a/web/frontend/src/app/components/admin-login/admin-login.component.ts
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.ts
@@ -15,6 +15,7 @@ import { AdminAuthService } from '../../services/admin-auth.service';
 export class AdminLoginComponent {
   correo = '';
   contrasena = '';
+  mostrarContrasena = false;
   error: string | null = null;
   autenticando = false;
 
@@ -47,5 +48,9 @@ export class AdminLoginComponent {
     } finally {
       this.autenticando = false;
     }
+  }
+
+  toggleMostrarContrasena(): void {
+    this.mostrarContrasena = !this.mostrarContrasena;
   }
 }


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia de inicio de sesión del administrador añadiendo instrucciones de ayuda cuando las credenciales fallan.  
- Permitir al usuario ver/ocultar la contraseña para reducir errores de tipeo.  
- Evitar envíos inválidos deshabilitando el botón de envío mientras falten datos o durante la autenticación.

### Description
- Añadido el booleano `mostrarContrasena` y la función `toggleMostrarContrasena()` en `AdminLoginComponent` para controlar la visibilidad de la contraseña.  
- Reemplazado el input de contraseña en `admin-login.component.html` por un bloque con `input` cuyo `type` es `mostrarContrasena ? 'text' : 'password'` y un botón toggle que llama a `toggleMostrarContrasena()`.  
- Agregado un mensaje de ayuda visible cuando hay `error` y cambiado la condición del botón a `[disabled]="loginForm.invalid || !correo || !contrasena || autenticando"` para evitar envíos con campos vacíos.  
- Incorporados estilos en `admin-login.component.scss` para `.admin-login__password`, `.admin-login__toggle` y `.admin-login__help`.

### Testing
- Se intentó instalar dependencias con `npm install` en `web/frontend`, pero la instalación falló con un `403 Forbidden` al descargar `sweetalert2`, por lo que las pruebas automáticas no pudieron ejecutarse.  
- No se ejecutaron tests automatizados por la falla en la instalación de dependencias.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69600658112c8320abb0ce9c7a61326f)