### PR TITLE
Agregar navbar compartido y navegación principal

### DIFF
--- a/web/doc/casos_uso.md
+++ b/web/doc/casos_uso.md
@@ -9,6 +9,7 @@ flowchart LR
         B[Escuela autenticada]
         C[Sistema externo de resultados]
         D[Operador técnico SEP]
+        E[Administrador SEP]
     end
 
     subgraph Sistema[Plataforma EIA]
@@ -20,6 +21,12 @@ flowchart LR
         CU6[CU-06 Detectar reenvío y requerir login]
         CU7[CU-07 Autenticarse para reenvío/descargas]
         CU8[CU-08 Listar versiones y ligas de descarga]
+        CU9[CU-09 Consultar archivos guardados]
+        CU10[CU-10 Seguimiento de solicitudes y descargas]
+        CU11[CU-11 Crear ticket de soporte]
+        CU12[CU-12 Consultar historial de tickets]
+        CU13[CU-13 Administrar carga de resultados]
+        CU14[CU-14 Gestionar tickets y respuestas]
     end
 
     A --> CU1
@@ -32,11 +39,18 @@ flowchart LR
     B --> CU6
     B --> CU7
     B --> CU8
+    B --> CU9
+    B --> CU10
+    B --> CU11
+    B --> CU12
 
     C --> CU8
 
     D --> CU2
     D --> CU5
