### PR TITLE
Use eye icons for password toggles with text fallback

### DIFF
--- a/web/frontend/src/app/components/admin-login/admin-login.component.html
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.html
@@ -43,7 +43,12 @@
           (click)="toggleMostrarContrasena()"
           [attr.aria-pressed]="mostrarContrasena"
         >
-          {{ mostrarContrasena ? 'Ocultar' : 'Mostrar' }}
+          <i
+            class="bi"
+            [ngClass]="mostrarContrasena ? 'bi-eye-slash' : 'bi-eye'"
+            aria-hidden="true"
+          ></i>
+          <span class="admin-login__toggle-text">{{ mostrarContrasena ? 'Ocultar' : 'Mostrar' }}</span>
         </button>
       </div>
 

--- a/web/frontend/src/app/components/admin-login/admin-login.component.scss
+++ b/web/frontend/src/app/components/admin-login/admin-login.component.scss
@@ -102,11 +102,18 @@
   cursor: pointer;
   padding: 0.35rem 0.5rem;
   border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .admin-login__toggle:focus-visible {
   outline: 2px solid #9d2449;
   outline-offset: 2px;
+}
+
+.admin-login__toggle-text {
+  font-size: 0.95rem;
 }
 
 .admin-login__error {

--- a/web/frontend/src/app/components/login/login.component.html
+++ b/web/frontend/src/app/components/login/login.component.html
@@ -29,7 +29,12 @@
           placeholder="Clave enviada en tu primer carga"
         />
         <button class="login__toggle" type="button" (click)="mostrarContrasena = !mostrarContrasena">
-          {{ mostrarContrasena ? 'Ocultar' : 'Mostrar' }}
+          <i
+            class="bi"
+            [ngClass]="mostrarContrasena ? 'bi-eye-slash' : 'bi-eye'"
+            aria-hidden="true"
+          ></i>
+          <span class="login__toggle-text">{{ mostrarContrasena ? 'Ocultar' : 'Mostrar' }}</span>
         </button>
       </div>
       <p class="login__hint">Usa la contraseña generada en tu primer envío.</p>

--- a/web/frontend/src/app/components/login/login.component.scss
+++ b/web/frontend/src/app/components/login/login.component.scss
@@ -87,12 +87,19 @@ input:focus {
   color: #2e7d32;
   font-weight: 600;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .login__toggle:focus {
   outline: 2px solid rgba(46, 125, 50, 0.4);
   outline-offset: 2px;
   border-radius: 6px;
+}
+
+.login__toggle-text {
+  font-size: 0.95rem;
 }
 
 .login__hint {

--- a/web/frontend/src/index.html
+++ b/web/frontend/src/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://framework-gb.cdn.gob.mx/gm/v3/assets/images/favicon.ico" rel="shortcut icon">
   <link rel="stylesheet" href="https://framework-gb.cdn.gob.mx/gm/v3/assets/styles/main.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
### Motivation
- Improve the password visibility toggles by showing an eye icon instead of only the words `Mostrar`/`Ocultar` for a more compact UI. 
- Keep the existing text as a fallback so the label is still visible if the icon font fails to load. 
- Use the existing Bootstrap tooling by adding Bootstrap Icons so the eye/eye-slash glyphs are available. 

### Description
- Added Bootstrap Icons stylesheet link in `web/frontend/src/index.html` to load `bootstrap-icons.min.css`. 
- Replaced plain toggle text in `login.component.html` and `admin-login.component.html` with an icon element `<i class="bi" [ngClass]="...">` plus a text `<span>` fallback. 
- Adjusted toggle button styles in `login.component.scss` and `admin-login.component.scss` to use `inline-flex`, center the icon and label, and added `.login__toggle-text` / `.admin-login__toggle-text` font sizing. 

### Testing
- No automated tests were executed for this change. 
- Manual visual verification is recommended to ensure the icon displays and the fallback text remains accessible when icons are unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fee975b2883209c9bfc432f35a54a)