### PR TITLE
Add tickets support page; multi-file admin results & downloadable results UI; docs update to GraphQL

### DIFF
--- a/web/doc/arquitectura_software.md
+++ b/web/doc/arquitectura_software.md
@@ -13,10 +13,10 @@ Describe la arquitectura de alto nivel para la plataforma que **recibe archivos 
 
 Arquitectura web de tres capas y procesos desacoplados:
 
-1. **Capa de presentación:** SPA en **Angular 19 (signals)** para carga anónima, descarga de PDFs y portal autenticado de descargas, usando la guía gráfica gob.mx v3 cargada desde CDN. Mientras el backend Python es desarrollado por otro equipo, el frontend operará con servicios simulados y datos de prueba almacenados en memoria/localStorage, manteniendo las mismas interfaces para conmutar a la API real sin cambios.
-2. **Capa de lógica de negocio:** API **FastAPI (Python 3.12)** para orquestar validaciones, generación de credenciales y publicación de ligas (implementada por un equipo distinto).
+1. **Capa de presentación:** SPA en **Angular 19 (signals)** para carga anónima, descarga de PDFs y portal autenticado de descargas, usando la guía gráfica gob.mx v3 cargada desde CDN. Mientras el backend GraphQL es desarrollado por otro equipo, el frontend operará con servicios simulados y datos de prueba almacenados en memoria/localStorage, manteniendo las mismas interfaces para conmutar a la API real sin cambios.
+2. **Capa de lógica de negocio:** API **GraphQL** para orquestar validaciones, generación de credenciales y publicación de ligas (implementada por un equipo distinto).
 3. **Capa de datos y archivos:** **PostgreSQL** para solicitudes/credenciales y **filesystem SSD** para repositorios separados de recepción y resultados.
-4. **Procesamiento asíncrono:** Workers (Redis + RQ/Celery) para validaciones y armado de PDFs.
+4. **Procesamiento asíncrono:** Workers (Redis o cola equivalente) para validaciones y armado de PDFs.
 
 ---
 
@@ -45,8 +45,8 @@ Arquitectura web de tres capas y procesos desacoplados:
   - Listado de versiones de resultados (consecutivo + liga) depositados por el sistema externo.
   - Reutiliza la autenticación para permitir reenvío de archivos cuando ya existan credenciales.
 - **Servicios de integración frontend**
-  - Interfaces Angular tipificadas hacia FastAPI para carga, login y descargas.
-  - Mientras no exista backend disponible, devuelven datos simulados/localStorage con la misma forma de respuesta que los futuros endpoints.
+  - Interfaces Angular tipificadas hacia GraphQL para carga, login y descargas.
+  - Mientras no exista backend disponible, devuelven datos simulados/localStorage con la misma forma de respuesta que las futuras operaciones.
 - **Panel técnico**
   - Monitoreo de logs, espacio en disco y estado de workers.
 
@@ -62,7 +62,7 @@ flowchart LR
     D[Escuela autenticada
     Descargas] --> B
 
