### PR TITLE
Alinear colores de tickets con la paleta base y añadir gestión de tickets en AdminPanel

### DIFF
--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.html
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.html
@@ -186,6 +186,112 @@
       </div>
     </div>
 
+    <section class="admin-panel__tickets">
+      <h3>Tickets de soporte</h3>
+      <div class="admin-panel__tickets-filters">
+        <label>
+          <span>Buscar</span>
+          <input
+            type="text"
+            [(ngModel)]="filtroTicketTexto"
+            placeholder="Folio, correo o motivo"
+          />
+        </label>
+        <label>
+          <span>Estatus</span>
+          <select [(ngModel)]="filtroTicketEstatus">
+            <option value="todos">Todos</option>
+            <option value="pendiente">Pendiente</option>
+            <option value="en-proceso">En proceso</option>
+            <option value="respondido">Respondido</option>
+          </select>
+        </label>
+      </div>
+
+      <p class="admin-panel__tickets-empty" *ngIf="!ticketsSoporteFiltrados.length">
+        No hay tickets registrados aún.
+      </p>
+
+      <div class="admin-panel__tickets-grid" *ngIf="ticketsSoporteFiltrados.length">
+        <div class="admin-panel__tickets-list">
+          <button
+            class="admin-panel__ticket-card"
+            type="button"
+            *ngFor="let ticket of ticketsSoporteFiltrados"
+            (click)="seleccionarTicket(ticket)"
+            [class.admin-panel__ticket-card--active]="ticket.id === ticketSeleccionadoId"
+          >
+            <div class="admin-panel__ticket-header">
+              <strong>{{ ticket.folio }}</strong>
+              <span class="admin-panel__ticket-status">{{ ticket.estatus }}</span>
+            </div>
+            <p>{{ ticket.motivo }}</p>
+            <small>{{ ticket.correo }}</small>
+            <small>{{ formatearFecha(ticket.fecha) }}</small>
+            <small *ngIf="obtenerUltimaRespuesta(ticket) as respuesta">
+              Última respuesta: {{ formatearFecha(respuesta.fecha) }}
+            </small>
+          </button>
+        </div>
+
+        <div class="admin-panel__ticket-detail" *ngIf="ticketSeleccionadoId as ticketId">
+          <ng-container *ngFor="let ticket of ticketsSoporte">
+            <ng-container *ngIf="ticket.id === ticketId">
+              <h4>Detalle del ticket</h4>
+              <p><strong>Folio:</strong> {{ ticket.folio }}</p>
+              <p><strong>Correo:</strong> {{ ticket.correo }}</p>
+              <p><strong>Motivo:</strong> {{ ticket.motivo }}</p>
+              <p *ngIf="ticket.motivoDetalle">
+                <strong>Motivo detalle:</strong> {{ ticket.motivoDetalle }}
+              </p>
+              <p><strong>Descripción:</strong> {{ ticket.descripcion }}</p>
+              <p><strong>Fecha:</strong> {{ formatearFecha(ticket.fecha) }}</p>
+
+              <div class="admin-panel__ticket-evidencias" *ngIf="ticket.evidencias.length">
+                <strong>Evidencias:</strong>
+                <ul>
+                  <li *ngFor="let evidencia of ticket.evidencias">{{ evidencia.nombre }}</li>
+                </ul>
+              </div>
+
+              <div class="admin-panel__ticket-respuestas" *ngIf="ticket.respuestas?.length">
+                <strong>Respuestas previas:</strong>
+                <div
+                  class="admin-panel__ticket-respuesta"
+                  *ngFor="let respuesta of ticket.respuestas"
+                >
+                  <p>{{ respuesta.mensaje }}</p>
+                  <small>{{ formatearFecha(respuesta.fecha) }}</small>
+                </div>
+              </div>
+
+              <div class="admin-panel__ticket-actions">
+                <label>
+                  <span>Estatus</span>
+                  <select [(ngModel)]="estatusTicketSeleccionado">
+                    <option value="pendiente">Pendiente</option>
+                    <option value="en-proceso">En proceso</option>
+                    <option value="respondido">Respondido</option>
+                  </select>
+                </label>
+                <label>
+                  <span>Respuesta al usuario</span>
+                  <textarea
+                    rows="4"
+                    [(ngModel)]="respuestaAdmin"
+                    placeholder="Escribe la respuesta del administrador"
+                  ></textarea>
+                </label>
+                <button class="admin-panel__ticket-save" type="button" (click)="guardarRespuesta()">
+                  Guardar respuesta
+                </button>
+              </div>
+            </ng-container>
+          </ng-container>
+        </div>
+      </div>
+    </section>
+
     <!-- <a class="admin-panel__link" routerLink="/admin/login">Ir al login</a> -->
     <button class="admin-panel__logout" type="button" (click)="cerrarSesion()">Cerrar sesión</button>
   </div>

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.scss
@@ -276,6 +276,159 @@
   color: #98989a;
 }
 
