### PR TITLE
Adjust quick-flow spacing; ensure error PDFs have .pdf and relax upload credential checks

### DIFF
--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts
@@ -113,27 +113,4 @@ describe('CargaMasivaComponent', () => {
     expect(component.resultados[0].errores[0]).toContain('Formato no permitido');
   });
 
-  it('should block when Excel email differs from the form', async () => {
-    const excelService = TestBed.inject(
-      ExcelValidationService
-    ) as unknown as ExcelValidationServiceStub;
-    excelService.resultado = {
-      ...resultadoValido,
-      esc: { ...resultadoValido.esc!, correo: 'otro@correo.mx' }
-    };
-
-    component.correoControl.setValue('demo@correo.mx');
-    const input = document.createElement('input');
-    const archivo = new File(['contenido'], 'archivo.xlsx', {
-      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    });
-    Object.defineProperty(input, 'files', { value: [archivo] });
-
-    await component.onArchivoSeleccionado({ target: input } as unknown as Event);
-
-    expect(component.resultados[0].estado).toBe('error');
-    expect(component.resultados[0].errores).toContain(
-      'El correo capturado debe coincidir con el que aparece en la hoja ESC del archivo.'
-    );
-  });
 });

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -373,25 +373,6 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (!this.authService.coincidenCredenciales(resultado.esc.cct, resultado.esc.correo)) {
-      this.agregarErrores(resultadoArchivo, [
-        'El CCT y el correo deben coincidir con los registrados en tu primer envío.'
-      ]);
-      await this.finalizarConError(resultadoArchivo);
-      return;
-    }
-
-    const correoFormulario = this.correoControl.value.trim().toLowerCase();
-    const correoEnArchivo = (resultado.esc.correo ?? '').trim().toLowerCase();
-
-    if (correoFormulario !== correoEnArchivo) {
-      this.agregarErrores(resultadoArchivo, [
-        'El correo capturado debe coincidir con el que aparece en la hoja ESC del archivo.'
-      ]);
-      await this.finalizarConError(resultadoArchivo);
-      return;
-    }
-
     let habiaCredenciales = false;
     let nuevasCredenciales: { contrasena: string; esNueva: boolean } | null = null;
     const fechaDisponible = this.calcularFechaDisponible();
@@ -586,7 +567,8 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
     resultadoArchivo.pdfEstado = 'generando';
     resultadoArchivo.pdfMensaje = 'Creando PDF con el detalle de errores...';
     resultadoArchivo.pdfError = null;
-    resultadoArchivo.pdfNombre = `errores-${resultadoArchivo.archivo.name.replace(/\s+/g, '-')}`;
+    const nombreBase = resultadoArchivo.archivo.name.replace(/\s+/g, '-').replace(/\.[^/.]+$/, '');
+    resultadoArchivo.pdfNombre = `errores-${nombreBase}.pdf`;
 
     try {
       const blob = await this.mockPdfService.generarPdfErrores({

--- a/web/frontend/src/app/components/inicio/inicio.component.scss
+++ b/web/frontend/src/app/components/inicio/inicio.component.scss
@@ -326,7 +326,7 @@ $gray-light: #f7f7f7;
     position: relative;
     background: #f8fafc;
     border-radius: 16px;
-    padding: 1.25rem 1.5rem 1.25rem 4rem;
+    padding: 1.25rem 1.5rem 1.25rem 5rem;
     font-size: 1.4rem;
     font-weight: 600;
     color: #111827;
@@ -335,7 +335,7 @@ $gray-light: #f7f7f7;
     &::before {
       content: counter(pasos);
       position: absolute;
-      left: 1.5rem;
+      left: 1.25rem;
       top: 50%;
       transform: translateY(-50%);
       width: 34px;


### PR DESCRIPTION
### Motivation
- Fix visual overlap of the numbered badges and their labels in the quick-flow steps on the home page so the numbers no longer collide with the text.
- Ensure downloaded error reports are always delivered with a `.pdf` extension regardless of the uploaded filename.
- Stop blocking the upload when the ESC email/CCT in the file differ from form values to align with the updated product decision.

### Description
- Increased left padding for `.flujo-rapido__pasos li` and adjusted the counter badge `left` offset in `web/frontend/src/app/components/inicio/inicio.component.scss` to avoid overlapping the step text.
- Updated `generarPdfErrores` in `web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts` to compute a base name with `replace(/\s+/g, '-')` and `replace(/\.[^/.]+$/, '')` and set `resultadoArchivo.pdfNombre = \`errores-${nombreBase}.pdf\`.
- Removed the runtime blocking checks that enforced credential/email equality inside `procesarResultado` so uploads no longer fail for mismatched ESC email/CCT.
- Deleted the unit test that asserted blocking on Excel/form email mismatch in `web/frontend/src/app/components/carga-masiva/carga-masiva.component.spec.ts` to reflect the new behavior.

### Testing
- Built and served the frontend with `npm --prefix web/frontend start`, and the Angular dev server completed a successful build.
- Executed a Playwright script to load the home page and capture a screenshot (`artifacts/inicio-flujo-rapido.png`) to verify layout changes.
- No unit test suite (`npm test`) was run as part of this change.
- The automated build and screenshot generation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960503235d483208e6bc3b6ce5663e4)