### PR TITLE
Update docs to GraphQL backend and add December deliverable report

### DIFF
--- a/web/doc/arquitectura_software.md
+++ b/web/doc/arquitectura_software.md
@@ -13,8 +13,8 @@ Describe la arquitectura de alto nivel para la plataforma que **recibe archivos 
 
 Arquitectura web de tres capas y procesos desacoplados:
 
-1. **Capa de presentación:** SPA en **Angular 19 (signals)** para carga anónima, descarga de PDFs y portal autenticado de descargas, usando la guía gráfica gob.mx v3 cargada desde CDN. Mientras el backend Python es desarrollado por otro equipo, el frontend operará con servicios simulados y datos de prueba almacenados en memoria/localStorage, manteniendo las mismas interfaces para conmutar a la API real sin cambios.
-2. **Capa de lógica de negocio:** API **FastAPI (Python 3.12)** para orquestar validaciones, generación de credenciales y publicación de ligas (implementada por un equipo distinto).
+1. **Capa de presentación:** SPA en **Angular 19 (signals)** para carga anónima, descarga de PDFs y portal autenticado de descargas, usando la guía gráfica gob.mx v3 cargada desde CDN. Mientras el backend GraphQL es desarrollado por otro equipo, el frontend operará con servicios simulados y datos de prueba almacenados en memoria/localStorage, manteniendo las mismas interfaces para conmutar a la API real sin cambios.
+2. **Capa de lógica de negocio:** API **GraphQL** para orquestar validaciones, generación de credenciales y publicación de ligas (implementada por un equipo distinto).
 3. **Capa de datos y archivos:** **PostgreSQL** para solicitudes/credenciales y **filesystem SSD** para repositorios separados de recepción y resultados.
 4. **Procesamiento asíncrono:** Workers (Redis + RQ/Celery) para validaciones y armado de PDFs.
 
@@ -45,7 +45,7 @@ Arquitectura web de tres capas y procesos desacoplados:
   - Listado de versiones de resultados (consecutivo + liga) depositados por el sistema externo.
   - Reutiliza la autenticación para permitir reenvío de archivos cuando ya existan credenciales.
 - **Servicios de integración frontend**
-  - Interfaces Angular tipificadas hacia FastAPI para carga, login y descargas.
+  - Interfaces Angular tipificadas hacia GraphQL para carga, login y descargas.
   - Mientras no exista backend disponible, devuelven datos simulados/localStorage con la misma forma de respuesta que los futuros endpoints.
 - **Panel técnico**
   - Monitoreo de logs, espacio en disco y estado de workers.
@@ -62,7 +62,7 @@ flowchart LR
     D[Escuela autenticada
     Descargas] --> B
 