+
+    E --> CU13
+    E --> CU14
 ```
 
 ---
@@ -75,7 +89,31 @@ flowchart LR
    - Actores: Escuela (autenticada), Sistema externo de resultados
    - Descripción: Muestra consecutivos y ligas depositadas por el sistema externo para la escuela autenticada.
 
-**Nota de implementación temporal:** mientras el backend GraphQL es construido por otro equipo, los casos de uso CU-01 a CU-07 se ejecutarán en el frontend con servicios simulados y datos de prueba/localStorage que imitan las respuestas esperadas. Cuando las operaciones estén disponibles, se cambiará la fuente de datos sin modificar los flujos de usuario.
+9. **CU-09 Consultar archivos guardados**
+   - Actor: Escuela (autenticada)
+   - Descripción: Lista archivos validados en el navegador, con búsqueda por nombre/CCT, acciones de descarga y eliminación, y acceso a resultados asociados.
+
+10. **CU-10 Seguimiento de solicitudes y descargas**
+   - Actor: Escuela (autenticada)
+   - Descripción: Provee filtros por CCT/fecha y panel de estado para validar solicitudes y descargas recientes, incluyendo reintentos simulados.
+
+11. **CU-11 Crear ticket de soporte**
+   - Actor: Escuela (autenticada)
+   - Descripción: Permite enviar un ticket con motivo, descripción y evidencias (PDF, Excel, Word o imágenes) desde la mesa de ayuda.
+
+12. **CU-12 Consultar historial de tickets**
+   - Actor: Escuela (autenticada)
+   - Descripción: Muestra el historial de tickets con estatus, evidencias y respuestas del administrador.
+
+13. **CU-13 Administrar carga de resultados**
+   - Actor: Administrador SEP
+   - Descripción: Selecciona un Excel validado, filtra por estatus/fecha y carga archivos de resultados (PDF/XLSX/etc.) asociados a la solicitud.
+
+14. **CU-14 Gestionar tickets y respuestas**
+   - Actor: Administrador SEP
+   - Descripción: Consulta tickets, aplica filtros, actualiza estatus y envía respuestas al usuario.
+
+**Nota de implementación temporal:** mientras el backend GraphQL es construido por otro equipo, los casos de uso CU-01 a CU-14 se ejecutarán en el frontend con servicios simulados y datos de prueba/localStorage que imitan las respuestas esperadas. Cuando las operaciones estén disponibles, se cambiará la fuente de datos sin modificar los flujos de usuario.
 
 ---
 

--- a/web/doc/srs.md
+++ b/web/doc/srs.md
@@ -49,6 +49,11 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend G
 - Descarga automática de PDF (confirmación o errores).
 - Pantalla protegida para consulta de ligas de descarga (login con CCT + correo validado).
 - Panel técnico básico para monitoreo de solicitudes.
+- Módulo de carga masiva con estado de validaciones y credenciales generadas.
+- Vista de archivos guardados con búsqueda, descarga y gestión de resultados asociados.
+- Panel de seguimiento de solicitudes y descargas con filtros por CCT/fecha.
+- Mesa de ayuda para creación y consulta de tickets de soporte.
+- Panel administrador para carga de resultados y gestión de tickets.
 - Uso de la **guía gráfica gob.mx v3** incluida desde CDN en `index.html`, con scripts auxiliares (`jquery.min.js`, `gobmx.js`, `main.js`) ya cargados.
 
 ### 2.2.2 Interfaces de hardware
@@ -72,6 +77,7 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend G
 - **Escuela autenticada:** usa CCT + contraseña (correo validado en primera carga) para reenviar archivos, cargar nuevas versiones (identificadas por hash) y descargar resultados publicados.
 - **Sistema externo de procesamiento:** genera resultados y deposita ligas/archivos para publicación.
 - **Operador técnico SEP:** supervisa logs y repositorios de archivos.
+- **Administrador SEP:** carga resultados asociados a solicitudes validadas y gestiona tickets de soporte.
 
 ### 3.2 Lista de casos de uso (resumen)
 
@@ -83,6 +89,12 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend G
 - CU-06 Detectar reenvío y requerir login.
 - CU-07 Autenticarse para reenvío de archivos y descargas (CCT + correo validado).
 - CU-08 Listar versiones y ligas de descarga provenientes del sistema externo.
+- CU-09 Consultar archivos guardados con acciones de descarga/limpieza.
+- CU-10 Seguimiento de solicitudes y descargas con filtros por CCT/fecha.
+- CU-11 Crear ticket de soporte con evidencias.
+- CU-12 Consultar historial de tickets y respuestas.
+- CU-13 Administrar carga de resultados (panel administrador).
+- CU-14 Gestionar tickets y respuestas (panel administrador).
 
 ---
 
@@ -119,6 +131,12 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 - RF-10: Mostrar **todas las versiones** de resultados que el sistema externo haya depositado, con consecutivo y liga.
 - RF-11: Mantener repositorios separados para archivos recibidos y resultados publicados.
 - RF-12: Implementar servicios frontend tipificados hacia GraphQL que, mientras no exista backend disponible, devuelvan datos simulados/localStorage usando el mismo contrato esperado de las operaciones.
+- RF-13: Permitir consultar archivos guardados localmente, con búsqueda por nombre/CCT, descarga, eliminación y vista de resultados asociados.
+- RF-14: Presentar seguimiento de solicitudes y descargas con filtros por CCT/fecha y panel de estado.
+- RF-15: Habilitar creación de tickets de soporte con motivo, descripción y evidencias adjuntas.
+- RF-16: Mostrar historial de tickets con estatus y respuestas del administrador.
+- RF-17: Permitir a administradores seleccionar solicitudes validadas, filtrar por estatus/fecha y subir archivos de resultados asociados.
+- RF-18: Permitir a administradores gestionar tickets (filtrar, actualizar estatus y registrar respuestas).
 
 ---
 

--- a/web/frontend/src/app/app.component.html
+++ b/web/frontend/src/app/app.component.html
@@ -1,4 +1,4 @@
-
-
-
-<router-outlet />
+<app-nav></app-nav>
+<main class="app-content">
+  <router-outlet />
+</main>

--- a/web/frontend/src/app/app.component.scss
+++ b/web/frontend/src/app/app.component.scss
@@ -1,0 +1,3 @@
+.app-content {
+  padding-top: 72px;
+}

--- a/web/frontend/src/app/app.component.ts
+++ b/web/frontend/src/app/app.component.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
+import { NavComponent } from './shared/nav/nav.component';
+
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, NavComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/web/frontend/src/app/shared/nav/nav.component.html
+++ b/web/frontend/src/app/shared/nav/nav.component.html
@@ -1,0 +1,109 @@
+<nav class="navbar navbar-expand-xl navbar-dark bg-sep-guinda sub-navbar fixed-top">
+  <div class="container-fluid px-3">
+    <a class="navbar-brand" [routerLink]="['/inicio']">Evaluación diagnóstica</a>
+    <button type="button" class="navbar-toggler" (click)="toggleMenu()" aria-label="Abrir menú">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="navbar-collapse" [class.show]="menuAbierto">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item">
+          <a class="nav-link subnav-link" [routerLink]="['/inicio']">
+            <i class="bi bi-house mr-1" aria-hidden="true"></i>
+            <strong>Inicio</strong>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link subnav-link" [routerLink]="['/carga-masiva']">
+            <i class="bi bi-upload mr-1" aria-hidden="true"></i>
+            <strong>Carga masiva</strong>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link subnav-link" [routerLink]="['/archivos-preescolar']">
+            <i class="bi bi-folder2-open mr-1" aria-hidden="true"></i>
+            <strong>Archivos guardados</strong>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link subnav-link" [routerLink]="['/descargas']">
+            <i class="bi bi-download mr-1" aria-hidden="true"></i>
+            <strong>Descargas</strong>
+          </a>
+        </li>
+
+        <ng-container *ngIf="isUsuarioAutenticado; else usuarioInvitado">
+          <li class="nav-item">
+            <a class="nav-link subnav-link" [routerLink]="['/tickets']">
+              <i class="bi bi-life-preserver mr-1" aria-hidden="true"></i>
+              <strong>Soporte</strong>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link subnav-link" [routerLink]="['/tickets-historial']">
+              <i class="bi bi-card-list mr-1" aria-hidden="true"></i>
+              <strong>Mis tickets</strong>
+            </a>
+          </li>
+          <li class="nav-item d-none d-md-block">
+            <span class="nav-link subnav-link subnav-separator">|</span>
+          </li>
+          <li class="nav-item dropdown">
+            <a
+              class="nav-link subnav-link dropdown-toggle"
+              href="javascript:void(0)"
+              id="userDropdown"
+              role="button"
+              (click)="toggleUserMenu()"
+              aria-expanded="false"
+            >
+              <i class="bi bi-person-circle mr-1" aria-hidden="true"></i>
+              <strong>{{ getNombreUsuario() }}</strong>
+            </a>
+            <div class="dropdown-menu" [class.show]="userMenuOpen">
+              <a class="dropdown-item" href="javascript:void(0)" (click)="cerrarSesion()">
+                <i class="bi bi-box-arrow-right mr-2" aria-hidden="true"></i>
+                Cerrar sesión
+              </a>
+            </div>
+          </li>
+        </ng-container>
+
+        <ng-template #usuarioInvitado>
+          <li class="nav-item d-none d-md-block">
+            <span class="nav-link subnav-link subnav-separator">|</span>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link subnav-link" href="javascript:void(0)" (click)="iniciarSesion()">
+              <i class="bi bi-box-arrow-in-right mr-1" aria-hidden="true"></i>
+              <strong>Login</strong>
+            </a>
+          </li>
+        </ng-template>
+
+        <ng-container *ngIf="isAdminAutenticado; else adminInvitado">
+          <li class="nav-item">
+            <a class="nav-link subnav-link" [routerLink]="['/admin/panel']">
+              <i class="bi bi-shield-lock mr-1" aria-hidden="true"></i>
+              <strong>Panel admin</strong>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link subnav-link" href="javascript:void(0)" (click)="cerrarSesionAdmin()">
+              <i class="bi bi-shield-x mr-1" aria-hidden="true"></i>
+              <strong>Salir admin</strong>
+            </a>
+          </li>
+        </ng-container>
+        <ng-template #adminInvitado>
+          <li class="nav-item">
+            <a class="nav-link subnav-link" href="javascript:void(0)" (click)="iniciarSesionAdmin()">
+              <i class="bi bi-shield-check mr-1" aria-hidden="true"></i>
+              <strong>Admin login</strong>
+            </a>
+          </li>
+        </ng-template>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/web/frontend/src/app/shared/nav/nav.component.scss
+++ b/web/frontend/src/app/shared/nav/nav.component.scss
@@ -1,0 +1,343 @@
+/* ========================================
+   NAV.COMPONENT.SCSS - RESPONSIVE FIJO
+   ======================================== */
+
+@use "sass:color";
+
+/* Paleta */
+$sep-guinda: #390b1f;
+$sep-burgundy: #691c32;
+$sep-gold: #a57f2c;
+$sep-guinda-light: color.adjust($sep-guinda, $lightness: 12%);
+$sep-guinda-lighter: color.adjust($sep-guinda, $lightness: 24%);
+$sep-gray-300: #d9d9d9;
+$sep-gray-700: #4a4a4a;
+
+.bg-sep-guinda {
+  background-color: $sep-guinda !important;
+}
+
+.navbar {
+  background-color: $sep-guinda !important;
+  border-bottom: none;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  z-index: 1030 !important;
+  min-height: 55px;
+  height: auto;
+  display: flex !important;
+  align-items: center;
+}
+
+.sub-navbar {
+  background-color: $sep-guinda !important;
+  border-bottom: 1px solid $sep-gray-300;
+  color: $sep-gray-700;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.04);
+  margin-bottom: 0 !important;
+  margin-top: 0 !important;
+  position: fixed !important;
+  top: 0 !important;
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 1025;
+
+  .navbar-collapse {
+    background-color: $sep-guinda !important;
+  }
+}
+
+@media (max-width: 1199.98px) {
+  .sub-navbar .navbar-toggler {
+    margin-top: 12px;
+  }
+}
+
+.navbar-brand {
+  color: #fff !important;
+  font-size: 1.1rem;
+  font-weight: 700;
+  text-decoration: none;
+
+  &:hover {
+    color: $sep-guinda-light !important;
+    text-decoration: none;
+  }
+}
+
+.subnav-link {
+  color: #fff !important;
+  padding: 0.4rem 1rem;
+  transition: color 0.3s ease, background-color 0.3s ease;
+  font-weight: 350;
+  white-space: normal;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    color: $sep-gold !important;
+    background-color: $sep-burgundy !important;
+    text-decoration: none;
+  }
+
+  &:focus {
+    outline: 2px solid color.adjust($sep-guinda, $lightness: 15%);
+    outline-offset: 2px;
+  }
+}
+
+.subnav-link strong {
+  font-weight: 600;
+}
+
+.subnav-separator {
+  opacity: 0.5;
+  cursor: default;
+  color: #fff !important;
+
+  &:hover,
+  &:focus {
+    color: $sep-guinda-lighter !important;
+    background: transparent;
+  }
+}
+
+.navbar-toggler {
+  border: 2px solid #fff !important;
+  outline: none;
+  margin-left: auto;
+  margin-right: 5px !important;
+  z-index: 1050;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.375rem;
+  transition: all 0.3s ease;
+  background-color: transparent;
+  color: #fff;
+
+  &:focus {
+    box-shadow: 0 0 0 0.25rem rgba($sep-guinda, 0.25) !important;
+    outline: 2px solid color.adjust($sep-guinda, $lightness: 15%);
+    outline-offset: 2px;
+  }
+  &:hover {
+    background-color: rgba($sep-gray-300, 0.15);
+  }
+}
+
+.navbar-toggler-icon {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E") !important;
+  width: 1.2em;
+  height: 1.2em;
+}
+
+.dropdown-menu {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 0;
+  min-width: 180px;
+  z-index: 1040;
+  margin-top: 0;
+}
+
+.dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 12px 20px;
+  color: #333 !important;
+  background: #fff;
+  border: 0;
+  border-bottom: 1px solid #f0f0f0;
+  text-decoration: none;
+  font-weight: 400;
+  font-size: 14px;
+  transition: background-color 0.2s ease;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover,
+  &:focus {
+    color: #333 !important;
+    background-color: #f8f9fa !important;
+    text-decoration: none;
+  }
+
+  &.active,
+  &:active {
+    color: #333 !important;
+    background-color: #e9ecef !important;
+    text-decoration: none;
+  }
+}
+
+@media (max-width: 1199.98px) {
+  .navbar {
+    position: fixed !important;
+    top: 0 !important;
+    left: 0;
+    right: 0;
+    padding: 0.5rem 0 !important;
+  }
+
+  .navbar > .container-fluid {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: nowrap;
+  }
+
+  .navbar-collapse {
+    display: none !important;
+    background-color: $sep-guinda !important;
+    border-radius: 0 0 0.5rem 0.5rem;
+    border-top: 1px solid $sep-gray-300;
+    margin-top: 0.5rem;
+    padding: 1rem 0;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1020;
+  }
+
+  .navbar-collapse.show {
+    display: block !important;
+  }
+
+  .navbar-nav {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 0 !important;
+  }
+
+  .navbar-nav .nav-item {
+    border-bottom: 1px solid rgba($sep-gray-300, 0.8);
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .navbar-nav .nav-link {
+    padding: 0.75rem 0 !important;
+    font-size: 1rem;
+    text-align: center;
+  }
+}
+
+@media (min-width: 1200px) and (max-width: 1716px) {
+  .navbar {
+    height: auto;
+    position: fixed !important;
+    top: 0 !important;
+  }
+
+  .navbar > .container-fluid {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: nowrap;
+  }
+
+  .navbar-brand {
+    margin-right: 0.75rem;
+    align-self: center;
+  }
+
+  .navbar-collapse {
+    display: flex !important;
+    flex-wrap: nowrap;
+    width: 100%;
+  }
+
+  .navbar-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.5rem;
+  }
+
+  .navbar-nav .nav-link {
+    padding: 0.35rem 0.75rem;
+    font-size: 1rem;
+    line-height: 1.25;
+  }
+}
+
+@media (min-width: 1717px) {
+  .navbar {
+    position: fixed !important;
+    top: 0 !important;
+  }
+
+  .navbar-collapse {
+    display: flex !important;
+  }
+
+  .navbar-toggler {
+    display: none !important;
+  }
+
+  .navbar-nav.ml-auto {
+    margin-left: auto !important;
+  }
+
+  .navbar-brand {
+    font-size: 1.2rem;
+  }
+
+  .navbar-nav .nav-link {
+    padding: 0.5rem 1.2rem;
+    font-size: 1rem;
+  }
+}
+
+@media (min-width: 1900px) {
+  .navbar-nav .nav-link {
+    font-size: 1rem;
+  }
+}
+
+.mr-1 {
+  margin-right: 0.25rem !important;
+}
+.mr-2 {
+  margin-right: 0.5rem !important;
+}
+
+.nav-link:focus,
+.dropdown-item:focus,
+.navbar-brand:focus {
+  outline: 2px solid color.adjust($sep-guinda, $lightness: 20%);
+  outline-offset: 2px;
+}
+
+.nav-link.active {
+  font-weight: 700;
+  color: $sep-gold !important;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.navbar-collapse.show,
+.dropdown-menu.show {
+  animation: fadeIn 0.3s ease-out;
+}
+
+@media print {
+  .navbar {
+    display: none !important;
+  }
+}

--- a/web/frontend/src/app/shared/nav/nav.component.ts
+++ b/web/frontend/src/app/shared/nav/nav.component.ts
@@ -1,0 +1,116 @@
+import { CommonModule } from '@angular/common';
+import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { NavigationEnd, Router, RouterModule } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
+import { AdminAuthService } from '../../services/admin-auth.service';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-nav',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './nav.component.html',
+  styleUrl: './nav.component.scss'
+})
+export class NavComponent implements OnInit, OnDestroy {
+  menuAbierto = false;
+  userMenuOpen = false;
+  isUsuarioAutenticado = false;
+  isAdminAutenticado = false;
+  correoUsuario: string | null = null;
+
+  private routerSubscription: Subscription | null = null;
+
+  constructor(
+    private readonly router: Router,
+    private readonly authService: AuthService,
+    private readonly adminAuthService: AdminAuthService
+  ) {}
+
+  ngOnInit(): void {
+    this.sincronizarEstado();
+    this.routerSubscription = this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe(() => this.sincronizarEstado());
+  }
+
+  ngOnDestroy(): void {
+    this.routerSubscription?.unsubscribe();
+  }
+
+  iniciarSesion(): void {
+    void this.router.navigate(['/login'], { queryParams: { redirect: '/carga-masiva' } });
+    this.cerrarMenus();
+  }
+
+  iniciarSesionAdmin(): void {
+    void this.router.navigate(['/admin/login'], { queryParams: { redirect: '/admin/panel' } });
+    this.cerrarMenus();
+  }
+
+  cerrarSesion(): void {
+    this.authService.cerrarSesion();
+    this.sincronizarEstado();
+    void this.router.navigate(['/inicio']);
+    this.cerrarMenus();
+  }
+
+  cerrarSesionAdmin(): void {
+    this.adminAuthService.cerrarSesion();
+    this.sincronizarEstado();
+    void this.router.navigate(['/inicio']);
+    this.cerrarMenus();
+  }
+
+  toggleMenu(): void {
+    this.menuAbierto = !this.menuAbierto;
+  }
+
+  toggleUserMenu(): void {
+    this.userMenuOpen = !this.userMenuOpen;
+  }
+
+  getNombreUsuario(): string {
+    if (!this.isUsuarioAutenticado) {
+      return 'Usuario';
+    }
+
+    if (this.correoUsuario) {
+      return this.correoUsuario;
+    }
+
+    return 'Sesión activa';
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    const targetElement = event.target as HTMLElement;
+
+    const userMenuClick =
+      targetElement.closest('#userDropdown') || targetElement.closest('.dropdown-menu');
+
+    const mainMenuClick =
+      targetElement.closest('.navbar-nav') || targetElement.closest('.navbar-toggler');
+
+    if (!userMenuClick && this.userMenuOpen) {
+      this.userMenuOpen = false;
+    }
+
+    if (!mainMenuClick && this.menuAbierto) {
+      this.menuAbierto = false;
+    }
+  }
+
+  private sincronizarEstado(): void {
+    this.isUsuarioAutenticado = this.authService.estaAutenticado();
+    this.isAdminAutenticado = this.adminAuthService.estaAutenticado();
+    this.correoUsuario = this.authService.obtenerCorreoSesion();
+  }
+
+  private cerrarMenus(): void {
+    this.menuAbierto = false;
+    this.userMenuOpen = false;
+  }
+}


### PR DESCRIPTION
### Motivation
- Centralizar la navegación en un componente reutilizable `shared/nav` para exponer las rutas principales (inicio, carga masiva, archivos guardados, descargas, tickets y panel admin) y reproducir el comportamiento del ejemplo proporcionado.
- Soportar dos caminos de login (`/login` y `/admin/login`) y mostrar enlaces condicionados según el estado de autenticación usuario/admin. 
- Facilitar la integración progresiva en la app y asegurar que el layout del contenido quede correctamente separado del navbar fijo.

### Description
- Se creó el componente standalone `NavComponent` en `web/frontend/src/app/shared/nav/` con `nav.component.html`, `nav.component.scss` y `nav.component.ts`, que implementa la UI, estilos responsivos y la lógica de menús/estado de sesión usando `AuthService` y `AdminAuthService`.
- Se integró el navbar en la aplicación importando `NavComponent` en `app.component.ts` y colocando `<app-nav></app-nav>` en `app.component.html`, además de añadir `padding-top` en `app.component.scss` para compensar el navbar fijo. 
- Los enlaces del navbar siguen las rutas definidas en `app.routes.ts` (`/inicio`, `/carga-masiva`, `/archivos-preescolar`, `/descargas`, `/tickets`, `/tickets-historial`, `/admin/login`, `/admin/panel`) y las acciones de login/cerrar sesión usan las funciones existentes de los servicios. 

### Testing
- Se construyó y se levantó la aplicación con `ng serve` y la compilación/watch terminó correctamente (build OK). 
- Se ejecutó un script automatizado de navegador (Playwright) que cargó la página `http://127.0.0.1:4200/` y generó una captura de pantalla del navbar (script completado con éxito). 
- No se ejecutaron pruebas unitarias automatizadas (`ng test`) como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724c13e8ec832095e1413f6d96559a)