### PR TITLE
Remove email match validation on upload

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
@@ -113,27 +113,4 @@ describe('CargaMasivaComponent', () => {
     expect(component.resultados[0].errores[0]).toContain('Formato no permitido');
   });
 
-  it('should block when Excel email differs from the form', async () => {
-    const excelService = TestBed.inject(
-      ExcelValidationService
-    ) as unknown as ExcelValidationServiceStub;
-    excelService.resultado = {
-      ...resultadoValido,
-      esc: { ...resultadoValido.esc!, correo: 'otro@correo.mx' }
-    };
-
-    component.correoControl.setValue('demo@correo.mx');
-    const input = document.createElement('input');
-    const archivo = new File(['contenido'], 'archivo.xlsx', {
-      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    });
-    Object.defineProperty(input, 'files', { value: [archivo] });
-
-    await component.onArchivoSeleccionado({ target: input } as unknown as Event);
-
-    expect(component.resultados[0].estado).toBe('error');
-    expect(component.resultados[0].errores).toContain(
-      'El correo capturado debe coincidir con el que aparece en la hoja ESC del archivo.'
-    );
-  });
 });

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -381,17 +381,6 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const correoFormulario = this.correoControl.value.trim().toLowerCase();
-    const correoEnArchivo = (resultado.esc.correo ?? '').trim().toLowerCase();
-
-    if (correoFormulario !== correoEnArchivo) {
-      this.agregarErrores(resultadoArchivo, [
-        'El correo capturado debe coincidir con el que aparece en la hoja ESC del archivo.'
-      ]);
-      await this.finalizarConError(resultadoArchivo);
-      return;
-    }
-
     let habiaCredenciales = false;
     let nuevasCredenciales: { contrasena: string; esNueva: boolean } | null = null;
     const fechaDisponible = this.calcularFechaDisponible();


### PR DESCRIPTION
### Motivation
- The product decision changed so the system must not reject uploads when the form email differs from the email found in the Excel ESC sheet.  
- Uploads should still perform other validations and preserve credential handling for first-time/registered senders.  

### Description
- Deleted the runtime check in `CargaMasivaComponent.procesarResultado` that compared `correoControl` with `resultado.esc.correo` and returned an error.  
- Removed the unit test that asserted the component blocks when Excel email differs from the form in `carga-masiva.component.spec.ts`.  
- Kept existing credential validation and registration logic (`authService.coincidenCredenciales` and `authService.registrarCredenciales`) intact.  

### Testing
- No automated tests were executed as part of this change.  
- The spec that enforced the removed behavior was deleted to reflect the new requirement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960503235d483208e6bc3b6ce5663e4)