-    B --> API[API FastAPI]
+    B --> API[API GraphQL]
     API --> W[Workers
     Validación/PDF]
     API --> DB[(PostgreSQL
@@ -78,11 +78,11 @@ flowchart LR
 ## 5. Decisiones tecnológicas clave
 
 - **Frontend:** Angular 19 + TypeScript (signals) con Angular CLI 19.2.x sobre Node 22.x y estilos base gob.mx v3 incluidos vía CDN en `index.html`. Los servicios Angular expondrán interfaces HTTP tipificadas; mientras no exista backend disponible, responderán con datos simulados/localStorage pero sin romper la forma de los endpoints.
-- **Backend:** Python 3.12 + FastAPI (desarrollado por un equipo distinto; la integración del frontend será transparente gracias a la capa de servicios simulados).
+- **Backend:** GraphQL (desarrollado por un equipo distinto; la integración del frontend será transparente gracias a la capa de servicios simulados).
 - **Workers:** Redis + RQ/Celery para validación y generación de PDFs.
 - **Persistencia:** PostgreSQL (datos) + Filesystem SSD (archivos válidos y resultados).
-- **Generación de PDF:** WeasyPrint/ReportLab o librería equivalente en Python.
-- **Validación de Excel:** pandas + openpyxl.
+- **Generación de PDF:** librería equivalente en el stack del backend.
+- **Validación de Excel:** librería equivalente en el stack del backend.
 - **Protocolos:** HTTPS obligatorio.
 
 ---
@@ -101,4 +101,4 @@ flowchart LR
 - Workers horizontales para paralelizar validaciones y PDFs.
 - Posibilidad de crecer almacenamiento sin interrumpir servicio (mínimo 1 TB inicial).
 - Separación de repositorios evita contención entre cargas y descargas.
-- Balanceo de carga sobre FastAPI si incrementa el volumen (objetivo: 120,000 validaciones).
+- Balanceo de carga sobre GraphQL si incrementa el volumen (objetivo: 120,000 validaciones).

--- a/web/doc/casos_uso.md
+++ b/web/doc/casos_uso.md
@@ -75,7 +75,7 @@ flowchart LR
    - Actores: Escuela (autenticada), Sistema externo de resultados
    - Descripción: Muestra consecutivos y ligas depositadas por el sistema externo para la escuela autenticada.
 
-**Nota de implementación temporal:** mientras el backend FastAPI es construido por otro equipo, los casos de uso CU-01 a CU-07 se ejecutarán en el frontend con servicios simulados y datos de prueba/localStorage que imitan las respuestas esperadas. Cuando los endpoints estén disponibles, se cambiará la fuente de datos sin modificar los flujos de usuario.
+**Nota de implementación temporal:** mientras el backend GraphQL es construido por otro equipo, los casos de uso CU-01 a CU-07 se ejecutarán en el frontend con servicios simulados y datos de prueba/localStorage que imitan las respuestas esperadas. Cuando las operaciones estén disponibles, se cambiará la fuente de datos sin modificar los flujos de usuario.
 
 ---
 

--- a/web/doc/entregables/01_Diagrama_Arquitectura_MUSES_Web.md
+++ b/web/doc/entregables/01_Diagrama_Arquitectura_MUSES_Web.md
@@ -1,0 +1,162 @@
+# DIAGRAMA DE ARQUITECTURA Y COMPONENTES DE LOS SISTEMAS WEB<br>EN DESARROLLO, DETALLANDO LA ESTRUCTURA LÓGICA Y TECNOLÓGICA<br>INCLUYENDO MÓDULOS DE ANGULAR, SERVICIOS API Y CONEXIONES<br>GRAPHQL
+
+**Periodo reportado:** diciembre y primera semana de enero.
+
+---
+
+## 1. Resumen ejecutivo del periodo
+
+Durante el periodo reportado se consolidó la visión arquitectónica del sistema web, se detallaron los componentes funcionales y se definieron las capas tecnológicas que soportan la recepción, validación y distribución de archivos. El frontend se planteó como una SPA en Angular 19 con integración a una API GraphQL (a cargo de un equipo externo), manteniendo un esquema de servicios simulados para continuar el avance mientras el backend se implementa. Asimismo, se documentaron los módulos clave de la aplicación y el flujo de integración con servicios de validación, generación de PDFs y persistencia en PostgreSQL + filesystem.
+
+---
+
+## 2. Alcance de la arquitectura (diciembre – primera semana de enero)
+
+- Definición de arquitectura de tres capas (presentación, lógica de negocio y datos/archivos).
+- Identificación de componentes funcionales: recepción anónima, reenvío autenticado, validación, credenciales/PDFs y descargas.
+- Estandarización de servicios de integración en frontend con contratos alineados a GraphQL.
+- Identificación de tecnologías clave: Angular 19 (signals), GraphQL, Redis + workers, PostgreSQL y filesystem SSD.
+
+---
+
+## 3. Diagrama de arquitectura (alto nivel)
+
+```mermaid
+flowchart LR
+    U[Escuela
+    Carga anónima] --> B[Browser
+    Angular 19]
+    D[Escuela autenticada
+    Descargas] --> B
+
+    B --> API[API GraphQL]
+    API --> W[Workers
+    Validación/PDF]
+    API --> DB[(PostgreSQL
+    Solicitudes/Credenciales)]
+    API --> FS1[(Repo recepción
+    Archivos válidos)]
+    API --> FS2[(Repo resultados
+    Ligas/ZIP externos)]
+```
+
+**Notas clave:**
+- La comunicación entre el frontend y la API se realizará vía operaciones GraphQL (queries/mutations).
+- Los workers procesan validaciones y generación de PDFs de manera asíncrona.
+- La persistencia combina base de datos relacional y repositorios de archivos en filesystem.
+
+---
+
+## 4. Diagrama de componentes (lógico-funcional)
+
+```mermaid
+flowchart TB
+    subgraph Frontend[SPA Angular 19]
+        R1[Módulo de recepción anónima]
+        R2[Módulo de reenvío autenticado]
+        R3[Módulo de descargas autenticadas]
+        R4[Módulo de autenticación]
+        R5[Panel técnico (monitoreo)]
+        S1[Servicios de integración GraphQL]
+
+        R1 --> S1
+        R2 --> S1
+        R3 --> S1
+        R4 --> S1
+        R5 --> S1
+    end
+
+    subgraph Backend[API GraphQL + Workers]
+        GQL[API GraphQL]
+        VAL[Motor de validación]
+        PDF[Generador de PDFs]
+        AUTH[Gestión de credenciales]
+    end
+
+    subgraph Datos[Persistencia]
+        DB[(PostgreSQL)]
+        FS1[(Repositorio recepción)]
+        FS2[(Repositorio resultados)]
+    end
+
+    S1 --> GQL
+    GQL --> VAL
+    GQL --> PDF
+    GQL --> AUTH
+    GQL --> DB
+    GQL --> FS1
+    GQL --> FS2
+```
+
+---
+
+## 5. Estructura lógica y tecnológica
+
+| Capa | Responsabilidad | Tecnologías/Componentes | Estado (dic–ene) |
+| --- | --- | --- | --- |
+| Presentación | SPA, flujos de carga y descargas, navegación | Angular 19 (signals), guía gráfica gob.mx v3 | Definición y estructura modular documentada |
+| Lógica de negocio | Orquestación de validaciones, credenciales, PDFs y ligas | API GraphQL, Workers (Redis + colas) | Contratos y operaciones definidos; integración pendiente con backend externo |
+| Datos/Archivos | Persistencia de solicitudes, credenciales y repositorios | PostgreSQL, filesystem SSD | Modelado conceptual documentado |
+
+---
+
+## 6. Módulos Angular definidos/creados
+
+Los módulos listados corresponden a la estructura definida para el avance del frontend en este periodo:
+
+1. **Recepción anónima**
+   - Carga inicial de archivo .xlsx sin autenticación.
+   - Mensajes de validación en línea.
+2. **Reenvío autenticado**
+   - Requiere login si ya existen credenciales para CCT/correo.
+3. **Autenticación**
+   - Inicio de sesión para descargas y reenvíos posteriores.
+4. **Descargas autenticadas**
+   - Listado de versiones de resultados y ligas de descarga.
+5. **Panel técnico**
+   - Monitoreo básico de logs, estado de workers y espacio en disco.
+
+---
+
+## 7. Servicios, API y conexiones GraphQL
+
+### 7.1 Principios de integración
+
+- El frontend opera con servicios simulados/localStorage mientras el backend GraphQL se implementa.
+- Las firmas de servicios se definen desde ahora para alinear queries/mutations reales sin refactor.
+
+### 7.2 Operaciones GraphQL previstas (ejemplo de contratos)
+
+- **Mutation: `uploadFile`**
+  - Entrada: metadatos de escuela + archivo .xlsx.
+  - Salida: estado de validación y referencia de PDF.
+- **Mutation: `authenticate`**
+  - Entrada: CCT + contraseña.
+  - Salida: token de sesión.
+- **Query: `downloadLinks`**
+  - Entrada: CCT autenticado.
+  - Salida: lista de versiones y ligas de descarga.
+- **Mutation: `resubmitFile`**
+  - Entrada: archivo y credenciales válidas.
+  - Salida: estado de validación y nueva referencia.
+
+---
+
+## 8. Evidencias de avance (diciembre – primera semana de enero)
+
+- Arquitectura de referencia documentada con capas y componentes principales.
+- Flujos funcionales y módulos Angular definidos para recepción, validación y descargas.
+- Contratos de integración establecidos con enfoque en GraphQL.
+- Definición de tecnologías y dependencias (Angular 19, Redis + workers, PostgreSQL, filesystem).
+
+---
+
+## 9. Próximos pasos inmediatos
+
+- Validación con el equipo de backend sobre el esquema de operaciones GraphQL.
+- Implementación de servicios Angular con endpoints reales cuando estén disponibles.
+- Desarrollo incremental de módulos y pruebas de integración.
+
+---
+
+**Responsable del informe:** Equipo de desarrollo web

--- a/web/doc/glosario.md
+++ b/web/doc/glosario.md
@@ -14,8 +14,8 @@
 - **SPA (Single Page Application):** Aplicación web de una sola página; el shell se carga una vez y las vistas cambian en el cliente sin recargar todo el documento. En este proyecto se implementa con Angular 19 y signals.
 - **Angular 19 (signals):** Framework para el frontend; habilita el modelo reactivo con signals.
 - **Guía gráfica gob.mx v3:** Estándar de diseño y estilos de la Administración Pública; se incluye desde CDN (`main.css`, `gobmx.js`, `main.js`) en `index.html`.
-- **FastAPI:** Framework de backend en Python 3.12 utilizado para la API.
+- **GraphQL:** Lenguaje de consulta y runtime de API utilizado para el backend.
 - **PostgreSQL:** Base de datos que guarda solicitudes, credenciales y bitácoras.
 - **Redis + RQ/Celery:** Infraestructura de workers para validaciones y generación de PDFs.
-- **Servicios simulados (frontend):** Implementaciones Angular que devuelven datos de prueba/localStorage con el mismo contrato HTTP que ofrecerá FastAPI, permitiendo cambiar a endpoints reales sin reescribir componentes.
-- **Equipo backend externo:** Grupo responsable de construir la API FastAPI; el frontend se prepara para integrarse cuando los endpoints estén disponibles.
+- **Servicios simulados (frontend):** Implementaciones Angular que devuelven datos de prueba/localStorage con el mismo contrato de operaciones que ofrecerá GraphQL, permitiendo cambiar a endpoints reales sin reescribir componentes.
+- **Equipo backend externo:** Grupo responsable de construir la API GraphQL; el frontend se prepara para integrarse cuando los endpoints estén disponibles.

--- a/web/doc/plan_iteraciones.md
+++ b/web/doc/plan_iteraciones.md
@@ -42,13 +42,13 @@
 ### Iteración E2 – Diseño arquitectónico y tecnológico
 
 **Objetivos:**
-- Definir arquitectura FastAPI + Angular 19 (signals) + workers Redis (validación/PDF) con lineamientos de estilo gob.mx v3 incluidos desde CDN en `index.html`.
+- Definir arquitectura GraphQL + Angular 19 (signals) + workers Redis (validación/PDF) con lineamientos de estilo gob.mx v3 incluidos desde CDN en `index.html`.
 - Diseñar separación de repositorios (recepción vs. resultados) y capacidad mínima de 1 TB.
 - Planear integración con sistema externo de resultados (ingesta de ligas/archivos).
 
 **Entregables:**
 - SAD actualizado.
-- Prototipo técnico mínimo: endpoint FastAPI de validación simulada + pantalla Angular de carga anónima con estado “Validando tu archivo…” usando la guía gráfica gob.mx.
+- Prototipo técnico mínimo: operación GraphQL de validación simulada + pantalla Angular de carga anónima con estado “Validando tu archivo…” usando la guía gráfica gob.mx.
 
 **Criterios de Aceptación:**
 
@@ -76,12 +76,12 @@
 - Repositorio de recepción operativo (filesystem + registros en PostgreSQL).
 
 **Plan de trabajo detallado – SPA Angular 19 (signals) con guía gob.mx v3**
-- **Punto de partida:** Angular CLI 19.2.x ya instalado; `index.html` incluye los assets de la guía gráfica gob.mx v3 desde CDN; el backend Python será construido por otro equipo.
+- **Punto de partida:** Angular CLI 19.2.x ya instalado; `index.html` incluye los assets de la guía gráfica gob.mx v3 desde CDN; el backend GraphQL será construido por otro equipo.
 - **¿Qué es SPA?** Una Single Page Application: el shell se renderiza una vez y las vistas cambian en el navegador (sin recargar toda la página) usando enrutamiento de Angular.
 - **Pasos previstos:**
   1. Definir rutas iniciales (`/` carga anónima, `/login`, `/descargas`) y un layout base que use los estilos gob.mx ya cargados.
   2. Crear el componente de inicio/carga con signals para estado de archivo, progreso y mensajes ("Validando tu archivo...").
-  3. Implementar servicios HTTP y de estado con signals que hoy regresen datos simulados/localStorage, respetando las firmas esperadas del futuro backend FastAPI para conmutar sin cambios cuando esté listo.
+  3. Implementar servicios HTTP y de estado con signals que hoy regresen datos simulados/localStorage, respetando las firmas esperadas del futuro backend GraphQL para conmutar sin cambios cuando esté listo.
   4. Preparar componentes de autenticación y listado de descargas reutilizando la guía gráfica (tablas, alerts, botones) con datos de prueba.
   5. Validar accesibilidad y consistencia visual con la guía gráfica en navegación SPA (sin recargas completas) y documentar cómo activar la fuente de datos real cuando esté disponible.
 
@@ -89,7 +89,7 @@
 
 **Objetivos:**
 - Implementar login (CCT + contraseña generada) y módulo de descargas.
-- Consumir ligas/archivos provistos por el sistema externo y listarlos por versión/consecutivo (iniciando con datos simulados en frontend; conmutar a FastAPI en cuanto el equipo de backend entregue endpoints).
+- Consumir ligas/archivos provistos por el sistema externo y listarlos por versión/consecutivo (iniciando con datos simulados en frontend; conmutar a GraphQL en cuanto el equipo de backend entregue endpoints).
 - Ajustar monitoreo técnico (logs, espacio en disco, salud de workers).
 
 **Entregables:**

--- a/web/doc/riesgos.md
+++ b/web/doc/riesgos.md
@@ -3,11 +3,10 @@
 | ID | Tipo      | Descripción                                                                 | Prob. | Impacto | Estrategia de mitigación |
 |----|-----------|-----------------------------------------------------------------------------|-------|---------|---------------------------|
 | R1 | Operativo | Escuelas continúan usando correo en lugar de la carga anónima .xlsx         | Media | Alta    | Comunicación oficial, instrucciones claras en portal, monitoreo de buzones |
-| R2 | Técnico   | Sobrecarga de validaciones (pico cercano al cierre, objetivo 120,000)       | Alta  | Alta    | Escalar workers FastAPI/Redis, pruebas de carga, autoescalado en infraestructura |
+| R2 | Técnico   | Sobrecarga de validaciones (pico cercano al cierre, objetivo 120,000)       | Alta  | Alta    | Escalar workers GraphQL/Redis, pruebas de carga, autoescalado en infraestructura |
 | R3 | Datos     | Archivos con estructura/nombres de hoja alterados rompen validación         | Alta  | Media   | Validación estricta de 10 reglas (incluye hash para detectar duplicados por contenido), mensajes claros en PDF de errores, plantillas oficiales |
 | R4 | Seguridad | Compromiso de credenciales (CCT + contraseña correo validado)               | Media | Alta    | Hashing de contraseñas, HTTPS obligatorio, bitácora de accesos, bloqueo por intentos fallidos |
 | R5 | Integración | Retraso o falla en depósito de resultados por el sistema externo           | Media | Alta    | Acuerdos de entrega, monitoreo de repositorio de resultados, alertas tempranas |
 | R6 | Infraestructura | Falta de espacio en repositorios (mínimo 1 TB para recepción/resultados) | Media | Alta    | Monitoreo de disco, planes de expansión en caliente, limpieza controlada de archivos obsoletos |
 | R7 | Cambio    | Resistencia de usuarios a la credencial generada automáticamente            | Media | Media   | Manuales y FAQs, recordatorio en PDF de confirmación, soporte de mesa de ayuda |
-| R8 | Integración | Diferencias entre datos simulados en frontend y contratos reales de FastAPI (backend de otro equipo) | Media | Media | Definir contratos HTTP desde el inicio, documentar mocks/localStorage, pruebas de integración al habilitar endpoints |
-
+| R8 | Integración | Diferencias entre datos simulados en frontend y contratos reales de GraphQL (backend de otro equipo) | Media | Media | Definir contratos de operaciones desde el inicio, documentar mocks/localStorage, pruebas de integración al habilitar endpoints |

--- a/web/doc/srs.md
+++ b/web/doc/srs.md
@@ -37,7 +37,7 @@ La plataforma cubre únicamente el flujo de recepción–validación–descarga 
 ### 2.1 Perspectiva del producto
 
 ## 2.1 Perspectiva del producto
-Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend FastAPI en Python 3.12** y **almacenamiento PostgreSQL + Filesystem**. No realiza cálculos educativos; actúa como **pasarela de validación y distribución de archivos**. El backend Python será implementado por otro equipo; el frontend entregará pantallas funcionales con servicios Angular que hoy responden con datos de prueba/localStorage, pero conservan las mismas firmas HTTP para conmutar a FastAPI sin reescritura. La lógica de negocio debe **bloquear reenvíos anónimos** si ya existe una credencial previa para el mismo CCT/correo, solicitar autenticación antes de permitir la nueva carga y **registrar la huella (hash) de cada archivo** para distinguir versiones aunque el nombre sea idéntico.
+Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend GraphQL** y **almacenamiento PostgreSQL + Filesystem**. No realiza cálculos educativos; actúa como **pasarela de validación y distribución de archivos**. El backend GraphQL será implementado por otro equipo; el frontend entregará pantallas funcionales con servicios Angular que hoy responden con datos de prueba/localStorage, pero conservan las mismas firmas de operaciones (queries/mutations) para conmutar al backend real sin reescritura. La lógica de negocio debe **bloquear reenvíos anónimos** si ya existe una credencial previa para el mismo CCT/correo, solicitar autenticación antes de permitir la nueva carga y **registrar la huella (hash) de cada archivo** para distinguir versiones aunque el nombre sea idéntico.
 
 ### 2.2 Interfaces del sistema
 
@@ -52,12 +52,12 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend F
 - Uso de la **guía gráfica gob.mx v3** incluida desde CDN en `index.html`, con scripts auxiliares (`jquery.min.js`, `gobmx.js`, `main.js`) ya cargados.
 
 ### 2.2.2 Interfaces de hardware
-- Servidor de aplicaciones para FastAPI.
+- Servidor de aplicaciones para GraphQL.
 - Servidor de base de datos PostgreSQL.
 - Almacenamiento de archivos en disco SSD (mínimo 1 TB para recepción/resultados).
 
 ### 2.2.3 Interfaces de software
-- Librerías de manipulación de Excel (pandas + openpyxl o equivalente en el stack Python).
+- Librerías de manipulación de Excel (o equivalente en el stack del backend).
 - Conectores de base de datos para PostgreSQL.
 - Integración de cola de trabajos (Redis/RQ o Celery) para validaciones y generación de PDFs.
 - CDN de la guía gráfica gob.mx v3 referenciada en `index.html` (hoja de estilos principal y scripts `gobmx.js`/`main.js`).
@@ -118,7 +118,7 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 - RF-09: Habilitar autenticación (CCT + contraseña) para reenviar archivos y consultar las ligas de descarga.
 - RF-10: Mostrar **todas las versiones** de resultados que el sistema externo haya depositado, con consecutivo y liga.
 - RF-11: Mantener repositorios separados para archivos recibidos y resultados publicados.
-- RF-12: Implementar servicios frontend tipificados hacia FastAPI que, mientras no exista backend disponible, devuelvan datos simulados/localStorage usando el mismo contrato esperado de los endpoints.
+- RF-12: Implementar servicios frontend tipificados hacia GraphQL que, mientras no exista backend disponible, devuelvan datos simulados/localStorage usando el mismo contrato esperado de las operaciones.
 
 ---
 
@@ -140,7 +140,7 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 ## 6.4 Escalabilidad y mantenibilidad
 - Capacidad de agregar nuevos niveles o estructuras sin rediseñar el sistema.
 - Arquitectura desacoplada (frontend, API y workers de validación/PDF) para escalar horizontalmente.
-- Capa de servicios frontend conmutables (modo simulado vs. API FastAPI) documentada para minimizar retrabajo cuando el backend quede disponible.
+- Capa de servicios frontend conmutables (modo simulado vs. API GraphQL) documentada para minimizar retrabajo cuando el backend quede disponible.
 
 ---
 

--- a/web/doc/vision_document.md
+++ b/web/doc/vision_document.md
@@ -91,7 +91,7 @@ Sustituir el envío de archivos por correo en la segunda aplicación EIA por un 
 ### 4.1 Perspectiva del sistema
 
 ## 4.1 Perspectiva del sistema
-Aplicación web de tres capas con **Angular 19 (signals)**, **FastAPI (Python 3.12)** y **PostgreSQL + Filesystem**, apoyada por workers para validación y PDFs. No calcula resultados; solo publica ligas entregadas por el sistema externo. La SPA usa la **guía gráfica gob.mx v3** cargada vía CDN (estilos y scripts en `index.html`). Mientras el backend Python es implementado por otro equipo, el frontend entregará pantallas funcionales con servicios Angular que devuelven datos de prueba/localStorage pero mantienen las mismas firmas HTTP previstas para FastAPI, para que el cambio a los endpoints reales sea transparente.
+Aplicación web de tres capas con **Angular 19 (signals)**, **GraphQL** y **PostgreSQL + Filesystem**, apoyada por workers para validación y PDFs. No calcula resultados; solo publica ligas entregadas por el sistema externo. La SPA usa la **guía gráfica gob.mx v3** cargada vía CDN (estilos y scripts en `index.html`). Mientras el backend GraphQL es implementado por otro equipo, el frontend entregará pantallas funcionales con servicios Angular que devuelven datos de prueba/localStorage pero mantienen las mismas firmas de operaciones (queries/mutations), para que el cambio al backend real sea transparente.
 
 ## 4.2 Funciones principales (vista de negocio)
 - Cargar archivo .xlsx sin autenticación **solo para el primer envío del CCT/correo**.
@@ -105,7 +105,7 @@ Aplicación web de tres capas con **Angular 19 (signals)**, **FastAPI (Python 3.
 - Las plantillas .xlsx mantienen nombres de hojas y columnas esperadas.
 - El sistema externo entrega resultados/ligas en el repositorio de resultados.
 - Disponibilidad de infraestructura HTTPS y almacenamiento mínimo de 1 TB.
-- El backend FastAPI será provisto por un equipo diferente; durante C1/C2 el frontend operará con datos simulados en localStorage y servicios Angular que replican las respuestas esperadas.
+- El backend GraphQL será provisto por un equipo diferente; durante C1/C2 el frontend operará con datos simulados en localStorage y servicios Angular que replican las respuestas esperadas.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Actualizar la documentación del proyecto para reflejar la decisión de usar un backend GraphQL en lugar de Python/FastAPI y alinear los contratos de integración del frontend. 
- Entregar el informe mensual correspondiente a diciembre y la primera semana de enero con el diagrama de arquitectura, diagramas de componentes, estructura lógica y tecnológica, módulos Angular y especificación de servicios/operaciones GraphQL.

### Description

- Replaced references to `FastAPI`/Python with `GraphQL` across multiple documentation files including `web/doc/arquitectura_software.md`, `web/doc/srs.md`, `web/doc/vision_document.md`, `web/doc/plan_iteraciones.md`, `web/doc/glosario.md`, `web/doc/riesgos.md` and `web/doc/casos_uso.md`. 
- Updated integration language in the frontend documentation from HTTP endpoint contracts to GraphQL operations (queries/mutations) and adjusted related risk and implementation notes accordingly. 
- Added a new deliverable `web/doc/entregables/01_Diagrama_Arquitectura_MUSES_Web.md` containing the December–early January report with high-level architecture and component mermaid diagrams, logical/component diagrams, list of Angular modules, technology stack, and example GraphQL operations (`uploadFile`, `authenticate`, `downloadLinks`, `resubmitFile`). 
- Standardized mentions of backend libraries/tools (PDF generation, Excel handling, workers) to be generic or "equivalent in the backend stack" where appropriate and aligned deployment/monitoring notes with GraphQL.

### Testing

- No automated tests were executed because the change set is documentation-only and does not modify application code or test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7be5e3b0832097c475df4c13a7bd)