-    B --> API[API FastAPI]
+    B --> API[API GraphQL]
     API --> W[Workers
     Validación/PDF]
     API --> DB[(PostgreSQL
@@ -77,12 +77,12 @@ flowchart LR
 
 ## 5. Decisiones tecnológicas clave
 
-- **Frontend:** Angular 19 + TypeScript (signals) con Angular CLI 19.2.x sobre Node 22.x y estilos base gob.mx v3 incluidos vía CDN en `index.html`. Los servicios Angular expondrán interfaces HTTP tipificadas; mientras no exista backend disponible, responderán con datos simulados/localStorage pero sin romper la forma de los endpoints.
-- **Backend:** Python 3.12 + FastAPI (desarrollado por un equipo distinto; la integración del frontend será transparente gracias a la capa de servicios simulados).
-- **Workers:** Redis + RQ/Celery para validación y generación de PDFs.
+- **Frontend:** Angular 19 + TypeScript (signals) con Angular CLI 19.2.x sobre Node 22.x y estilos base gob.mx v3 incluidos vía CDN en `index.html`. Los servicios Angular expondrán interfaces tipificadas; mientras no exista backend disponible, responderán con datos simulados/localStorage pero sin romper la forma de las operaciones.
+- **Backend:** GraphQL (carpeta `graphql-server`) desarrollado por un equipo distinto; la integración del frontend será transparente gracias a la capa de servicios simulados.
+- **Workers:** Redis o cola equivalente para validación y generación de PDFs.
 - **Persistencia:** PostgreSQL (datos) + Filesystem SSD (archivos válidos y resultados).
-- **Generación de PDF:** WeasyPrint/ReportLab o librería equivalente en Python.
-- **Validación de Excel:** pandas + openpyxl.
+- **Generación de PDF:** Librería equivalente en el stack del backend GraphQL.
+- **Validación de Excel:** Librería equivalente en el stack del backend GraphQL.
 - **Protocolos:** HTTPS obligatorio.
 
 ---
@@ -101,4 +101,4 @@ flowchart LR
 - Workers horizontales para paralelizar validaciones y PDFs.
 - Posibilidad de crecer almacenamiento sin interrumpir servicio (mínimo 1 TB inicial).
 - Separación de repositorios evita contención entre cargas y descargas.
-- Balanceo de carga sobre FastAPI si incrementa el volumen (objetivo: 120,000 validaciones).
+- Balanceo de carga sobre GraphQL si incrementa el volumen (objetivo: 120,000 validaciones).

--- a/web/doc/casos_uso.md
+++ b/web/doc/casos_uso.md
@@ -75,7 +75,7 @@ flowchart LR
    - Actores: Escuela (autenticada), Sistema externo de resultados
    - Descripción: Muestra consecutivos y ligas depositadas por el sistema externo para la escuela autenticada.
 
-**Nota de implementación temporal:** mientras el backend FastAPI es construido por otro equipo, los casos de uso CU-01 a CU-07 se ejecutarán en el frontend con servicios simulados y datos de prueba/localStorage que imitan las respuestas esperadas. Cuando los endpoints estén disponibles, se cambiará la fuente de datos sin modificar los flujos de usuario.
+**Nota de implementación temporal:** mientras el backend GraphQL es construido por otro equipo, los casos de uso CU-01 a CU-07 se ejecutarán en el frontend con servicios simulados y datos de prueba/localStorage que imitan las respuestas esperadas. Cuando las operaciones estén disponibles, se cambiará la fuente de datos sin modificar los flujos de usuario.
 
 ---
 

--- a/web/doc/glosario.md
+++ b/web/doc/glosario.md
@@ -14,8 +14,8 @@
 - **SPA (Single Page Application):** Aplicación web de una sola página; el shell se carga una vez y las vistas cambian en el cliente sin recargar todo el documento. En este proyecto se implementa con Angular 19 y signals.
 - **Angular 19 (signals):** Framework para el frontend; habilita el modelo reactivo con signals.
 - **Guía gráfica gob.mx v3:** Estándar de diseño y estilos de la Administración Pública; se incluye desde CDN (`main.css`, `gobmx.js`, `main.js`) en `index.html`.
-- **FastAPI:** Framework de backend en Python 3.12 utilizado para la API.
+- **GraphQL:** Lenguaje de consulta y capa de API utilizada por el backend (servidor en `graphql-server`).
 - **PostgreSQL:** Base de datos que guarda solicitudes, credenciales y bitácoras.
-- **Redis + RQ/Celery:** Infraestructura de workers para validaciones y generación de PDFs.
-- **Servicios simulados (frontend):** Implementaciones Angular que devuelven datos de prueba/localStorage con el mismo contrato HTTP que ofrecerá FastAPI, permitiendo cambiar a endpoints reales sin reescribir componentes.
-- **Equipo backend externo:** Grupo responsable de construir la API FastAPI; el frontend se prepara para integrarse cuando los endpoints estén disponibles.
+- **Redis o cola equivalente:** Infraestructura de workers para validaciones y generación de PDFs.
+- **Servicios simulados (frontend):** Implementaciones Angular que devuelven datos de prueba/localStorage con el mismo contrato que ofrecerá la API GraphQL, permitiendo cambiar a operaciones reales sin reescribir componentes.
+- **Equipo backend externo:** Grupo responsable de construir la API GraphQL; el frontend se prepara para integrarse cuando las operaciones estén disponibles.

--- a/web/doc/plan_iteraciones.md
+++ b/web/doc/plan_iteraciones.md
@@ -42,13 +42,13 @@
 ### Iteración E2 – Diseño arquitectónico y tecnológico
 
 **Objetivos:**
-- Definir arquitectura FastAPI + Angular 19 (signals) + workers Redis (validación/PDF) con lineamientos de estilo gob.mx v3 incluidos desde CDN en `index.html`.
+- Definir arquitectura GraphQL + Angular 19 (signals) + workers Redis (validación/PDF) con lineamientos de estilo gob.mx v3 incluidos desde CDN en `index.html`.
 - Diseñar separación de repositorios (recepción vs. resultados) y capacidad mínima de 1 TB.
 - Planear integración con sistema externo de resultados (ingesta de ligas/archivos).
 
 **Entregables:**
 - SAD actualizado.
-- Prototipo técnico mínimo: endpoint FastAPI de validación simulada + pantalla Angular de carga anónima con estado “Validando tu archivo…” usando la guía gráfica gob.mx.
+- Prototipo técnico mínimo: operación GraphQL de validación simulada + pantalla Angular de carga anónima con estado “Validando tu archivo…” usando la guía gráfica gob.mx.
 
 **Criterios de Aceptación:**
 
@@ -76,12 +76,12 @@
 - Repositorio de recepción operativo (filesystem + registros en PostgreSQL).
 
 **Plan de trabajo detallado – SPA Angular 19 (signals) con guía gob.mx v3**
-- **Punto de partida:** Angular CLI 19.2.x ya instalado; `index.html` incluye los assets de la guía gráfica gob.mx v3 desde CDN; el backend Python será construido por otro equipo.
+- **Punto de partida:** Angular CLI 19.2.x ya instalado; `index.html` incluye los assets de la guía gráfica gob.mx v3 desde CDN; el backend GraphQL será construido por otro equipo.
 - **¿Qué es SPA?** Una Single Page Application: el shell se renderiza una vez y las vistas cambian en el navegador (sin recargar toda la página) usando enrutamiento de Angular.
 - **Pasos previstos:**
   1. Definir rutas iniciales (`/` carga anónima, `/login`, `/descargas`) y un layout base que use los estilos gob.mx ya cargados.
   2. Crear el componente de inicio/carga con signals para estado de archivo, progreso y mensajes ("Validando tu archivo...").
-  3. Implementar servicios HTTP y de estado con signals que hoy regresen datos simulados/localStorage, respetando las firmas esperadas del futuro backend FastAPI para conmutar sin cambios cuando esté listo.
+  3. Implementar servicios HTTP y de estado con signals que hoy regresen datos simulados/localStorage, respetando las firmas esperadas del futuro backend GraphQL para conmutar sin cambios cuando esté listo.
   4. Preparar componentes de autenticación y listado de descargas reutilizando la guía gráfica (tablas, alerts, botones) con datos de prueba.
   5. Validar accesibilidad y consistencia visual con la guía gráfica en navegación SPA (sin recargas completas) y documentar cómo activar la fuente de datos real cuando esté disponible.
 
@@ -89,7 +89,7 @@
 
 **Objetivos:**
 - Implementar login (CCT + contraseña generada) y módulo de descargas.
-- Consumir ligas/archivos provistos por el sistema externo y listarlos por versión/consecutivo (iniciando con datos simulados en frontend; conmutar a FastAPI en cuanto el equipo de backend entregue endpoints).
+- Consumir ligas/archivos provistos por el sistema externo y listarlos por versión/consecutivo (iniciando con datos simulados en frontend; conmutar a GraphQL en cuanto el equipo de backend entregue operaciones).
 - Ajustar monitoreo técnico (logs, espacio en disco, salud de workers).
 
 **Entregables:**

--- a/web/doc/riesgos.md
+++ b/web/doc/riesgos.md
@@ -3,11 +3,10 @@
 | ID | Tipo      | Descripción                                                                 | Prob. | Impacto | Estrategia de mitigación |
 |----|-----------|-----------------------------------------------------------------------------|-------|---------|---------------------------|
 | R1 | Operativo | Escuelas continúan usando correo en lugar de la carga anónima .xlsx         | Media | Alta    | Comunicación oficial, instrucciones claras en portal, monitoreo de buzones |
-| R2 | Técnico   | Sobrecarga de validaciones (pico cercano al cierre, objetivo 120,000)       | Alta  | Alta    | Escalar workers FastAPI/Redis, pruebas de carga, autoescalado en infraestructura |
+| R2 | Técnico   | Sobrecarga de validaciones (pico cercano al cierre, objetivo 120,000)       | Alta  | Alta    | Escalar workers GraphQL/Redis, pruebas de carga, autoescalado en infraestructura |
 | R3 | Datos     | Archivos con estructura/nombres de hoja alterados rompen validación         | Alta  | Media   | Validación estricta de 10 reglas (incluye hash para detectar duplicados por contenido), mensajes claros en PDF de errores, plantillas oficiales |
 | R4 | Seguridad | Compromiso de credenciales (CCT + contraseña correo validado)               | Media | Alta    | Hashing de contraseñas, HTTPS obligatorio, bitácora de accesos, bloqueo por intentos fallidos |
 | R5 | Integración | Retraso o falla en depósito de resultados por el sistema externo           | Media | Alta    | Acuerdos de entrega, monitoreo de repositorio de resultados, alertas tempranas |
 | R6 | Infraestructura | Falta de espacio en repositorios (mínimo 1 TB para recepción/resultados) | Media | Alta    | Monitoreo de disco, planes de expansión en caliente, limpieza controlada de archivos obsoletos |
 | R7 | Cambio    | Resistencia de usuarios a la credencial generada automáticamente            | Media | Media   | Manuales y FAQs, recordatorio en PDF de confirmación, soporte de mesa de ayuda |
-| R8 | Integración | Diferencias entre datos simulados en frontend y contratos reales de FastAPI (backend de otro equipo) | Media | Media | Definir contratos HTTP desde el inicio, documentar mocks/localStorage, pruebas de integración al habilitar endpoints |
-
+| R8 | Integración | Diferencias entre datos simulados en frontend y contratos reales de GraphQL (backend de otro equipo) | Media | Media | Definir contratos desde el inicio, documentar mocks/localStorage, pruebas de integración al habilitar operaciones |

--- a/web/doc/srs.md
+++ b/web/doc/srs.md
@@ -37,7 +37,7 @@ La plataforma cubre únicamente el flujo de recepción–validación–descarga 
 ### 2.1 Perspectiva del producto
 
 ## 2.1 Perspectiva del producto
-Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend FastAPI en Python 3.12** y **almacenamiento PostgreSQL + Filesystem**. No realiza cálculos educativos; actúa como **pasarela de validación y distribución de archivos**. El backend Python será implementado por otro equipo; el frontend entregará pantallas funcionales con servicios Angular que hoy responden con datos de prueba/localStorage, pero conservan las mismas firmas HTTP para conmutar a FastAPI sin reescritura. La lógica de negocio debe **bloquear reenvíos anónimos** si ya existe una credencial previa para el mismo CCT/correo, solicitar autenticación antes de permitir la nueva carga y **registrar la huella (hash) de cada archivo** para distinguir versiones aunque el nombre sea idéntico.
+Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend GraphQL** (carpeta `graphql-server`) y **almacenamiento PostgreSQL + Filesystem**. No realiza cálculos educativos; actúa como **pasarela de validación y distribución de archivos**. El backend GraphQL será implementado por otro equipo; el frontend entregará pantallas funcionales con servicios Angular que hoy responden con datos de prueba/localStorage, pero conservan las mismas firmas HTTP para conmutar a la API GraphQL sin reescritura. La lógica de negocio debe **bloquear reenvíos anónimos** si ya existe una credencial previa para el mismo CCT/correo, solicitar autenticación antes de permitir la nueva carga y **registrar la huella (hash) de cada archivo** para distinguir versiones aunque el nombre sea idéntico.
 
 ### 2.2 Interfaces del sistema
 
@@ -52,14 +52,14 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend F
 - Uso de la **guía gráfica gob.mx v3** incluida desde CDN en `index.html`, con scripts auxiliares (`jquery.min.js`, `gobmx.js`, `main.js`) ya cargados.
 
 ### 2.2.2 Interfaces de hardware
-- Servidor de aplicaciones para FastAPI.
+- Servidor de aplicaciones para GraphQL.
 - Servidor de base de datos PostgreSQL.
 - Almacenamiento de archivos en disco SSD (mínimo 1 TB para recepción/resultados).
 
 ### 2.2.3 Interfaces de software
-- Librerías de manipulación de Excel (pandas + openpyxl o equivalente en el stack Python).
-- Conectores de base de datos para PostgreSQL.
-- Integración de cola de trabajos (Redis/RQ o Celery) para validaciones y generación de PDFs.
+- Librerías de manipulación de Excel (equivalentes en el stack del backend GraphQL).
+- Conectores de base de datos para PostgreSQL en el runtime del servidor GraphQL.
+- Integración de cola de trabajos (Redis o equivalente) para validaciones y generación de PDFs.
 - CDN de la guía gráfica gob.mx v3 referenciada en `index.html` (hoja de estilos principal y scripts `gobmx.js`/`main.js`).
 
 ---
@@ -118,7 +118,7 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 - RF-09: Habilitar autenticación (CCT + contraseña) para reenviar archivos y consultar las ligas de descarga.
 - RF-10: Mostrar **todas las versiones** de resultados que el sistema externo haya depositado, con consecutivo y liga.
 - RF-11: Mantener repositorios separados para archivos recibidos y resultados publicados.
-- RF-12: Implementar servicios frontend tipificados hacia FastAPI que, mientras no exista backend disponible, devuelvan datos simulados/localStorage usando el mismo contrato esperado de los endpoints.
+- RF-12: Implementar servicios frontend tipificados hacia GraphQL que, mientras no exista backend disponible, devuelvan datos simulados/localStorage usando el mismo contrato esperado de las operaciones.
 
 ---
 
@@ -140,7 +140,7 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 ## 6.4 Escalabilidad y mantenibilidad
 - Capacidad de agregar nuevos niveles o estructuras sin rediseñar el sistema.
 - Arquitectura desacoplada (frontend, API y workers de validación/PDF) para escalar horizontalmente.
-- Capa de servicios frontend conmutables (modo simulado vs. API FastAPI) documentada para minimizar retrabajo cuando el backend quede disponible.
+- Capa de servicios frontend conmutables (modo simulado vs. API GraphQL) documentada para minimizar retrabajo cuando el backend quede disponible.
 
 ---
 

--- a/web/doc/vision_document.md
+++ b/web/doc/vision_document.md
@@ -91,7 +91,7 @@ Sustituir el envío de archivos por correo en la segunda aplicación EIA por un 
 ### 4.1 Perspectiva del sistema
 
 ## 4.1 Perspectiva del sistema
-Aplicación web de tres capas con **Angular 19 (signals)**, **FastAPI (Python 3.12)** y **PostgreSQL + Filesystem**, apoyada por workers para validación y PDFs. No calcula resultados; solo publica ligas entregadas por el sistema externo. La SPA usa la **guía gráfica gob.mx v3** cargada vía CDN (estilos y scripts en `index.html`). Mientras el backend Python es implementado por otro equipo, el frontend entregará pantallas funcionales con servicios Angular que devuelven datos de prueba/localStorage pero mantienen las mismas firmas HTTP previstas para FastAPI, para que el cambio a los endpoints reales sea transparente.
+Aplicación web de tres capas con **Angular 19 (signals)**, **backend GraphQL** (carpeta `graphql-server`) y **PostgreSQL + Filesystem**, apoyada por workers para validación y PDFs. No calcula resultados; solo publica ligas entregadas por el sistema externo. La SPA usa la **guía gráfica gob.mx v3** cargada vía CDN (estilos y scripts en `index.html`). Mientras el backend GraphQL es implementado por otro equipo, el frontend entregará pantallas funcionales con servicios Angular que devuelven datos de prueba/localStorage pero mantienen las mismas firmas HTTP previstas para la API GraphQL, para que el cambio a las operaciones reales sea transparente.
 
 ## 4.2 Funciones principales (vista de negocio)
 - Cargar archivo .xlsx sin autenticación **solo para el primer envío del CCT/correo**.
@@ -105,7 +105,7 @@ Aplicación web de tres capas con **Angular 19 (signals)**, **FastAPI (Python 3.
 - Las plantillas .xlsx mantienen nombres de hojas y columnas esperadas.
 - El sistema externo entrega resultados/ligas en el repositorio de resultados.
 - Disponibilidad de infraestructura HTTPS y almacenamiento mínimo de 1 TB.
-- El backend FastAPI será provisto por un equipo diferente; durante C1/C2 el frontend operará con datos simulados en localStorage y servicios Angular que replican las respuestas esperadas.
+- El backend GraphQL será provisto por un equipo diferente; durante C1/C2 el frontend operará con datos simulados en localStorage y servicios Angular que replican las respuestas esperadas.
 
 ---
 

--- a/web/frontend/src/app/app.routes.ts
+++ b/web/frontend/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { LoginComponent } from './components/login/login.component';
 import { DescargasComponent } from './components/descargas/descargas.component';
 import { AdminLoginComponent } from './components/admin-login/admin-login.component';
 import { AdminPanelComponent } from './components/admin-panel/admin-panel.component';
+import { TicketsComponent } from './components/tickets/tickets.component';
 
 
 export const routes: Routes = [
@@ -57,6 +58,11 @@ export const routes: Routes = [
   {
     path: 'descargas',
     component: DescargasComponent,
+    pathMatch: 'full'
+  },
+  {
+    path: 'tickets',
+    component: TicketsComponent,
     pathMatch: 'full'
   },
   /* {

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -28,7 +28,7 @@
       </select>
       <p class="admin-panel__helper">
         El listado de Excels depende del nivel seleccionado. Primero selecciona un registro y luego
-        sube el PDF correspondiente.
+        sube los archivos correspondientes.
       </p>
       <p class="admin-panel__helper" *ngIf="!excelDisponibles.length">
         Aún no hay Excels disponibles para asociar. Valida un archivo desde el módulo de carga.
@@ -135,24 +135,28 @@
         </div>
       </div>
 
-      <label class="admin-panel__upload-label" for="pdf-upload">Selecciona un PDF</label>
+      <label class="admin-panel__upload-label" for="pdf-upload">Selecciona archivos de resultados</label>
       <p class="admin-panel__helper" *ngIf="!excelSeleccionado">
-        Selecciona un registro de Excel para habilitar la carga del PDF.
+        Selecciona un registro de Excel para habilitar la carga de archivos.
       </p>
       <input
         id="pdf-upload"
         class="admin-panel__upload-input"
         type="file"
-        accept="application/pdf"
+        accept=".pdf,.xlsx,.jpg,.jpeg,.doc,.docx"
+        multiple
         (change)="seleccionarArchivo($event)"
       />
+      <p class="admin-panel__helper">
+        Formatos permitidos: PDF, XLSX, JPG, Word. Máximo {{ maxArchivos }} archivos.
+      </p>
       <button
         class="admin-panel__upload-button"
         type="button"
-        (click)="subirPdf()"
-        [disabled]="!excelSeleccionado"
+        (click)="subirArchivos()"
+        [disabled]="!excelSeleccionado || !selectedFiles.length"
       >
-        Subir PDF
+        Subir archivos
       </button>
 
       <div

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -14,7 +14,9 @@ import Swal from 'sweetalert2';
   styleUrl: './admin-panel.component.scss',
 })
 export class AdminPanelComponent implements OnInit {
-  selectedFile: File | null = null;
+  readonly maxArchivos = 10;
+  readonly extensionesPermitidas = ['.pdf', '.xlsx', '.jpg', '.jpeg', '.doc', '.docx'];
+  selectedFiles: File[] = [];
   selectedNivel = '';
   uploadStatus: 'idle' | 'uploading' | 'success' | 'error' = 'idle';
   feedbackMessage = '';
@@ -26,8 +28,8 @@ export class AdminPanelComponent implements OnInit {
   filtroFecha = '';
   paginaActual = 1;
   tamanioPagina = 10;
-  private readonly uploadHistoryKey = 'adminPanelPdfHistory';
-  private readonly pdfStoragePrefix = 'pdf-resultados';
+  private readonly uploadHistoryKey = 'adminPanelResultadosHistory';
+  private readonly archivosStoragePrefix = 'archivos-resultados';
 
   constructor(
     private readonly adminAuthService: AdminAuthService,
@@ -42,94 +44,112 @@ export class AdminPanelComponent implements OnInit {
 
   seleccionarArchivo(event: Event): void {
     const input = event.target as HTMLInputElement;
-    this.selectedFile = input.files?.[0] ?? null;
-    if (!this.selectedFile) {
+    const archivos = input.files ? Array.from(input.files) : [];
+    const validacionCantidad = this.validarCantidadArchivos(archivos);
+
+    if (!validacionCantidad.esValida) {
       this.uploadStatus = 'idle';
-      this.feedbackMessage = 'Selecciona un archivo PDF para comenzar.';
+      this.feedbackMessage = validacionCantidad.mensaje;
+      this.selectedFiles = [];
+      input.value = '';
       return;
     }
 
+    const validacionTipos = this.validarTiposArchivos(archivos);
+    if (!validacionTipos.esValida) {
+      this.uploadStatus = 'error';
+      this.feedbackMessage = validacionTipos.mensaje;
+      this.selectedFiles = [];
+      input.value = '';
+      return;
+    }
+
+    this.selectedFiles = archivos;
     this.uploadStatus = 'idle';
-    this.feedbackMessage = `Archivo seleccionado: ${this.selectedFile.name}`;
+    this.feedbackMessage =
+      archivos.length === 1
+        ? `Archivo seleccionado: ${archivos[0].name}`
+        : `Archivos seleccionados: ${archivos.length}`;
   }
 
-  async subirPdf(): Promise<void> {
+  async subirArchivos(): Promise<void> {
     if (!this.excelSeleccionado) {
       this.uploadStatus = 'error';
-      this.feedbackMessage = 'Selecciona un registro de Excel antes de subir el PDF.';
+      this.feedbackMessage = 'Selecciona un registro de Excel antes de subir los archivos.';
       return;
     }
 
-    if (!this.selectedFile) {
+    if (!this.selectedFiles.length) {
       this.uploadStatus = 'error';
       this.feedbackMessage = 'No se ha seleccionado ningún archivo.';
       return;
     }
 
-    const isPdf =
-      this.selectedFile.type === 'application/pdf' ||
-      this.selectedFile.name.toLowerCase().endsWith('.pdf');
-
-    if (!isPdf) {
+    const validacionTipos = this.validarTiposArchivos(this.selectedFiles);
+    if (!validacionTipos.esValida) {
       this.uploadStatus = 'error';
-      this.feedbackMessage = 'El archivo seleccionado no es un PDF válido.';
+      this.feedbackMessage = validacionTipos.mensaje;
+      return;
+    }
+
+    const existingFiles = this.obtenerArchivosParaExcel(this.excelSeleccionado.key);
+    if (existingFiles.length + this.selectedFiles.length > this.maxArchivos) {
+      this.uploadStatus = 'error';
+      this.feedbackMessage = `Solo puedes cargar hasta ${this.maxArchivos} archivos por registro.`;
       return;
     }
 
     this.uploadStatus = 'uploading';
-    this.feedbackMessage = 'Cargando archivo...';
+    this.feedbackMessage = 'Cargando archivos...';
 
-    const fileToUpload = this.selectedFile;
     const excelKey = this.excelSeleccionado.key;
     const excelSeleccionado = this.excelSeleccionado;
 
-    if (this.existePdfParaExcel(excelKey)) {
+    if (existingFiles.length) {
       const confirmacion = await Swal.fire({
-        title: '¿Reemplazar PDF existente?',
-        text: `Ya hay un PDF asignado a ${excelSeleccionado?.nombre ?? 'este Excel'} (${
+        title: '¿Agregar más archivos?',
+        text: `Ya hay archivos asignados a ${excelSeleccionado?.nombre ?? 'este Excel'} (${
           excelSeleccionado?.cct ?? 'CCT no registrada'
         }, ${excelSeleccionado?.correo ?? 'correo no registrado'}).`,
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: 'Sí, reemplazar',
+        confirmButtonText: 'Sí, agregar',
         cancelButtonText: 'Cancelar'
       });
 
       if (!confirmacion.isConfirmed) {
         this.uploadStatus = 'idle';
-        this.feedbackMessage = 'Carga cancelada. Se mantuvo el PDF anterior.';
+        this.feedbackMessage = 'Carga cancelada. Se mantuvieron los archivos previos.';
         return;
       }
     }
 
-    this.readPdfAsBase64(fileToUpload)
-      .then((pdfBase64) => {
-        const metadata = {
-          excelKey,
-          pdfName: fileToUpload.name,
-          pdfBase64,
-          fecha: new Date().toISOString(),
-        };
+    try {
+      const nuevosArchivos = await this.convertirArchivosBase64(this.selectedFiles);
+      const metadata = {
+        excelKey,
+        archivos: [...existingFiles, ...nuevosArchivos],
+        fecha: new Date().toISOString()
+      };
 
-        localStorage.setItem(this.obtenerPdfStorageKey(excelKey), JSON.stringify(metadata));
+      localStorage.setItem(this.obtenerArchivosStorageKey(excelKey), JSON.stringify(metadata));
+
+      const historyEntries = nuevosArchivos.map((archivo) => ({
+        name: archivo.name,
+        size: archivo.size,
+        uploadedAt: metadata.fecha
+      }));
+
+      this.uploadHistory = [...historyEntries, ...this.uploadHistory].slice(0, 5);
+      this.saveUploadHistory();
+      this.actualizarEstadoExcel(excelKey);
 
         this.uploadStatus = 'success';
-        this.feedbackMessage = 'PDF cargado correctamente.';
-
-        const historyEntry = {
-          name: fileToUpload.name,
-          size: fileToUpload.size,
-          uploadedAt: metadata.fecha,
-        };
-
-        this.uploadHistory = [historyEntry, ...this.uploadHistory].slice(0, 5);
-        this.saveUploadHistory();
-        this.actualizarEstadoExcel(excelKey);
-      })
-      .catch(() => {
-        this.uploadStatus = 'error';
-        this.feedbackMessage = 'No se pudo leer el PDF. Intenta nuevamente.';
-      });
+        this.feedbackMessage = 'Archivos cargados correctamente.';
+      } catch (error) {
+      this.uploadStatus = 'error';
+      this.feedbackMessage = 'No se pudieron leer los archivos. Intenta nuevamente.';
+    }
   }
 
   obtenerToken(): string | null {
@@ -138,7 +158,7 @@ export class AdminPanelComponent implements OnInit {
 
   cerrarSesion(): void {
     this.adminAuthService.cerrarSesion();
-    this.selectedFile = null;
+    this.selectedFiles = [];
     this.excelSeleccionado = null;
     this.selectedNivel = '';
     this.uploadStatus = 'idle';
@@ -210,7 +230,7 @@ export class AdminPanelComponent implements OnInit {
       const key = this.obtenerClaveExcel(registro);
       const nivel = this.obtenerNivelRegistro(registro);
       const fecha = registro.fechaGuardado || new Date().toISOString();
-      const estatus = registro.estatus ?? (this.existePdfParaExcel(key) ? 'asignado' : 'pendiente');
+      const estatus = registro.estatus ?? (this.existeArchivosParaExcel(key) ? 'asignado' : 'pendiente');
       return {
         key,
         nombre: registro.nombre,
@@ -277,12 +297,48 @@ export class AdminPanelComponent implements OnInit {
     return this.paginaActual;
   }
 
-  private existePdfParaExcel(excelKey: string): boolean {
-    return !!localStorage.getItem(this.obtenerPdfStorageKey(excelKey));
+  private existeArchivosParaExcel(excelKey: string): boolean {
+    return this.obtenerArchivosParaExcel(excelKey).length > 0;
   }
 
-  private obtenerPdfStorageKey(excelKey: string): string {
-    return `${this.pdfStoragePrefix}:${excelKey}`;
+  private obtenerArchivosStorageKey(excelKey: string): string {
+    return `${this.archivosStoragePrefix}:${excelKey}`;
+  }
+
+  private obtenerArchivosParaExcel(
+    excelKey: string
+  ): Array<{ name: string; size: number; type: string; base64: string }> {
+    const stored = localStorage.getItem(this.obtenerArchivosStorageKey(excelKey));
+    if (!stored) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(stored) as {
+        archivos?: Array<{ name: string; size: number; type: string; base64: string }>;
+        pdfName?: string;
+        pdfBase64?: string;
+      };
+
+      if (Array.isArray(parsed.archivos)) {
+        return parsed.archivos;
+      }
+
+      if (parsed.pdfBase64 && parsed.pdfName) {
+        return [
+          {
+            name: parsed.pdfName,
+            size: 0,
+            type: 'application/pdf',
+            base64: parsed.pdfBase64
+          }
+        ];
+      }
+
+      return [];
+    } catch (error) {
+      return [];
+    }
   }
 
   private obtenerClaveExcel(registro: RegistroArchivo): string {
@@ -314,7 +370,7 @@ export class AdminPanelComponent implements OnInit {
     return 'preescolar';
   }
 
-  private readPdfAsBase64(file: File): Promise<string> {
+  private readArchivoAsBase64(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => {
@@ -327,6 +383,54 @@ export class AdminPanelComponent implements OnInit {
       reader.onerror = () => reject(new Error('Error al leer archivo'));
       reader.readAsDataURL(file);
     });
+  }
+
+  private async convertirArchivosBase64(
+    archivos: File[]
+  ): Promise<Array<{ name: string; size: number; type: string; base64: string }>> {
+    const resultados = [];
+    for (const archivo of archivos) {
+      const base64 = await this.readArchivoAsBase64(archivo);
+      resultados.push({
+        name: archivo.name,
+        size: archivo.size,
+        type: archivo.type,
+        base64
+      });
+    }
+    return resultados;
+  }
+
+  private validarCantidadArchivos(archivos: File[]): { esValida: boolean; mensaje: string } {
+    if (!archivos.length) {
+      return { esValida: false, mensaje: 'Selecciona hasta 10 archivos para comenzar.' };
+    }
+
+    if (archivos.length > this.maxArchivos) {
+      return {
+        esValida: false,
+        mensaje: `Solo puedes seleccionar hasta ${this.maxArchivos} archivos por carga.`
+      };
+    }
+
+    return { esValida: true, mensaje: '' };
+  }
+
+  private validarTiposArchivos(archivos: File[]): { esValida: boolean; mensaje: string } {
+    const archivosInvalidos = archivos.filter((archivo) => {
+      const nombre = archivo.name.toLowerCase();
+      return !this.extensionesPermitidas.some((extension) => nombre.endsWith(extension));
+    });
+
+    if (!archivosInvalidos.length) {
+      return { esValida: true, mensaje: '' };
+    }
+
+    const nombres = archivosInvalidos.map((archivo) => archivo.name).join(', ');
+    return {
+      esValida: false,
+      mensaje: `Tipo de archivo no permitido: ${nombres}. Solo PDF, XLSX, JPG o Word.`
+    };
   }
 }
 

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.html
@@ -42,64 +42,106 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let registro of registrosFiltrados">
-          <td data-label="Nombre">{{ registro.nombre }}</td>
-          <td data-label="Nivel">{{ obtenerEtiquetaNivel(registro.nivel) }}</td>
-          <td data-label="CCT">{{ registro.cct || '—' }}</td>
-          <td data-label="Correo">{{ registro.correo || '—' }}</td>
-          <td data-label="Tamaño">{{ formatearTamano(registro.tamano) }}</td>
-          <td data-label="Fecha">{{ formatearFecha(registro.fechaGuardado) }}</td>
-          <td data-label="Acciones">
-            <div class="archivos__acciones">
-              <button type="button" class="archivos__accion" (click)="descargar(registro)">
-                <svg class="archivos__icono" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                  <path
-                    d="M12 4v10m0 0l-4-4m4 4l4-4M5 20h14"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-                Descargar
-              </button>
-              <button
-                type="button"
-                class="archivos__accion archivos__accion--peligro"
-                (click)="eliminar(registro)"
-                aria-label="Eliminar archivo guardado"
-                title="Eliminar"
-              >
-                <svg class="archivos__icono" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                  <path
-                    d="M9 3.5h6M4 7h16M18 7l-.6 11.1c-.08 1.4-1.23 2.4-2.63 2.4H9.23c-1.4 0-2.55-1.05-2.63-2.45L6 7"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linecap="round"
-                  />
-                  <path d="M10 11v6m4-6v6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
-                </svg>
-              </button>
-            </div>
-          </td>
-          <td data-label="Resultados">
-            <ng-container *ngIf="obtenerPdfPorRegistro(registro) as resultadoPdf; else pendienteResultado">
-              <div class="archivos__resultado">
-                <span class="archivos__resultado-nombre">
-                  {{ obtenerEtiquetaPdf(resultadoPdf) }}
-                </span>
+        <ng-container *ngFor="let registro of registrosFiltrados">
+          <tr>
+            <td data-label="Nombre">{{ registro.nombre }}</td>
+            <td data-label="Nivel">{{ obtenerEtiquetaNivel(registro.nivel) }}</td>
+            <td data-label="CCT">{{ registro.cct || '—' }}</td>
+            <td data-label="Correo">{{ registro.correo || '—' }}</td>
+            <td data-label="Tamaño">{{ formatearTamano(registro.tamano) }}</td>
+            <td data-label="Fecha">{{ formatearFecha(registro.fechaGuardado) }}</td>
+            <td data-label="Acciones">
+              <div class="archivos__acciones">
+                <button type="button" class="archivos__accion" (click)="descargar(registro)">
+                  <svg class="archivos__icono" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path
+                      d="M12 4v10m0 0l-4-4m4 4l4-4M5 20h14"
+                      stroke="currentColor"
+                      stroke-width="1.6"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                  Descargar
+                </button>
                 <button
                   type="button"
-                  class="archivos__accion"
-                  (click)="descargarResultados(resultadoPdf.storageKey)"
+                  class="archivos__accion archivos__accion--peligro"
+                  (click)="eliminar(registro)"
+                  aria-label="Eliminar archivo guardado"
+                  title="Eliminar"
                 >
-                  Descargar resultados
+                  <svg class="archivos__icono" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path
+                      d="M9 3.5h6M4 7h16M18 7l-.6 11.1c-.08 1.4-1.23 2.4-2.63 2.4H9.23c-1.4 0-2.55-1.05-2.63-2.45L6 7"
+                      stroke="currentColor"
+                      stroke-width="1.6"
+                      stroke-linecap="round"
+                    />
+                    <path d="M10 11v6m4-6v6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                  </svg>
                 </button>
               </div>
-            </ng-container>
-            <ng-template #pendienteResultado>Pendiente</ng-template>
-          </td>
-        </tr>
+            </td>
+            <td data-label="Resultados">
+              <ng-container *ngIf="obtenerResultadosPorRegistro(registro) as resultadoArchivos; else pendienteResultado">
+                <button
+                  type="button"
+                  class="archivos__resultado-toggle"
+                  (click)="toggleResultados(resultadoArchivos.storageKey)"
+                  [attr.aria-expanded]="estaFilaExpandida(resultadoArchivos.storageKey)"
+                >
+                  <svg
+                    class="archivos__icono"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                    [attr.data-expandido]="estaFilaExpandida(resultadoArchivos.storageKey)"
+                  >
+                    <path
+                      d="M8 5l8 7-8 7"
+                      stroke="currentColor"
+                      stroke-width="1.8"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                  Ver resultados ({{ resultadoArchivos.archivos.length }})
+                </button>
+              </ng-container>
+              <ng-template #pendienteResultado>Pendiente</ng-template>
+            </td>
+          </tr>
+          <tr
+            class="archivos__resultados-row"
+            *ngIf="
+              obtenerResultadosPorRegistro(registro) as resultadoArchivos;
+              else sinResultados
+            "
+            [class.archivos__resultados-row--visible]="estaFilaExpandida(resultadoArchivos.storageKey)"
+            [hidden]="!estaFilaExpandida(resultadoArchivos.storageKey)"
+          >
+            <td colspan="8">
+              <div class="archivos__resultados">
+                <h4>Archivos de resultados</h4>
+                <ul>
+                  <li *ngFor="let archivo of resultadoArchivos.archivos">
+                    <span>{{ archivo.name }}</span>
+                    <span class="archivos__resultados-meta">{{ formatearTamano(archivo.size) }}</span>
+                    <button
+                      type="button"
+                      class="archivos__accion"
+                      (click)="descargarResultados(archivo)"
+                    >
+                      Descargar
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+          <ng-template #sinResultados></ng-template>
+        </ng-container>
       </tbody>
     </table>
   </div>

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.scss
@@ -196,6 +196,63 @@
   font-size: 1.5rem;
 }
 
+.archivos__resultado-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: none;
+  background: transparent;
+  color: #1f2937;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+}
+
+.archivos__resultado-toggle svg {
+  transition: transform 0.2s ease;
+}
+
+.archivos__resultado-toggle svg[data-expandido='true'] {
+  transform: rotate(90deg);
+}
+
+.archivos__resultados-row {
+  background: #f8fafc;
+}
+
+.archivos__resultados {
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.archivos__resultados h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.archivos__resultados ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.archivos__resultados li {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.archivos__resultados-meta {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
 .archivos__vacio {
   text-align: center;
   padding: 2rem 1rem;

--- a/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
+++ b/web/frontend/src/app/components/archivos-guardados/archivos-guardados.component.ts
@@ -22,8 +22,10 @@ export class ArchivosGuardadosComponent implements OnInit {
   mensajeError: string | null = null;
   correoActivo: string | null = null;
   filtroTexto = '';
+  private readonly resultadosStoragePrefix = 'archivos-resultados';
   private readonly pdfStoragePrefix = 'pdf-resultados';
-  private resultadosPdf: Record<string, PdfMetadataConStorage> = {};
+  private resultadosArchivos: Record<string, ResultadoArchivosConStorage> = {};
+  filasExpandidas = new Set<string>();
 
   constructor(
     private readonly archivoStorageService: ArchivoStorageService,
@@ -44,7 +46,8 @@ export class ArchivosGuardadosComponent implements OnInit {
   cargarRegistros(): void {
     this.mensajeError = null;
     this.registros = this.archivoStorageService.obtenerRegistros(this.correoActivo);
-    this.cargarResultadosPdf();
+    this.cargarResultadosArchivos();
+    this.filasExpandidas.clear();
 
     if (this.registros.length === 0) {
       this.mensajeInfo = 'Aún no has cargado archivos en este navegador.';
@@ -113,56 +116,50 @@ export class ArchivosGuardadosComponent implements OnInit {
     }
   }
 
-  descargarResultados(storageKey: string): void {
-    const data = localStorage.getItem(storageKey);
-    if (!data) {
+  descargarResultados(archivo: ResultadoArchivo): void {
+    const base64 = archivo.base64 ?? '';
+    const [header, base64Data] = base64.split(',');
+    if (!base64Data) {
       return;
     }
 
-    try {
-      const parsed = JSON.parse(data) as PdfMetadata;
-      if (!parsed?.pdfBase64) {
-        return;
-      }
+    const mimeMatch = header?.match(/data:(.*?);base64/);
+    const mimeType = mimeMatch?.[1] ?? archivo.type ?? 'application/octet-stream';
+    const byteString = atob(base64Data);
+    const bytes = new Uint8Array(byteString.length);
+    for (let i = 0; i < byteString.length; i += 1) {
+      bytes[i] = byteString.charCodeAt(i);
+    }
 
-      const [header, base64Data] = parsed.pdfBase64.split(',');
-      if (!base64Data) {
-        return;
-      }
+    const blob = new Blob([bytes], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const enlace = document.createElement('a');
+    enlace.href = url;
+    enlace.download = archivo.name ?? 'resultado';
+    enlace.style.display = 'none';
 
-      const mimeMatch = header?.match(/data:(.*?);base64/);
-      const mimeType = mimeMatch?.[1] ?? 'application/pdf';
-      const byteString = atob(base64Data);
-      const bytes = new Uint8Array(byteString.length);
-      for (let i = 0; i < byteString.length; i += 1) {
-        bytes[i] = byteString.charCodeAt(i);
-      }
+    document.body.appendChild(enlace);
+    enlace.click();
+    document.body.removeChild(enlace);
+    URL.revokeObjectURL(url);
+    this.registrarDescarga(enlace.download);
+  }
 
-      const blob = new Blob([bytes], { type: mimeType });
-      const url = URL.createObjectURL(blob);
-      const enlace = document.createElement('a');
-      enlace.href = url;
-      enlace.download = parsed.pdfName ?? 'resultados.pdf';
-      enlace.style.display = 'none';
+  obtenerResultadosPorRegistro(registro: RegistroArchivo): ResultadoArchivosConStorage | null {
+    const storageKey = this.obtenerResultadosStorageKey(registro);
+    return this.resultadosArchivos[storageKey] ?? null;
+  }
 
-      document.body.appendChild(enlace);
-      enlace.click();
-      document.body.removeChild(enlace);
-      URL.revokeObjectURL(url);
-      this.registrarDescarga(enlace.download);
-    } catch (error) {
+  toggleResultados(storageKey: string): void {
+    if (this.filasExpandidas.has(storageKey)) {
+      this.filasExpandidas.delete(storageKey);
       return;
     }
+    this.filasExpandidas.add(storageKey);
   }
 
-  obtenerPdfPorRegistro(registro: RegistroArchivo): PdfMetadataConStorage | null {
-    const storageKey = this.obtenerPdfStorageKey(registro);
-    return this.resultadosPdf[storageKey] ?? null;
-  }
-
-  obtenerEtiquetaPdf(resultado: PdfMetadataConStorage): string {
-    const nombre = resultado.pdfName?.trim();
-    return nombre ? nombre : 'PDF asignado';
+  estaFilaExpandida(storageKey: string): boolean {
+    return this.filasExpandidas.has(storageKey);
   }
 
   obtenerEtiquetaNivel(nivel?: string): string {
@@ -214,19 +211,45 @@ export class ArchivosGuardadosComponent implements OnInit {
     return `${valor.toFixed(valor >= 10 ? 1 : 2)} ${unidades[indice]}`;
   }
 
-  private cargarResultadosPdf(): void {
-    this.resultadosPdf = {};
+  private cargarResultadosArchivos(): void {
+    this.resultadosArchivos = {};
     this.registros.forEach((registro) => {
-      const storageKey = this.obtenerPdfStorageKey(registro);
-      const data = localStorage.getItem(storageKey);
-      if (!data) {
+      const resultadosKey = this.obtenerResultadosStorageKey(registro);
+      const dataResultados = localStorage.getItem(resultadosKey);
+      if (dataResultados) {
+        try {
+          const parsed = JSON.parse(dataResultados) as ResultadoArchivos;
+          if (Array.isArray(parsed.archivos) && parsed.archivos.length) {
+            this.resultadosArchivos[resultadosKey] = { ...parsed, storageKey: resultadosKey };
+            return;
+          }
+        } catch (error) {
+          return;
+        }
+      }
+
+      const pdfKey = this.obtenerPdfStorageKey(registro);
+      const dataPdf = localStorage.getItem(pdfKey);
+      if (!dataPdf) {
         return;
       }
 
       try {
-        const parsed = JSON.parse(data) as PdfMetadata;
+        const parsed = JSON.parse(dataPdf) as PdfMetadata;
         if (parsed?.pdfBase64) {
-          this.resultadosPdf[storageKey] = { ...parsed, storageKey };
+          this.resultadosArchivos[resultadosKey] = {
+            excelKey: parsed.excelKey,
+            fecha: parsed.fecha,
+            archivos: [
+              {
+                name: parsed.pdfName,
+                size: 0,
+                type: 'application/pdf',
+                base64: parsed.pdfBase64
+              }
+            ],
+            storageKey: resultadosKey
+          };
         }
       } catch (error) {
         return;
@@ -234,13 +257,21 @@ export class ArchivosGuardadosComponent implements OnInit {
     });
   }
 
+  private obtenerResultadosStorageKey(registro: RegistroArchivo): string {
+    return `${this.resultadosStoragePrefix}:${this.obtenerClaveRegistro(registro)}`;
+  }
+
   private obtenerPdfStorageKey(registro: RegistroArchivo): string {
-    const claveEstable =
+    return `${this.pdfStoragePrefix}:${this.obtenerClaveRegistro(registro)}`;
+  }
+
+  private obtenerClaveRegistro(registro: RegistroArchivo): string {
+    return (
       registro.claveEstable ??
       `${(registro.cct ?? '').trim()}|${(registro.correo ?? '').trim().toLowerCase()}|${
         registro.nombre
-      }|${registro.fechaGuardado}`;
-    return `${this.pdfStoragePrefix}:${claveEstable}`;
+      }|${registro.fechaGuardado}`
+    );
   }
 
   private registrarDescarga(nombre: string): void {
@@ -259,6 +290,19 @@ interface PdfMetadata {
   fecha: string;
 }
 
-interface PdfMetadataConStorage extends PdfMetadata {
+interface ResultadoArchivo {
+  name: string;
+  size: number;
+  type: string;
+  base64: string;
+}
+
+interface ResultadoArchivos {
+  excelKey: string;
+  archivos: ResultadoArchivo[];
+  fecha: string;
+}
+
+interface ResultadoArchivosConStorage extends ResultadoArchivos {
   storageKey: string;
 }

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -210,6 +210,7 @@
       <div class="carga__acciones">
         <button
           class="carga__boton-primario"
+          *ngIf="!mostrarCargaMasiva"
           [class.carga__boton-guardado]="resultado.guardado"
           (click)="guardarArchivo(resultado)"
           [disabled]="resultado.estado !== 'exito' || resultado.guardando || !correoControl.valid || resultado.guardado"
@@ -259,6 +260,16 @@
         </button>
       </div>
     </article>
+
+    <div class="carga__acciones carga__acciones--totales" *ngIf="mostrarCargaMasiva">
+      <button
+        class="carga__boton-primario"
+        (click)="guardarTodo()"
+        [disabled]="!puedeCargarTodo"
+      >
+        {{ guardandoTodo ? 'Guardando…' : 'CARGAR TODO' }}
+      </button>
+    </div>
 
     <p class="carga__historial">
       ¿Ya guardaste un archivo? <a routerLink="/archivos-preescolar">Consulta tus cargas anteriores</a>.

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.scss
@@ -620,6 +620,11 @@
   margin-top: 0.9rem;
 }
 
+.carga__acciones--totales {
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
 .carga__boton-primario,
 .carga__boton-secundario {
   padding: 0.8rem 1.2rem;

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -92,6 +92,7 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
   credencialesMostradas: CredencialesMostradas | null = null;
   credencialesAsociadas = false;
   contrasenaAsociada: string | null = null;
+  guardandoTodo = false;
   trackByArchivo = (_: number, item: ResultadoArchivo): string =>
     `${item.archivo.name}-${item.archivo.lastModified.getTime()}`;
 
@@ -99,6 +100,18 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
 
   get hayErrores(): boolean {
     return this.resultados.some((resultado) => resultado.estado === 'error');
+  }
+
+  get mostrarCargaMasiva(): boolean {
+    return this.resultados.length > 2;
+  }
+
+  get resultadosValidosSinGuardar(): ResultadoArchivo[] {
+    return this.resultados.filter((resultado) => resultado.estado === 'exito' && !resultado.guardado);
+  }
+
+  get puedeCargarTodo(): boolean {
+    return this.correoControl.valid && this.resultadosValidosSinGuardar.length > 0 && !this.guardandoTodo;
   }
 
   constructor(
@@ -353,6 +366,37 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       });
     } finally {
       resultado.guardando = false;
+    }
+  }
+
+  async guardarTodo(): Promise<void> {
+    if (!this.correoControl.valid) {
+      this.correoControl.markAllAsTouched();
+      await Swal.fire({
+        icon: 'warning',
+        title: 'Correo requerido',
+        text: 'Agrega un correo electrónico válido antes de guardar tus archivos.'
+      });
+      return;
+    }
+
+    if (!this.resultadosValidosSinGuardar.length) {
+      await Swal.fire({
+        icon: 'info',
+        title: 'Sin archivos listos',
+        text: 'No hay archivos validados correctamente para guardar.'
+      });
+      return;
+    }
+
+    this.guardandoTodo = true;
+
+    try {
+      for (const resultado of this.resultadosValidosSinGuardar) {
+        await this.guardarArchivo(resultado);
+      }
+    } finally {
+      this.guardandoTodo = false;
     }
   }
 

--- a/web/frontend/src/app/components/tickets/tickets.component.html
+++ b/web/frontend/src/app/components/tickets/tickets.component.html
@@ -1,0 +1,78 @@
+<section class="tickets">
+  <header class="tickets__encabezado">
+    <p class="tickets__eyebrow">Mesa de ayuda</p>
+    <h1 class="tickets__titulo">Crear ticket de soporte</h1>
+    <p class="tickets__descripcion">
+      Comparte tu problema para que podamos ayudarte a validar y subir tus archivos.
+    </p>
+  </header>
+
+  <form class="tickets__formulario" (ngSubmit)="enviarTicket()">
+    <label class="tickets__campo">
+      <span>Motivo del ticket</span>
+      <select [formControl]="motivoControl">
+        <option value="" disabled>Selecciona una opción</option>
+        <option *ngFor="let motivo of motivos" [value]="motivo">{{ motivo }}</option>
+      </select>
+      <small class="tickets__error" *ngIf="motivoControl.invalid && motivoControl.touched">
+        Selecciona un motivo.
+      </small>
+    </label>
+
+    <label class="tickets__campo" *ngIf="mostrarMotivoOtro">
+      <span>Describe el motivo</span>
+      <input
+        type="text"
+        [formControl]="motivoOtroControl"
+        placeholder="Escribe el motivo específico"
+        maxlength="200"
+      />
+      <small class="tickets__error" *ngIf="motivoOtroControl.invalid && motivoOtroControl.touched">
+        Ingresa un motivo válido.
+      </small>
+    </label>
+
+    <label class="tickets__campo">
+      <span>Describe tu problema</span>
+      <textarea
+        [formControl]="descripcionControl"
+        rows="6"
+        placeholder="Incluye detalles como fecha, nivel, CCT o mensajes de error."
+        maxlength="1500"
+      ></textarea>
+      <small class="tickets__error" *ngIf="descripcionControl.invalid && descripcionControl.touched">
+        Este campo es obligatorio.
+      </small>
+    </label>
+
+    <div class="tickets__campo">
+      <span>Evidencias (máximo {{ maxEvidencias }})</span>
+      <div class="tickets__evidencias">
+        <label class="tickets__evidencias-boton">
+          Agregar evidencia
+          <input
+            type="file"
+            accept=".pdf,.xlsx,.xls,.doc,.docx,.jpg,.jpeg,.png"
+            (change)="onArchivoSeleccionado($event)"
+            [disabled]="!puedeAgregarEvidencias"
+          />
+        </label>
+        <p class="tickets__evidencias-ayuda">
+          Sube archivos uno por uno (PDF, Excel, Word o imágenes).
+        </p>
+      </div>
+
+      <ul class="tickets__evidencias-lista" *ngIf="evidencias.length">
+        <li *ngFor="let evidencia of evidencias">
+          <span>{{ evidencia.archivo.name }}</span>
+          <button type="button" (click)="quitarEvidencia(evidencia.id)">Quitar</button>
+        </li>
+      </ul>
+    </div>
+
+    <p class="tickets__mensaje tickets__mensaje--error" *ngIf="mensajeError">{{ mensajeError }}</p>
+    <p class="tickets__mensaje tickets__mensaje--exito" *ngIf="mensajeExito">{{ mensajeExito }}</p>
+
+    <button class="tickets__boton" type="submit">Enviar ticket</button>
+  </form>
+</section>

--- a/web/frontend/src/app/components/tickets/tickets.component.scss
+++ b/web/frontend/src/app/components/tickets/tickets.component.scss
@@ -1,0 +1,167 @@
+.tickets {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  color: #1f2937;
+}
+
+.tickets__encabezado {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tickets__eyebrow {
+  color: #0f766e;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.tickets__titulo {
+  margin: 0;
+  font-size: clamp(1.8rem, 2vw, 2.2rem);
+}
+
+.tickets__descripcion {
+  margin: 0;
+  color: #4b5563;
+}
+
+.tickets__formulario {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+}
+
+.tickets__campo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.tickets__campo input,
+.tickets__campo textarea,
+.tickets__campo select {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.tickets__campo textarea {
+  resize: vertical;
+}
+
+.tickets__error {
+  color: #b91c1c;
+  font-weight: 500;
+}
+
+.tickets__evidencias {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.tickets__evidencias-boton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  border-radius: 10px;
+  border: 1px dashed #0f766e;
+  color: #0f766e;
+  font-weight: 700;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.tickets__evidencias-boton input {
+  display: none;
+}
+
+.tickets__evidencias-ayuda {
+  margin: 0;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.tickets__evidencias-lista {
+  list-style: none;
+  padding: 0;
+  margin: 0.4rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.tickets__evidencias-lista li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: #f9fafb;
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+}
+
+.tickets__evidencias-lista button {
+  border: none;
+  background: #fee2e2;
+  color: #991b1b;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 0.35rem 0.7rem;
+  cursor: pointer;
+}
+
+.tickets__mensaje {
+  margin: 0;
+  font-weight: 600;
+}
+
+.tickets__mensaje--error {
+  color: #b91c1c;
+}
+
+.tickets__mensaje--exito {
+  color: #047857;
+}
+
+.tickets__boton {
+  align-self: flex-start;
+  padding: 0.85rem 1.4rem;
+  border-radius: 10px;
+  border: none;
+  background: #0f766e;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.tickets__boton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 118, 110, 0.2);
+}
+
+@media (max-width: 720px) {
+  .tickets__formulario {
+    padding: 1.2rem;
+  }
+
+  .tickets__boton {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/web/frontend/src/app/components/tickets/tickets.component.ts
+++ b/web/frontend/src/app/components/tickets/tickets.component.ts
@@ -1,0 +1,111 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+
+interface EvidenciaArchivo {
+  id: string;
+  archivo: File;
+}
+
+@Component({
+  selector: 'app-tickets',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './tickets.component.html',
+  styleUrl: './tickets.component.scss'
+})
+export class TicketsComponent {
+  readonly motivos = [
+    'Tengo problemas para subir mi evaluación',
+    'Necesito apoyo con mis credenciales',
+    'Otra'
+  ];
+  readonly maxEvidencias = 10;
+  readonly extensionesPermitidas = ['.pdf', '.xlsx', '.xls', '.doc', '.docx', '.jpg', '.jpeg', '.png'];
+
+  readonly motivoControl = new FormControl('', { nonNullable: true, validators: [Validators.required] });
+  readonly motivoOtroControl = new FormControl('', {
+    nonNullable: true,
+    validators: [Validators.maxLength(200)]
+  });
+  readonly descripcionControl = new FormControl('', {
+    nonNullable: true,
+    validators: [Validators.required, Validators.maxLength(1500)]
+  });
+
+  evidencias: EvidenciaArchivo[] = [];
+  mensajeError: string | null = null;
+  mensajeExito: string | null = null;
+
+  get mostrarMotivoOtro(): boolean {
+    return this.motivoControl.value === 'Otra';
+  }
+
+  get puedeAgregarEvidencias(): boolean {
+    return this.evidencias.length < this.maxEvidencias;
+  }
+
+  onArchivoSeleccionado(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const archivo = input.files?.[0];
+    input.value = '';
+    this.mensajeError = null;
+    this.mensajeExito = null;
+
+    if (!archivo) {
+      return;
+    }
+
+    if (!this.puedeAgregarEvidencias) {
+      this.mensajeError = `Solo puedes adjuntar hasta ${this.maxEvidencias} evidencias.`;
+      return;
+    }
+
+    if (!this.esExtensionPermitida(archivo.name)) {
+      this.mensajeError = 'Formato no permitido. Usa PDF, Excel, Word o imágenes.';
+      return;
+    }
+
+    this.evidencias = [
+      ...this.evidencias,
+      { id: crypto.randomUUID(), archivo }
+    ];
+  }
+
+  quitarEvidencia(id: string): void {
+    this.evidencias = this.evidencias.filter((item) => item.id !== id);
+  }
+
+  enviarTicket(): void {
+    this.mensajeError = null;
+    this.mensajeExito = null;
+
+    if (!this.motivoControl.valid || !this.descripcionControl.valid) {
+      this.motivoControl.markAllAsTouched();
+      this.descripcionControl.markAllAsTouched();
+      if (this.mostrarMotivoOtro) {
+        this.motivoOtroControl.markAllAsTouched();
+      }
+      this.mensajeError = 'Completa los campos obligatorios para enviar el ticket.';
+      return;
+    }
+
+    if (this.mostrarMotivoOtro && !this.motivoOtroControl.value.trim()) {
+      this.motivoOtroControl.markAllAsTouched();
+      this.mensajeError = 'Indica el motivo cuando seleccionas "Otra".';
+      return;
+    }
+
+    this.mensajeExito =
+      'Tu ticket se registró correctamente. En breve te contactaremos por correo.';
+    this.motivoControl.reset('');
+    this.motivoOtroControl.reset('');
+    this.descripcionControl.reset('');
+    this.evidencias = [];
+  }
+
+  private esExtensionPermitida(nombre: string): boolean {
+    const nombreLower = nombre.toLowerCase();
+    return this.extensionesPermitidas.some((extension) => nombreLower.endsWith(extension));
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a user-facing support channel so schools can report upload problems or other questions and attach evidence files.
- Allow administrators to attach multiple result files per Excel record and surface downloadable results to teachers in the saved-files list.
- Add a convenient bulk “CARGAR TODO” action to persist many validated files at once.
- Align architecture docs to the chosen backend API style (`GraphQL`) used in recent updates.

### Description
- Added a new standalone `TicketsComponent` with template and styles (`tickets.component.ts|html|scss`) providing a reason `select` (including conditional “Otra”), a description textarea, one-by-one evidence upload handling (`onArchivoSeleccionado()`), client-side file-type and max-10 validation, and `enviarTicket()` success/error flows.
- Enhanced admin upload flow to accept multiple files (`multiple`), validate types/limits client-side, convert files to base64 and persist under `archivos-resultados:<excelKey>` with updated history key, and replaced single-PDF upload API/UI with `subirArchivos()`/`convertirArchivosBase64()` handling in `admin-panel.component.*`.
- Updated saved-files list (`archivos-guardados.component.*`) to show an expandable results toggle instead of a plain “Pendiente”, to read multiple result files (with legacy single-PDF fallback), manage expanded-row state (`filasExpandidas`), and provide per-file download via `descargarResultados(archivo)`.
- Added bulk-save flow to `carga-masiva.component.*` including `mostrarCargaMasiva`, `resultadosValidosSinGuardar`, `puedeCargarTodo`, `guardarTodo()` and UI/SCSS changes to surface a “CARGAR TODO” action.
- Styling tweaks: new CSS for result-toggle chevron, expanded results row, tickets form layout and bulk-actions styling (`*.scss` files updated).
- Documentation updates: replaced references to `FastAPI` with `GraphQL` and adjusted related phrasing across architecture and planning docs (`web/doc/*`).
- Wired the `TicketsComponent` into routing at `'/tickets'` (`app.routes.ts`).

### Testing
- Frontend dev server was started with `npm run start` (which runs `ng serve`) and the Angular dev server completed bundle generation successfully and entered watch mode (application built). This run succeeded.
- A Playwright script was attempted to capture a screenshot of `http://127.0.0.1:4200/tickets`, but the Chromium process crashed in this environment (SIGSEGV) and the screenshot step failed. 
- No automated unit tests (`ng test`) or end-to-end tests completed successfully as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69700648d0848320af8a09e33fb83bf6)