### PR TITLE
Update documentation to reference GraphQL backend (graphql-server)

### DIFF
--- a/web/doc/arquitectura_software.md
+++ b/web/doc/arquitectura_software.md
@@ -13,10 +13,10 @@ Describe la arquitectura de alto nivel para la plataforma que **recibe archivos 
 
 Arquitectura web de tres capas y procesos desacoplados:
 
-1. **Capa de presentación:** SPA en **Angular 19 (signals)** para carga anónima, descarga de PDFs y portal autenticado de descargas, usando la guía gráfica gob.mx v3 cargada desde CDN. Mientras el backend Python es desarrollado por otro equipo, el frontend operará con servicios simulados y datos de prueba almacenados en memoria/localStorage, manteniendo las mismas interfaces para conmutar a la API real sin cambios.
-2. **Capa de lógica de negocio:** API **FastAPI (Python 3.12)** para orquestar validaciones, generación de credenciales y publicación de ligas (implementada por un equipo distinto).
+1. **Capa de presentación:** SPA en **Angular 19 (signals)** para carga anónima, descarga de PDFs y portal autenticado de descargas, usando la guía gráfica gob.mx v3 cargada desde CDN. Mientras el backend GraphQL es desarrollado por otro equipo, el frontend operará con servicios simulados y datos de prueba almacenados en memoria/localStorage, manteniendo las mismas interfaces para conmutar a la API real sin cambios.
+2. **Capa de lógica de negocio:** API **GraphQL** para orquestar validaciones, generación de credenciales y publicación de ligas (implementada por un equipo distinto).
 3. **Capa de datos y archivos:** **PostgreSQL** para solicitudes/credenciales y **filesystem SSD** para repositorios separados de recepción y resultados.
-4. **Procesamiento asíncrono:** Workers (Redis + RQ/Celery) para validaciones y armado de PDFs.
+4. **Procesamiento asíncrono:** Workers (Redis o cola equivalente) para validaciones y armado de PDFs.
 
 ---
 
@@ -45,8 +45,8 @@ Arquitectura web de tres capas y procesos desacoplados:
   - Listado de versiones de resultados (consecutivo + liga) depositados por el sistema externo.
   - Reutiliza la autenticación para permitir reenvío de archivos cuando ya existan credenciales.
 - **Servicios de integración frontend**
-  - Interfaces Angular tipificadas hacia FastAPI para carga, login y descargas.
-  - Mientras no exista backend disponible, devuelven datos simulados/localStorage con la misma forma de respuesta que los futuros endpoints.
+  - Interfaces Angular tipificadas hacia GraphQL para carga, login y descargas.
+  - Mientras no exista backend disponible, devuelven datos simulados/localStorage con la misma forma de respuesta que las futuras operaciones.
 - **Panel técnico**
   - Monitoreo de logs, espacio en disco y estado de workers.
 
@@ -62,7 +62,7 @@ flowchart LR
     D[Escuela autenticada
     Descargas] --> B
 
