### PR TITLE
Ocultar descargas a invitados y redirigir a `/login`

### DIFF
--- a/web/frontend/src/app/components/descargas/descargas.component.html
+++ b/web/frontend/src/app/components/descargas/descargas.component.html
@@ -1,46 +1,10 @@
 <div class="descargas">
   <header class="encabezado">
     <h1>Descarga de versiones</h1>
-    <p>Ingresa con el correo y contraseña generada para acceder a las ligas de descarga.</p>
+    <p>Consulta las versiones disponibles para descarga.</p>
   </header>
 
   <section class="tarjeta">
-    <div *ngIf="!autenticado" class="formulario">
-      <form [formGroup]="accesoForm" (ngSubmit)="iniciarSesion()">
-        <div class="campo">
-          <label for="correo">Correo electrónico</label>
-          <input
-            id="correo"
-            type="email"
-            formControlName="correo"
-            placeholder="usuario@dominio.com"
-            [class.error]="accesoForm.controls.correo.invalid && accesoForm.controls.correo.touched"
-          />
-          <small *ngIf="accesoForm.controls.correo.invalid && accesoForm.controls.correo.touched">
-            Ingresa un correo válido.
-          </small>
-        </div>
-
-        <div class="campo">
-          <label for="contrasena">Contraseña generada</label>
-          <input
-            id="contrasena"
-            type="password"
-            formControlName="contrasena"
-            placeholder="Ej. Abc123456789"
-            [class.error]="accesoForm.controls.contrasena.invalid && accesoForm.controls.contrasena.touched"
-          />
-          <small *ngIf="accesoForm.controls.contrasena.invalid && accesoForm.controls.contrasena.touched">
-            La contraseña es obligatoria.
-          </small>
-        </div>
-
-        <button type="submit" [disabled]="autenticando" class="btn primario">
-          {{ autenticando ? 'Validando...' : 'Ingresar' }}
-        </button>
-      </form>
-    </div>
-
     <div *ngIf="autenticado" class="contenido">
       <app-seguimiento-descargas></app-seguimiento-descargas>
 

--- a/web/frontend/src/app/components/descargas/descargas.component.ts
+++ b/web/frontend/src/app/components/descargas/descargas.component.ts
@@ -1,92 +1,45 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { RouterModule } from '@angular/router';
-import Swal from 'sweetalert2';
+import { Router } from '@angular/router';
 import { finalize, firstValueFrom, Subject, takeUntil } from 'rxjs';
+import Swal from 'sweetalert2';
 import { AuthService } from '../../services/auth.service';
