### PR TITLE
Usar evento nativo `submit` en el formulario de tickets

### DIFF
--- a/web/frontend/src/app/components/tickets/tickets.component.html
+++ b/web/frontend/src/app/components/tickets/tickets.component.html
@@ -10,7 +10,7 @@
     </p>
   </header>
 
-  <form class="tickets__formulario" (ngSubmit)="enviarTicket($event)">
+  <form class="tickets__formulario" (submit)="enviarTicket($event)">
     <label class="tickets__campo">
       <span>Motivo del ticket</span>
       <select [formControl]="motivoControl">


### PR DESCRIPTION
### Motivation
- Asegurar que el envío del formulario ejecute el handler aun cuando no exista un `FormGroup`/`ngForm` asociado para que la información se guarde en `localStorage` (`tickets-soporte`) y se muestre el JSON y la lista de tickets.

### Description
- Cambiado el template para escuchar el evento nativo `submit` en lugar de `(ngSubmit)` en `web/frontend/src/app/components/tickets/tickets.component.html` (`<form class="tickets__formulario" (submit)="enviarTicket($event)">`).

### Testing
- No se ejecutaron pruebas automatizadas en este cambio (ninguna prueba fue solicitada ni corrida).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69715920f1e88320955e8d5acba41338)