-    B --> API[API FastAPI]
+    B --> API[API GraphQL]
     API --> W[Workers
     Validación/PDF]
     API --> DB[(PostgreSQL
@@ -77,12 +77,12 @@ flowchart LR
 
 ## 5. Decisiones tecnológicas clave
 
-- **Frontend:** Angular 19 + TypeScript (signals) con Angular CLI 19.2.x sobre Node 22.x y estilos base gob.mx v3 incluidos vía CDN en `index.html`. Los servicios Angular expondrán interfaces HTTP tipificadas; mientras no exista backend disponible, responderán con datos simulados/localStorage pero sin romper la forma de los endpoints.
-- **Backend:** Python 3.12 + FastAPI (desarrollado por un equipo distinto; la integración del frontend será transparente gracias a la capa de servicios simulados).
-- **Workers:** Redis + RQ/Celery para validación y generación de PDFs.
+- **Frontend:** Angular 19 + TypeScript (signals) con Angular CLI 19.2.x sobre Node 22.x y estilos base gob.mx v3 incluidos vía CDN en `index.html`. Los servicios Angular expondrán interfaces tipificadas; mientras no exista backend disponible, responderán con datos simulados/localStorage pero sin romper la forma de las operaciones.
+- **Backend:** GraphQL (carpeta `graphql-server`) desarrollado por un equipo distinto; la integración del frontend será transparente gracias a la capa de servicios simulados.
+- **Workers:** Redis o cola equivalente para validación y generación de PDFs.
 - **Persistencia:** PostgreSQL (datos) + Filesystem SSD (archivos válidos y resultados).
-- **Generación de PDF:** WeasyPrint/ReportLab o librería equivalente en Python.
-- **Validación de Excel:** pandas + openpyxl.
+- **Generación de PDF:** Librería equivalente en el stack del backend GraphQL.
+- **Validación de Excel:** Librería equivalente en el stack del backend GraphQL.
 - **Protocolos:** HTTPS obligatorio.
 
 ---
@@ -101,4 +101,4 @@ flowchart LR
 - Workers horizontales para paralelizar validaciones y PDFs.
 - Posibilidad de crecer almacenamiento sin interrumpir servicio (mínimo 1 TB inicial).
 - Separación de repositorios evita contención entre cargas y descargas.
-- Balanceo de carga sobre FastAPI si incrementa el volumen (objetivo: 120,000 validaciones).
+- Balanceo de carga sobre GraphQL si incrementa el volumen (objetivo: 120,000 validaciones).

--- a/web/doc/casos_uso.md
+++ b/web/doc/casos_uso.md
@@ -75,7 +75,7 @@ flowchart LR
    - Actores: Escuela (autenticada), Sistema externo de resultados
    - Descripción: Muestra consecutivos y ligas depositadas por el sistema externo para la escuela autenticada.
 
-**Nota de implementación temporal:** mientras el backend FastAPI es construido por otro equipo, los casos de uso CU-01 a CU-07 se ejecutarán en el frontend con servicios simulados y datos de prueba/localStorage que imitan las respuestas esperadas. Cuando los endpoints estén disponibles, se cambiará la fuente de datos sin modificar los flujos de usuario.
+**Nota de implementación temporal:** mientras el backend GraphQL es construido por otro equipo, los casos de uso CU-01 a CU-07 se ejecutarán en el frontend con servicios simulados y datos de prueba/localStorage que imitan las respuestas esperadas. Cuando las operaciones estén disponibles, se cambiará la fuente de datos sin modificar los flujos de usuario.
 
 ---
 

--- a/web/doc/glosario.md
+++ b/web/doc/glosario.md
@@ -14,8 +14,8 @@
 - **SPA (Single Page Application):** Aplicación web de una sola página; el shell se carga una vez y las vistas cambian en el cliente sin recargar todo el documento. En este proyecto se implementa con Angular 19 y signals.
 - **Angular 19 (signals):** Framework para el frontend; habilita el modelo reactivo con signals.
 - **Guía gráfica gob.mx v3:** Estándar de diseño y estilos de la Administración Pública; se incluye desde CDN (`main.css`, `gobmx.js`, `main.js`) en `index.html`.
-- **FastAPI:** Framework de backend en Python 3.12 utilizado para la API.
+- **GraphQL:** Lenguaje de consulta y capa de API utilizada por el backend (servidor en `graphql-server`).
 - **PostgreSQL:** Base de datos que guarda solicitudes, credenciales y bitácoras.
-- **Redis + RQ/Celery:** Infraestructura de workers para validaciones y generación de PDFs.
-- **Servicios simulados (frontend):** Implementaciones Angular que devuelven datos de prueba/localStorage con el mismo contrato HTTP que ofrecerá FastAPI, permitiendo cambiar a endpoints reales sin reescribir componentes.
-- **Equipo backend externo:** Grupo responsable de construir la API FastAPI; el frontend se prepara para integrarse cuando los endpoints estén disponibles.
+- **Redis o cola equivalente:** Infraestructura de workers para validaciones y generación de PDFs.
+- **Servicios simulados (frontend):** Implementaciones Angular que devuelven datos de prueba/localStorage con el mismo contrato que ofrecerá la API GraphQL, permitiendo cambiar a operaciones reales sin reescribir componentes.
+- **Equipo backend externo:** Grupo responsable de construir la API GraphQL; el frontend se prepara para integrarse cuando las operaciones estén disponibles.

--- a/web/doc/plan_iteraciones.md
+++ b/web/doc/plan_iteraciones.md
@@ -42,13 +42,13 @@
 ### Iteración E2 – Diseño arquitectónico y tecnológico
 
 **Objetivos:**
-- Definir arquitectura FastAPI + Angular 19 (signals) + workers Redis (validación/PDF) con lineamientos de estilo gob.mx v3 incluidos desde CDN en `index.html`.
+- Definir arquitectura GraphQL + Angular 19 (signals) + workers Redis (validación/PDF) con lineamientos de estilo gob.mx v3 incluidos desde CDN en `index.html`.
 - Diseñar separación de repositorios (recepción vs. resultados) y capacidad mínima de 1 TB.
 - Planear integración con sistema externo de resultados (ingesta de ligas/archivos).
 
 **Entregables:**
 - SAD actualizado.
-- Prototipo técnico mínimo: endpoint FastAPI de validación simulada + pantalla Angular de carga anónima con estado “Validando tu archivo…” usando la guía gráfica gob.mx.
+- Prototipo técnico mínimo: operación GraphQL de validación simulada + pantalla Angular de carga anónima con estado “Validando tu archivo…” usando la guía gráfica gob.mx.
 
 **Criterios de Aceptación:**
 
@@ -76,12 +76,12 @@
 - Repositorio de recepción operativo (filesystem + registros en PostgreSQL).
 
 **Plan de trabajo detallado – SPA Angular 19 (signals) con guía gob.mx v3**
-- **Punto de partida:** Angular CLI 19.2.x ya instalado; `index.html` incluye los assets de la guía gráfica gob.mx v3 desde CDN; el backend Python será construido por otro equipo.
+- **Punto de partida:** Angular CLI 19.2.x ya instalado; `index.html` incluye los assets de la guía gráfica gob.mx v3 desde CDN; el backend GraphQL será construido por otro equipo.
 - **¿Qué es SPA?** Una Single Page Application: el shell se renderiza una vez y las vistas cambian en el navegador (sin recargar toda la página) usando enrutamiento de Angular.
 - **Pasos previstos:**
   1. Definir rutas iniciales (`/` carga anónima, `/login`, `/descargas`) y un layout base que use los estilos gob.mx ya cargados.
   2. Crear el componente de inicio/carga con signals para estado de archivo, progreso y mensajes ("Validando tu archivo...").
-  3. Implementar servicios HTTP y de estado con signals que hoy regresen datos simulados/localStorage, respetando las firmas esperadas del futuro backend FastAPI para conmutar sin cambios cuando esté listo.
+  3. Implementar servicios HTTP y de estado con signals que hoy regresen datos simulados/localStorage, respetando las firmas esperadas del futuro backend GraphQL para conmutar sin cambios cuando esté listo.
   4. Preparar componentes de autenticación y listado de descargas reutilizando la guía gráfica (tablas, alerts, botones) con datos de prueba.
   5. Validar accesibilidad y consistencia visual con la guía gráfica en navegación SPA (sin recargas completas) y documentar cómo activar la fuente de datos real cuando esté disponible.
 
@@ -89,7 +89,7 @@
 
 **Objetivos:**
 - Implementar login (CCT + contraseña generada) y módulo de descargas.
-- Consumir ligas/archivos provistos por el sistema externo y listarlos por versión/consecutivo (iniciando con datos simulados en frontend; conmutar a FastAPI en cuanto el equipo de backend entregue endpoints).
+- Consumir ligas/archivos provistos por el sistema externo y listarlos por versión/consecutivo (iniciando con datos simulados en frontend; conmutar a GraphQL en cuanto el equipo de backend entregue operaciones).
 - Ajustar monitoreo técnico (logs, espacio en disco, salud de workers).
 
 **Entregables:**

--- a/web/doc/riesgos.md
+++ b/web/doc/riesgos.md
@@ -3,11 +3,10 @@
 | ID | Tipo      | Descripción                                                                 | Prob. | Impacto | Estrategia de mitigación |
 |----|-----------|-----------------------------------------------------------------------------|-------|---------|---------------------------|
 | R1 | Operativo | Escuelas continúan usando correo en lugar de la carga anónima .xlsx         | Media | Alta    | Comunicación oficial, instrucciones claras en portal, monitoreo de buzones |
-| R2 | Técnico   | Sobrecarga de validaciones (pico cercano al cierre, objetivo 120,000)       | Alta  | Alta    | Escalar workers FastAPI/Redis, pruebas de carga, autoescalado en infraestructura |
+| R2 | Técnico   | Sobrecarga de validaciones (pico cercano al cierre, objetivo 120,000)       | Alta  | Alta    | Escalar workers GraphQL/Redis, pruebas de carga, autoescalado en infraestructura |
 | R3 | Datos     | Archivos con estructura/nombres de hoja alterados rompen validación         | Alta  | Media   | Validación estricta de 10 reglas (incluye hash para detectar duplicados por contenido), mensajes claros en PDF de errores, plantillas oficiales |
 | R4 | Seguridad | Compromiso de credenciales (CCT + contraseña correo validado)               | Media | Alta    | Hashing de contraseñas, HTTPS obligatorio, bitácora de accesos, bloqueo por intentos fallidos |
 | R5 | Integración | Retraso o falla en depósito de resultados por el sistema externo           | Media | Alta    | Acuerdos de entrega, monitoreo de repositorio de resultados, alertas tempranas |
 | R6 | Infraestructura | Falta de espacio en repositorios (mínimo 1 TB para recepción/resultados) | Media | Alta    | Monitoreo de disco, planes de expansión en caliente, limpieza controlada de archivos obsoletos |
 | R7 | Cambio    | Resistencia de usuarios a la credencial generada automáticamente            | Media | Media   | Manuales y FAQs, recordatorio en PDF de confirmación, soporte de mesa de ayuda |
-| R8 | Integración | Diferencias entre datos simulados en frontend y contratos reales de FastAPI (backend de otro equipo) | Media | Media | Definir contratos HTTP desde el inicio, documentar mocks/localStorage, pruebas de integración al habilitar endpoints |
-
+| R8 | Integración | Diferencias entre datos simulados en frontend y contratos reales de GraphQL (backend de otro equipo) | Media | Media | Definir contratos desde el inicio, documentar mocks/localStorage, pruebas de integración al habilitar operaciones |

--- a/web/doc/srs.md
+++ b/web/doc/srs.md
@@ -37,7 +37,7 @@ La plataforma cubre únicamente el flujo de recepción–validación–descarga 
 ### 2.1 Perspectiva del producto
 
 ## 2.1 Perspectiva del producto
-Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend FastAPI en Python 3.12** y **almacenamiento PostgreSQL + Filesystem**. No realiza cálculos educativos; actúa como **pasarela de validación y distribución de archivos**. El backend Python será implementado por otro equipo; el frontend entregará pantallas funcionales con servicios Angular que hoy responden con datos de prueba/localStorage, pero conservan las mismas firmas HTTP para conmutar a FastAPI sin reescritura. La lógica de negocio debe **bloquear reenvíos anónimos** si ya existe una credencial previa para el mismo CCT/correo, solicitar autenticación antes de permitir la nueva carga y **registrar la huella (hash) de cada archivo** para distinguir versiones aunque el nombre sea idéntico.
+Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend GraphQL** (carpeta `graphql-server`) y **almacenamiento PostgreSQL + Filesystem**. No realiza cálculos educativos; actúa como **pasarela de validación y distribución de archivos**. El backend GraphQL será implementado por otro equipo; el frontend entregará pantallas funcionales con servicios Angular que hoy responden con datos de prueba/localStorage, pero conservan las mismas firmas HTTP para conmutar a la API GraphQL sin reescritura. La lógica de negocio debe **bloquear reenvíos anónimos** si ya existe una credencial previa para el mismo CCT/correo, solicitar autenticación antes de permitir la nueva carga y **registrar la huella (hash) de cada archivo** para distinguir versiones aunque el nombre sea idéntico.
 
 ### 2.2 Interfaces del sistema
 
@@ -52,14 +52,14 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend F
 - Uso de la **guía gráfica gob.mx v3** incluida desde CDN en `index.html`, con scripts auxiliares (`jquery.min.js`, `gobmx.js`, `main.js`) ya cargados.
 
 ### 2.2.2 Interfaces de hardware
-- Servidor de aplicaciones para FastAPI.
+- Servidor de aplicaciones para GraphQL.
 - Servidor de base de datos PostgreSQL.
 - Almacenamiento de archivos en disco SSD (mínimo 1 TB para recepción/resultados).
 
 ### 2.2.3 Interfaces de software
-- Librerías de manipulación de Excel (pandas + openpyxl o equivalente en el stack Python).
-- Conectores de base de datos para PostgreSQL.
-- Integración de cola de trabajos (Redis/RQ o Celery) para validaciones y generación de PDFs.
+- Librerías de manipulación de Excel (equivalentes en el stack del backend GraphQL).
+- Conectores de base de datos para PostgreSQL en el runtime del servidor GraphQL.
+- Integración de cola de trabajos (Redis o equivalente) para validaciones y generación de PDFs.
 - CDN de la guía gráfica gob.mx v3 referenciada en `index.html` (hoja de estilos principal y scripts `gobmx.js`/`main.js`).
 
 ---
@@ -118,7 +118,7 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 - RF-09: Habilitar autenticación (CCT + contraseña) para reenviar archivos y consultar las ligas de descarga.
 - RF-10: Mostrar **todas las versiones** de resultados que el sistema externo haya depositado, con consecutivo y liga.
 - RF-11: Mantener repositorios separados para archivos recibidos y resultados publicados.
-- RF-12: Implementar servicios frontend tipificados hacia FastAPI que, mientras no exista backend disponible, devuelvan datos simulados/localStorage usando el mismo contrato esperado de los endpoints.
+- RF-12: Implementar servicios frontend tipificados hacia GraphQL que, mientras no exista backend disponible, devuelvan datos simulados/localStorage usando el mismo contrato esperado de las operaciones.
 
 ---
 
@@ -140,7 +140,7 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 ## 6.4 Escalabilidad y mantenibilidad
 - Capacidad de agregar nuevos niveles o estructuras sin rediseñar el sistema.
 - Arquitectura desacoplada (frontend, API y workers de validación/PDF) para escalar horizontalmente.
-- Capa de servicios frontend conmutables (modo simulado vs. API FastAPI) documentada para minimizar retrabajo cuando el backend quede disponible.
+- Capa de servicios frontend conmutables (modo simulado vs. API GraphQL) documentada para minimizar retrabajo cuando el backend quede disponible.
 
 ---
 

--- a/web/doc/vision_document.md
+++ b/web/doc/vision_document.md
@@ -91,7 +91,7 @@ Sustituir el envío de archivos por correo en la segunda aplicación EIA por un 
 ### 4.1 Perspectiva del sistema
 
 ## 4.1 Perspectiva del sistema
-Aplicación web de tres capas con **Angular 19 (signals)**, **FastAPI (Python 3.12)** y **PostgreSQL + Filesystem**, apoyada por workers para validación y PDFs. No calcula resultados; solo publica ligas entregadas por el sistema externo. La SPA usa la **guía gráfica gob.mx v3** cargada vía CDN (estilos y scripts en `index.html`). Mientras el backend Python es implementado por otro equipo, el frontend entregará pantallas funcionales con servicios Angular que devuelven datos de prueba/localStorage pero mantienen las mismas firmas HTTP previstas para FastAPI, para que el cambio a los endpoints reales sea transparente.
+Aplicación web de tres capas con **Angular 19 (signals)**, **backend GraphQL** (carpeta `graphql-server`) y **PostgreSQL + Filesystem**, apoyada por workers para validación y PDFs. No calcula resultados; solo publica ligas entregadas por el sistema externo. La SPA usa la **guía gráfica gob.mx v3** cargada vía CDN (estilos y scripts en `index.html`). Mientras el backend GraphQL es implementado por otro equipo, el frontend entregará pantallas funcionales con servicios Angular que devuelven datos de prueba/localStorage pero mantienen las mismas firmas HTTP previstas para la API GraphQL, para que el cambio a las operaciones reales sea transparente.
 
 ## 4.2 Funciones principales (vista de negocio)
 - Cargar archivo .xlsx sin autenticación **solo para el primer envío del CCT/correo**.
@@ -105,7 +105,7 @@ Aplicación web de tres capas con **Angular 19 (signals)**, **FastAPI (Python 3.
 - Las plantillas .xlsx mantienen nombres de hojas y columnas esperadas.
 - El sistema externo entrega resultados/ligas en el repositorio de resultados.
 - Disponibilidad de infraestructura HTTPS y almacenamiento mínimo de 1 TB.
-- El backend FastAPI será provisto por un equipo diferente; durante C1/C2 el frontend operará con datos simulados en localStorage y servicios Angular que replican las respuestas esperadas.
+- El backend GraphQL será provisto por un equipo diferente; durante C1/C2 el frontend operará con datos simulados en localStorage y servicios Angular que replican las respuestas esperadas.
 
 ---
 


### PR DESCRIPTION
### Motivation
- The project backend has moved from a Python/FastAPI implementation to a GraphQL-based server located in `graphql-server`, so documentation must reflect the new API surface and dependencies. 
- Align architecture, iteration plans, integrations and glossary entries to avoid misleading references to FastAPI/Python and to clarify expected frontend integration with GraphQL operations.

### Description
- Replaced references to FastAPI/Python with `GraphQL` and added explicit reference to the `graphql-server` folder across documentation files. 
- Updated `web/doc/srs.md`, `web/doc/vision_document.md`, `web/doc/arquitectura_software.md`, `web/doc/plan_iteraciones.md`, `web/doc/glosario.md`, `web/doc/casos_uso.md`, and `web/doc/riesgos.md` to reflect GraphQL operations, adjust service/worker wording, and change examples/diagrams accordingly. 
- Adjusted worker/queue wording from `Redis/RQ/Celery` to `Redis or queue equivalent` and replaced Python-specific library mentions with generic "equivalent in the backend GraphQL stack" where appropriate. 
- Updated RF-12 and frontend integration notes to require typed frontend services against GraphQL and clarified the simulated/mock behavior until the backend GraphQL is available. 

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69700648d0848320af8a09e33fb83bf6)