-import { EstadoCredencialesService } from '../../services/estado-credenciales.service';
 import { VersionDisponible, VersionesService } from '../../services/versiones.service';
 import { SeguimientoDescargasComponent } from './seguimiento-descargas/seguimiento-descargas.component';
 
 @Component({
   selector: 'app-descargas',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule, SeguimientoDescargasComponent],
+  imports: [CommonModule, SeguimientoDescargasComponent],
   templateUrl: './descargas.component.html',
   styleUrl: './descargas.component.scss'
 })
 export class DescargasComponent implements OnInit, OnDestroy {
   autenticado = false;
   cargandoVersiones = false;
-  autenticando = false;
   error: string | null = null;
   versiones: VersionDisponible[] = [];
   private readonly destroy$ = new Subject<void>();
 
-  readonly accesoForm = new FormGroup({
-    correo: new FormControl('', [Validators.required, Validators.email]),
-    contrasena: new FormControl('', [Validators.required])
-  });
-
   constructor(
     private readonly authService: AuthService,
-    private readonly estadoCredencialesService: EstadoCredencialesService,
-    private readonly versionesService: VersionesService
+    private readonly versionesService: VersionesService,
+    private readonly router: Router
   ) {}
 
   ngOnInit(): void {
-    const estado = this.estadoCredencialesService.obtener();
-    if (estado) {
-      this.accesoForm.patchValue({ correo: estado.correo, contrasena: estado.contrasena });
+    this.autenticado = this.authService.estaAutenticado();
+    if (!this.autenticado) {
+      void this.router.navigate(['/login']);
+      return;
     }
 
-    this.autenticado = this.authService.estaAutenticado();
-    if (this.autenticado) {
-      this.cargarVersiones();
-    }
+    this.cargarVersiones();
   }
 
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
-  }
-
-  async iniciarSesion(): Promise<void> {
-    if (this.accesoForm.invalid) {
-      this.accesoForm.markAllAsTouched();
-      return;
-    }
-
-    const correo = this.accesoForm.controls.correo.value ?? '';
-    const contrasena = this.accesoForm.controls.contrasena.value ?? '';
-
-    this.error = null;
-    this.autenticando = true;
-
-    try {
-      this.authService.iniciarSesion(correo, contrasena);
-      this.estadoCredencialesService.actualizar(correo, contrasena);
-      this.autenticado = true;
-      await Swal.fire({
-        icon: 'success',
-        title: 'Acceso concedido',
-        text: 'Ya puedes descargar las versiones disponibles.',
-        timer: 2300,
-        timerProgressBar: true
-      });
-      this.cargarVersiones();
-    } catch (error) {
-      this.autenticado = false;
-      this.error = error instanceof Error ? error.message : 'No fue posible iniciar sesión.';
-      await Swal.fire({
-        icon: 'error',
-        title: 'Credenciales inválidas',
-        text: this.error
-      });
-    } finally {
-      this.autenticando = false;
-    }
   }
 
   cargarVersiones(): void {

--- a/web/frontend/src/app/shared/nav/nav.component.html
+++ b/web/frontend/src/app/shared/nav/nav.component.html
@@ -19,16 +19,6 @@
             <strong>Carga masiva</strong>
           </a>
         </li>
-        <li class="nav-item">
-          <a
-            class="nav-link subnav-link"
-            [routerLink]="['/descargas']"
-            *ngIf="!isUsuarioAutenticado"
-          >
-            <i class="bi bi-download mr-1" aria-hidden="true"></i>
-            <strong>Descargas</strong>
-          </a>
-        </li>
 
         <ng-container *ngIf="isUsuarioAutenticado; else usuarioInvitado">
           <li class="nav-item d-none d-md-block">


### PR DESCRIPTION
### Motivation
- Evitar que usuarios no autenticados vean o accedan al módulo de descargas desde el menú principal ni al formulario de login embebido en la página de descargas.
- Reusar la ruta de autenticación existente en ` /login` para centralizar el inicio de sesión y la experiencia de usuario.

### Description
- Eliminé el enlace de "Descargas" visible para usuarios invitados en `web/frontend/src/app/shared/nav/nav.component.html` para mostrarlo solo dentro del menú de usuario autenticado.
- Quité el formulario de inicio de sesión embebido y el estado de credenciales del componente de descargas y actualicé el encabezado en `web/frontend/src/app/components/descargas/descargas.component.html`.
- La página de `DescargasComponent` ahora detecta la sesión y si el usuario no está autenticado redirige a `'/login'` mediante el `Router`, y solo carga las versiones cuando hay sesión activa en `web/frontend/src/app/components/descargas/descargas.component.ts`.
- Eliminé imports/propiedades relacionadas con el formulario y ajusté las dependencias del componente (`AuthService`, `VersionesService`, `Router`).

### Testing
- Levanté el servidor de desarrollo con `npm --prefix web/frontend run start -- --host 0.0.0.0 --port 4200` y la aplicación compiló correctamente tras corregir una importación faltante de `sweetalert2` (build completado con éxito).
- Capturé un screenshot automático de la página `/inicio` usando Playwright y la navegación resultó en un menú sin el enlace de "Descargas" para invitados (`artifacts/menu-sin-descargas.png`).
- No se ejecutaron tests unitarios automáticos adicionales en este cambio; los pasos de build y la verificación visual automatizada fueron exitosos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739d1c873c8320b55ea8b644983f80)