+.admin-panel__tickets {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin-panel__tickets h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #13322e;
+}
+
+.admin-panel__tickets-filters {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.admin-panel__tickets-filters label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: #13322e;
+}
+
+.admin-panel__tickets-filters input,
+.admin-panel__tickets-filters select,
+.admin-panel__ticket-actions select,
+.admin-panel__ticket-actions textarea {
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+}
+
+.admin-panel__tickets-empty {
+  margin: 0;
+  color: #64748b;
+}
+
+.admin-panel__tickets-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(220px, 1fr) minmax(280px, 1.6fr);
+}
+
+.admin-panel__tickets-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-panel__ticket-card {
+  text-align: left;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.admin-panel__ticket-card--active {
+  border-color: #0f766e;
+  box-shadow: 0 10px 20px rgba(15, 118, 110, 0.15);
+}
+
+.admin-panel__ticket-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-weight: 700;
+  color: #13322e;
+}
+
+.admin-panel__ticket-status {
+  text-transform: capitalize;
+  font-size: 0.9rem;
+  color: #0f766e;
+}
+
+.admin-panel__ticket-detail {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-panel__ticket-detail h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #13322e;
+}
+
+.admin-panel__ticket-evidencias ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.admin-panel__ticket-respuestas {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-panel__ticket-respuesta {
+  background: #ecfeff;
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+}
+
+.admin-panel__ticket-respuesta p {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.admin-panel__ticket-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-panel__ticket-actions label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: #13322e;
+}
+
+.admin-panel__ticket-actions textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.admin-panel__ticket-save {
+  align-self: flex-start;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  background: #0f766e;
+  color: #ffffff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .admin-panel__logout {
   align-self: flex-start;
   padding: 0.75rem 1.5rem;
@@ -320,6 +473,10 @@
   .admin-panel__history-title,
   .admin-panel__history-meta {
     font-size: 0.95rem;
+  }
+
+  .admin-panel__tickets-grid {
+    grid-template-columns: 1fr;
   }
 
   .admin-panel__table {

--- a/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
+++ b/web/frontend/src/app/components/admin-panel/admin-panel.component.ts
@@ -26,10 +26,17 @@ export class AdminPanelComponent implements OnInit {
   filtroTexto = '';
   filtroEstatus: 'todos' | 'asignado' | 'pendiente' = 'todos';
   filtroFecha = '';
+  ticketsSoporte: TicketSoporte[] = [];
+  ticketSeleccionadoId: string | null = null;
+  respuestaAdmin = '';
+  estatusTicketSeleccionado: TicketSoporte['estatus'] = 'pendiente';
+  filtroTicketTexto = '';
+  filtroTicketEstatus: 'todos' | TicketSoporte['estatus'] = 'todos';
   paginaActual = 1;
   tamanioPagina = 10;
   private readonly uploadHistoryKey = 'adminPanelResultadosHistory';
   private readonly archivosStoragePrefix = 'archivos-resultados';
+  private readonly ticketsStorageKey = 'tickets-soporte';
 
   constructor(
     private readonly adminAuthService: AdminAuthService,
@@ -40,6 +47,7 @@ export class AdminPanelComponent implements OnInit {
   ngOnInit(): void {
     this.uploadHistory = this.loadUploadHistory();
     this.cargarExcelDisponibles();
+    this.cargarTicketsSoporte();
   }
 
   seleccionarArchivo(event: Event): void {
@@ -166,6 +174,77 @@ export class AdminPanelComponent implements OnInit {
     void this.router.navigate(['/admin/login']);
   }
 
+  get ticketsSoporteFiltrados(): TicketSoporte[] {
+    const texto = this.filtroTicketTexto.trim().toLowerCase();
+    const estatus = this.filtroTicketEstatus;
+    return this.ticketsSoporte.filter((ticket) => {
+      const coincideTexto =
+        !texto ||
+        ticket.folio.toLowerCase().includes(texto) ||
+        ticket.correo.toLowerCase().includes(texto) ||
+        ticket.motivo.toLowerCase().includes(texto);
+      const coincideEstatus = estatus === 'todos' || ticket.estatus === estatus;
+      return coincideTexto && coincideEstatus;
+    });
+  }
+
+  seleccionarTicket(ticket: TicketSoporte): void {
+    this.ticketSeleccionadoId = ticket.id;
+    this.estatusTicketSeleccionado = ticket.estatus;
+    this.respuestaAdmin = '';
+  }
+
+  guardarRespuesta(): void {
+    if (!this.ticketSeleccionadoId) {
+      return;
+    }
+
+    const mensaje = this.respuestaAdmin.trim();
+    const tickets = this.obtenerTicketsSoporte();
+    const actualizados = tickets.map((ticket) => {
+      if (ticket.id !== this.ticketSeleccionadoId) {
+        return ticket;
+      }
+      const respuestas = ticket.respuestas ?? [];
+      const nuevasRespuestas =
+        mensaje.length > 0
+          ? [
+              ...respuestas,
+              { mensaje, fecha: new Date().toISOString(), autor: 'admin' as const }
+            ]
+          : respuestas;
+
+      return {
+        ...ticket,
+        estatus: this.estatusTicketSeleccionado,
+        respuestas: nuevasRespuestas
+      };
+    });
+
+    localStorage.setItem(this.ticketsStorageKey, JSON.stringify(actualizados));
+    this.respuestaAdmin = '';
+    this.cargarTicketsSoporte();
+  }
+
+  obtenerUltimaRespuesta(ticket: TicketSoporte): { mensaje: string; fecha: string } | null {
+    if (!ticket.respuestas?.length) {
+      return null;
+    }
+    const respuesta = ticket.respuestas[ticket.respuestas.length - 1];
+    return { mensaje: respuesta.mensaje, fecha: respuesta.fecha };
+  }
+
+  formatearFecha(fecha: string): string {
+    const parsed = new Date(fecha);
+    if (Number.isNaN(parsed.getTime())) {
+      return '—';
+    }
+    return new Intl.DateTimeFormat('es-MX', {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(parsed);
+  }
+
   get excelDisponiblesFiltrados(): ExcelDisponible[] {
     return this.aplicarFiltros(this.excelDisponibles);
   }
@@ -218,6 +297,30 @@ export class AdminPanelComponent implements OnInit {
     }
 
     return [];
+  }
+
+  private cargarTicketsSoporte(): void {
+    this.ticketsSoporte = this.obtenerTicketsSoporte();
+  }
+
+  private obtenerTicketsSoporte(): TicketSoporte[] {
+    const stored = localStorage.getItem(this.ticketsStorageKey);
+    if (!stored) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.map((ticket) => ({
+        ...ticket,
+        respuestas: Array.isArray(ticket.respuestas) ? ticket.respuestas : []
+      }));
+    } catch {
+      return [];
+    }
   }
 
   private saveUploadHistory(): void {
@@ -442,4 +545,17 @@ interface ExcelDisponible {
   estatus: 'asignado' | 'pendiente';
   fecha: string;
   nivel: string;
+}
+
+interface TicketSoporte {
+  id: string;
+  folio: string;
+  correo: string;
+  motivo: string;
+  motivoDetalle: string;
+  descripcion: string;
+  fecha: string;
+  estatus: 'pendiente' | 'en-proceso' | 'respondido';
+  respuestas: Array<{ mensaje: string; fecha: string; autor: 'admin' }>;
+  evidencias: Array<{ nombre: string; tamano: number; tipo: string }>;
 }

--- a/web/frontend/src/app/components/tickets-historial/tickets-historial.component.html
+++ b/web/frontend/src/app/components/tickets-historial/tickets-historial.component.html
@@ -16,32 +16,64 @@
           <th>Folio</th>
           <th>Motivo</th>
           <th>Descripción</th>
+          <th>Respuesta</th>
           <th>Fecha</th>
           <th>Evidencias</th>
           <th>Estatus</th>
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let ticket of tickets">
-          <td data-label="Folio">{{ ticket.folio }}</td>
-          <td data-label="Motivo">
-            {{ ticket.motivo }}
-            <span *ngIf="ticket.motivoDetalle">({{ ticket.motivoDetalle }})</span>
-          </td>
-          <td data-label="Descripción">{{ ticket.descripcion }}</td>
-          <td data-label="Fecha">{{ formatearFecha(ticket.fecha) }}</td>
-          <td data-label="Evidencias">{{ ticket.evidencias.length }}</td>
-          <td data-label="Estatus">
-            <span
-              class="tickets-historial__badge"
-              [class.tickets-historial__badge--pendiente]="ticket.estatus === 'pendiente'"
-              [class.tickets-historial__badge--proceso]="ticket.estatus === 'en-proceso'"
-              [class.tickets-historial__badge--respondido]="ticket.estatus === 'respondido'"
-            >
-              {{ obtenerEtiquetaEstatus(ticket.estatus) }}
-            </span>
-          </td>
-        </tr>
+        <ng-container *ngFor="let ticket of tickets">
+          <tr>
+            <td data-label="Folio">{{ ticket.folio }}</td>
+            <td data-label="Motivo">
+              {{ ticket.motivo }}
+              <span *ngIf="ticket.motivoDetalle">({{ ticket.motivoDetalle }})</span>
+            </td>
+            <td data-label="Descripción">{{ ticket.descripcion }}</td>
+            <td data-label="Respuesta">
+              <ng-container *ngIf="obtenerUltimaRespuesta(ticket) as respuesta; else sinRespuesta">
+                <p>{{ respuesta.mensaje }}</p>
+                <small>{{ formatearFecha(respuesta.fecha) }}</small>
+              </ng-container>
+              <ng-template #sinRespuesta>Sin respuesta</ng-template>
+            </td>
+            <td data-label="Fecha">{{ formatearFecha(ticket.fecha) }}</td>
+            <td data-label="Evidencias">{{ ticket.evidencias.length }}</td>
+            <td data-label="Estatus">
+              <button
+                type="button"
+                class="tickets-historial__badge tickets-historial__badge-button"
+                [class.tickets-historial__badge--pendiente]="ticket.estatus === 'pendiente'"
+                [class.tickets-historial__badge--proceso]="ticket.estatus === 'en-proceso'"
+                [class.tickets-historial__badge--respondido]="ticket.estatus === 'respondido'"
+                (click)="toggleDetalleRespuesta(ticket.id)"
+                [attr.aria-expanded]="esTicketExpandido(ticket.id)"
+              >
+                {{ obtenerEtiquetaEstatus(ticket.estatus) }}
+              </button>
+            </td>
+          </tr>
+          <tr class="tickets-historial__detalle" *ngIf="esTicketExpandido(ticket.id)">
+            <td colspan="7">
+              <div class="tickets-historial__detalle-contenido">
+                <h3>Respuesta del administrador</h3>
+                <ng-container *ngIf="ticket.respuestas?.length; else sinRespuestas">
+                  <div
+                    class="tickets-historial__detalle-respuesta"
+                    *ngFor="let respuesta of ticket.respuestas"
+                  >
+                    <p>{{ respuesta.mensaje }}</p>
+                    <small>{{ formatearFecha(respuesta.fecha) }}</small>
+                  </div>
+                </ng-container>
+                <ng-template #sinRespuestas>
+                  <p>Este ticket aún no tiene respuesta.</p>
+                </ng-template>
+              </div>
+            </td>
+          </tr>
+        </ng-container>
       </tbody>
     </table>
   </div>

--- a/web/frontend/src/app/components/tickets-historial/tickets-historial.component.scss
+++ b/web/frontend/src/app/components/tickets-historial/tickets-historial.component.scss
@@ -74,19 +74,64 @@
   font-size: 0.85rem;
 }
 
+.tickets-historial__badge-button {
+  border: none;
+  cursor: pointer;
+  background: transparent;
+}
+
 .tickets-historial__badge--pendiente {
-  background: #fef9c3;
-  color: #854d0e;
+  background: #ddc9a3;
+  color: #611232;
 }
 
 .tickets-historial__badge--proceso {
-  background: #e0f2fe;
-  color: #0369a1;
+  background: #bc955c;
+  color: #ffffff;
 }
 
 .tickets-historial__badge--respondido {
-  background: #dcfce7;
-  color: #166534;
+  background: #13322e;
+  color: #ffffff;
+}
+
+.tickets-historial__detalle td {
+  padding: 0;
+  border-bottom: none;
+}
+
+.tickets-historial__detalle-contenido {
+  margin: 0 1rem 1rem;
+  padding: 1rem;
+  border-radius: 12px;
+  background: #ffffff;
+  border: 1px solid #ddc9a3;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tickets-historial__detalle-contenido h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #611232;
+}
+
+.tickets-historial__detalle-respuesta {
+  background: #ddc9a3;
+  border-radius: 10px;
+  padding: 0.75rem;
+}
+
+.tickets-historial__detalle-respuesta p {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+  color: #13322e;
+}
+
+.tickets-historial__detalle-respuesta small,
+.tickets-historial__detalle-contenido p {
+  color: #611232;
 }
 
 .tickets-historial__link {

--- a/web/frontend/src/app/components/tickets-historial/tickets-historial.component.ts
+++ b/web/frontend/src/app/components/tickets-historial/tickets-historial.component.ts
@@ -13,6 +13,7 @@ interface TicketSoporte {
   descripcion: string;
   fecha: string;
   estatus: 'pendiente' | 'en-proceso' | 'respondido';
+  respuestas: Array<{ mensaje: string; fecha: string; autor: 'admin' }>;
   evidencias: Array<{ nombre: string; tamano: number; tipo: string }>;
 }
 
@@ -27,6 +28,7 @@ export class TicketsHistorialComponent implements OnInit {
   tickets: TicketSoporte[] = [];
   mensajeInfo: string | null = null;
   correoActivo: string | null = null;
+  ticketExpandidoId: string | null = null;
 
   constructor(
     private readonly authService: AuthService,
@@ -82,6 +84,22 @@ export class TicketsHistorialComponent implements OnInit {
       dateStyle: 'medium',
       timeStyle: 'short'
     }).format(parsed);
+  }
+
+  obtenerUltimaRespuesta(ticket: TicketSoporte): { mensaje: string; fecha: string } | null {
+    if (!ticket.respuestas?.length) {
+      return null;
+    }
+    const respuesta = ticket.respuestas[ticket.respuestas.length - 1];
+    return { mensaje: respuesta.mensaje, fecha: respuesta.fecha };
+  }
+
+  toggleDetalleRespuesta(ticketId: string): void {
+    this.ticketExpandidoId = this.ticketExpandidoId === ticketId ? null : ticketId;
+  }
+
+  esTicketExpandido(ticketId: string): boolean {
+    return this.ticketExpandidoId === ticketId;
   }
 
   private normalizarCorreo(correo: string | null): string | null {

--- a/web/frontend/src/app/components/tickets/tickets.component.html
+++ b/web/frontend/src/app/components/tickets/tickets.component.html
@@ -10,7 +10,7 @@
     </p>
   </header>
 
-  <form class="tickets__formulario" (ngSubmit)="enviarTicket($event)">
+  <form class="tickets__formulario" (submit)="enviarTicket($event)">
     <label class="tickets__campo">
       <span>Motivo del ticket</span>
       <select [formControl]="motivoControl">
@@ -93,6 +93,18 @@
       <div class="tickets__historial-meta">
         <span>Evidencias: {{ ticket.evidencias.length }}</span>
         <span>Estatus: {{ ticket.estatus }}</span>
+      </div>
+      <ul class="tickets__historial-evidencias" *ngIf="ticket.evidencias.length">
+        <li *ngFor="let evidencia of ticket.evidencias">
+          {{ evidencia.nombre }}
+        </li>
+      </ul>
+      <div class="tickets__historial-respuestas" *ngIf="ticket.respuestas?.length">
+        <h3>Respuesta del administrador</h3>
+        <div class="tickets__historial-respuesta" *ngFor="let respuesta of ticket.respuestas">
+          <p>{{ respuesta.mensaje }}</p>
+          <span>{{ respuesta.fecha | date: 'medium' }}</span>
+        </div>
       </div>
     </div>
   </section>

--- a/web/frontend/src/app/components/tickets/tickets.component.scss
+++ b/web/frontend/src/app/components/tickets/tickets.component.scss
@@ -195,6 +195,49 @@
   flex-wrap: wrap;
 }
 
+.tickets__historial-evidencias {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #374151;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.tickets__historial-evidencias li {
+  list-style: disc;
+}
+
+.tickets__historial-respuestas {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tickets__historial-respuestas h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f766e;
+}
+
+.tickets__historial-respuesta {
+  background: #f0fdfa;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  color: #0f172a;
+}
+
+.tickets__historial-respuesta p {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.tickets__historial-respuesta span {
+  font-size: 0.85rem;
+  color: #475569;
+}
+
 .tickets__debug {
   border: 1px dashed #cbd5e1;
   border-radius: 12px;

--- a/web/frontend/src/app/components/tickets/tickets.component.ts
+++ b/web/frontend/src/app/components/tickets/tickets.component.ts
@@ -19,6 +19,7 @@ interface TicketSoporte {
   descripcion: string;
   fecha: string;
   estatus: 'pendiente' | 'en-proceso' | 'respondido';
+  respuestas: Array<{ mensaje: string; fecha: string; autor: 'admin' }>;
   evidencias: Array<{ nombre: string; tamano: number; tipo: string }>;
 }
 
@@ -153,6 +154,7 @@ export class TicketsComponent implements OnInit {
       descripcion: this.descripcionControl.value.trim(),
       fecha: new Date().toISOString(),
       estatus: 'pendiente',
+      respuestas: [],
       evidencias: this.evidencias.map((item) => ({
         nombre: item.archivo.name,
         tamano: item.archivo.size,


### PR DESCRIPTION
### Motivation
- Unificar los colores del historial de tickets y las respuestas con la paleta corporativa proporcionada para evitar el amarillo/azul no deseado. 
- Permitir que el administrador consulte, filtre y responda tickets desde el `AdminPanel`. 
- Mostrar las respuestas del administrador en la vista de historial para mejorar el seguimiento del soporte.

### Description
- Actualicé los estilos en `tickets-historial.component.scss` para usar la paleta base (`#611232`, `#9d2449`, `#a57f2c`, `#DDC9A3`, `#98989A`, `#13322e`, `#FFFFFF`, `#BC955C`) y reasigné colores de badges, detalles y bordes. 
- Agregué la interfaz y lógica de gestión de tickets en `admin-panel.component.{ts,html,scss}` con filtros (`filtroTicketTexto`, `filtroTicketEstatus`), listado, selección de ticket (`seleccionarTicket`), formulario para respuesta (`respuestaAdmin`, `guardarRespuesta`) y persistencia en `localStorage` (`tickets-soporte`). 
- Extendí los modelos y componentes de tickets para incluir `respuestas` y evidencias, y añadí la funcionalidad de desplegar respuestas en el historial con métodos como `toggleDetalleRespuesta`, `esTicketExpandido`, `obtenerUltimaRespuesta`, `cargarTicketsSoporte` y `obtenerTicketsSoporte` en los componentes afectados. 
- Ajusté templates para mostrar la última respuesta en tablas y filas expandibles en `tickets-historial.component.html` y añadí la visualización de respuestas/evidencias en `tickets.component.{html,scss}`.

### Testing
- No se ejecutaron pruebas automatizadas en estos cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69715920f1e88320955e8d5acba41338)