### PR TITLE
Ajustar endpoint GraphQL y completar flujo de registro diferido de usuarios/credenciales

### DIFF
--- a/graphql-server/src/schema/resolvers.ts
+++ b/graphql-server/src/schema/resolvers.ts
@@ -83,9 +83,9 @@ interface EstudianteRow {
 
 interface CreateUserInput {
   email: string;
-  nombre: string;
-  apepaterno: string;
-  apematerno: string;
+  nombre?: string | null;
+  apepaterno?: string | null;
+  apematerno?: string | null;
   rol: string;
   password: string;
 }
@@ -364,6 +364,9 @@ export const resolvers = {
     createUser: async (_: any, { input }: { input: CreateUserInput }) => {
       try {
         const { email, nombre, apepaterno, apematerno, rol, password } = input;
+        const nombreSeguro = (nombre ?? '').trim();
+        const apepaternoSeguro = (apepaterno ?? '').trim();
+        const apematernoSeguro = apematerno ? apematerno.trim() : null;
 
         // Validar que el email no exista
         const existingUser = await query('SELECT id FROM usuarios WHERE email = $1', [email]);
@@ -400,7 +403,7 @@ export const resolvers = {
             (SELECT codigo FROM cat_roles_usuario WHERE id_rol = usuarios.rol) as "rol",
             activo,
             fecha_registro as "fechaRegistro"`,
-          [email, nombre, apepaterno, apematerno, roleId, `${salt}:${passwordHash}`]
+          [email, nombreSeguro, apepaternoSeguro, apematernoSeguro, roleId, `${salt}:${passwordHash}`]
         );
 
         const createdUser = result.rows[0] as CreateUserResult;

--- a/graphql-server/src/schema/typeDefs.ts
+++ b/graphql-server/src/schema/typeDefs.ts
@@ -213,8 +213,8 @@ export const typeDefs = `#graphql
   """
   input CreateUserInput {
     email: String!
-    nombre: String!
-    apepaterno: String!
+    nombre: String
+    apepaterno: String
     apematerno: String
     rol: UserRole!
     clavesCCT: [String!]!

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -37,7 +37,7 @@
           Ya generaste credenciales con tu primer envío. Inicia sesión con tu correo y la contraseña generada para continuar con la siguiente carga.
         </p>
         <p class="carga__sesion-detalle" *ngIf="!sesionActiva && !tieneCredenciales">
-          Es tu primera carga: valida el archivo para generar automáticamente tu contraseña y credenciales de acceso.
+          Es tu primera carga: valida el archivo y cárgalo para generar automáticamente tu contraseña y credenciales de acceso.
         </p>
       </div>
     </div>
@@ -300,7 +300,7 @@
         <h3>Estatus de validación</h3>
         <ul>
           <li>Al seleccionar el archivo se muestra “Validando tu archivo…”.</li>
-          <li>Si las reglas se cumplen, se confirma la fecha disponible (hoy + 4 días) y las credenciales generadas.</li>
+          <li>Si las reglas se cumplen, se confirma la fecha disponible (hoy + 4 días) y al cargar se generan las credenciales.</li>
           <li>Si hay errores, revisa la lista anterior, corrige en Excel y vuelve a cargar.</li>
         </ul>
       </div>

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -306,6 +306,10 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
         nivel: resultado.tipoDetectado ?? undefined
       });
       await this.mostrarConfirmacionGuardado(guardado, 'guardado', resultado);
+      const credencialesListas = await this.registrarUsuarioYCredenciales(resultado);
+      if (!credencialesListas) {
+        return;
+      }
       if (resultado.escDatos && resultado.resultadoExito && resultado.pdfTipo !== 'exito') {
         await this.generarPdfExito(
           resultado,
@@ -337,6 +341,10 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
               }
             );
             await this.mostrarConfirmacionGuardado(resultadoReemplazo, 'reemplazo', resultado);
+            const credencialesListas = await this.registrarUsuarioYCredenciales(resultado);
+            if (!credencialesListas) {
+              return;
+            }
             if (resultado.escDatos && resultado.resultadoExito && resultado.pdfTipo !== 'exito') {
               await this.generarPdfExito(
                 resultado,
@@ -368,6 +376,98 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       });
     } finally {
       resultado.guardando = false;
+    }
+  }
+
+  private async registrarUsuarioYCredenciales(resultado: ResultadoArchivo): Promise<boolean> {
+    if (!resultado.escDatos || !resultado.resultadoExito) {
+      resultado.errorGuardado = 'No se encontró la información de la escuela para registrar tus credenciales.';
+      await Swal.fire({
+        icon: 'error',
+        title: 'No se pudo registrar',
+        text: resultado.errorGuardado
+      });
+      return false;
+    }
+
+    const credencialesExistentes = this.authService.obtenerCredenciales();
+
+    if (credencialesExistentes) {
+      resultado.resultadoExito.credenciales = {
+        usuario: credencialesExistentes.correo,
+        contrasena: credencialesExistentes.contrasena,
+        esNueva: false
+      };
+      this.credencialesMostradas = {
+        usuario: credencialesExistentes.correo,
+        contrasena: credencialesExistentes.contrasena,
+        esNueva: false
+      };
+      this.estadoCredencialesService.actualizar(
+        credencialesExistentes.correo,
+        credencialesExistentes.contrasena
+      );
+      this.actualizarEstadoSesion();
+      return true;
+    }
+
+    const contrasenaGenerada = this.authService.generarContrasenaTemporal();
+
+    try {
+      await firstValueFrom(
+        this.usuariosService.crearUsuario({
+          email: resultado.escDatos.correo,
+          rol: 'RESPONSABLE_CCT',
+          clavesCCT: [resultado.escDatos.cct],
+          password: contrasenaGenerada
+        })
+      );
+    } catch (error) {
+      resultado.errorGuardado =
+        error instanceof Error
+          ? error.message
+          : 'No pudimos registrar el usuario en el sistema. Intenta nuevamente.';
+      await Swal.fire({
+        icon: 'error',
+        title: 'No se pudo registrar',
+        text: resultado.errorGuardado
+      });
+      return false;
+    }
+
+    try {
+      const nuevasCredenciales = this.authService.registrarCredenciales(
+        resultado.escDatos.cct,
+        resultado.escDatos.correo,
+        contrasenaGenerada
+      );
+      this.estadoCredencialesService.actualizar(
+        resultado.escDatos.correo,
+        nuevasCredenciales.contrasena
+      );
+      resultado.resultadoExito.credenciales = {
+        usuario: resultado.escDatos.correo,
+        contrasena: nuevasCredenciales.contrasena,
+        esNueva: nuevasCredenciales.esNueva
+      };
+      this.credencialesMostradas = {
+        usuario: resultado.escDatos.correo,
+        contrasena: nuevasCredenciales.contrasena,
+        esNueva: nuevasCredenciales.esNueva
+      };
+      this.actualizarEstadoSesion();
+      return true;
+    } catch (error) {
+      resultado.errorGuardado =
+        error instanceof Error
+          ? error.message
+          : 'No pudimos registrar tus credenciales. Intenta nuevamente.';
+      await Swal.fire({
+        icon: 'error',
+        title: 'No se pudo registrar',
+        text: resultado.errorGuardado
+      });
+      return false;
     }
   }
 
@@ -419,46 +519,18 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       return;
     }
 
-    let habiaCredenciales = false;
-    let nuevasCredenciales: { contrasena: string; esNueva: boolean } | null = null;
     const fechaDisponible = this.calcularFechaDisponible();
+    const credencialesValidas = this.authService.coincidenCredenciales(
+      resultado.esc.cct,
+      resultado.esc.correo
+    );
 
-    try {
-      habiaCredenciales = !!this.authService.obtenerCredenciales();
-      nuevasCredenciales = this.authService.registrarCredenciales(resultado.esc.cct, resultado.esc.correo);
-      this.estadoCredencialesService.actualizar(resultado.esc.correo, nuevasCredenciales.contrasena);
-    } catch (error) {
+    if (!credencialesValidas) {
       this.agregarErrores(resultadoArchivo, [
-        error instanceof Error
-          ? error.message
-          : 'No pudimos validar tus credenciales. Usa el CCT y correo originales.'
+        'Ya existe un acceso asociado a otro CCT o correo. Usa las credenciales originales.'
       ]);
       await this.finalizarConError(resultadoArchivo);
       return;
-    }
-
-    if (resultado.esc && nuevasCredenciales?.esNueva) {
-      try {
-        await firstValueFrom(
-          this.usuariosService.crearUsuario({
-            email: resultado.esc.correo,
-            nombre: resultado.esc.nombreEscuela,
-            apepaterno: 'Responsable',
-            apematerno: 'CCT',
-            rol: 'RESPONSABLE_CCT',
-            clavesCCT: [resultado.esc.cct],
-            password: nuevasCredenciales.contrasena
-          })
-        );
-      } catch (error) {
-        this.agregarErrores(resultadoArchivo, [
-          error instanceof Error
-            ? error.message
-            : 'No pudimos registrar el usuario en el sistema. Intenta nuevamente.'
-        ]);
-        await this.finalizarConError(resultadoArchivo);
-        return;
-      }
     }
 
     resultadoArchivo.estado = 'exito';
@@ -470,20 +542,11 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       fechaDisponible,
       credenciales: {
         usuario: resultado.esc.correo,
-        contrasena: nuevasCredenciales?.contrasena ?? '',
-        esNueva: (nuevasCredenciales?.esNueva ?? false) && !habiaCredenciales
+        contrasena: '',
+        esNueva: false
       },
       totalAlumnos: resultado.alumnos?.length ?? 0
     };
-
-    this.credencialesMostradas = {
-      usuario: resultadoArchivo.resultadoExito.credenciales.usuario,
-      contrasena: resultadoArchivo.resultadoExito.credenciales.contrasena,
-      esNueva: resultadoArchivo.resultadoExito.credenciales.esNueva
-    };
-
-    this.actualizarEstadoSesion();
-
   }
 
   private validarPorTipo(tipo: TipoArchivoCarga, buffer: ArrayBuffer): Promise<ResultadoValidacion> {

--- a/web/frontend/src/app/services/auth.service.ts
+++ b/web/frontend/src/app/services/auth.service.ts
@@ -33,7 +33,11 @@ export class AuthService {
     }
   }
 
-  registrarCredenciales(cct: string, correo: string): { contrasena: string; esNueva: boolean } {
+  registrarCredenciales(
+    cct: string,
+    correo: string,
+    contrasenaPersonalizada?: string
+  ): { contrasena: string; esNueva: boolean } {
     const credencialesActuales = this.obtenerCredenciales();
     const cctNormalizado = this.normalizarCct(cct);
     const correoNormalizado = this.normalizarCorreo(correo);
@@ -46,7 +50,8 @@ export class AuthService {
     }
 
     const esNueva = !credencialesActuales;
-    const contrasena = credencialesActuales?.contrasena ?? this.generarContrasena();
+    const contrasena =
+      credencialesActuales?.contrasena ?? contrasenaPersonalizada ?? this.generarContrasena();
 
     localStorage.setItem(
       this.credencialesKey,
@@ -54,6 +59,10 @@ export class AuthService {
     );
 
     return { contrasena, esNueva };
+  }
+
+  generarContrasenaTemporal(): string {
+    return this.generarContrasena();
   }
 
   coincidenCredenciales(cct: string, correo: string): boolean {

--- a/web/frontend/src/app/services/graphql.service.ts
+++ b/web/frontend/src/app/services/graphql.service.ts
@@ -12,7 +12,7 @@ export interface GraphQlResponse<T> {
 
 @Injectable({ providedIn: 'root' })
 export class GraphqlService {
-  private readonly graphqlEndpoint = '/graphql';
+  private readonly graphqlEndpoint = this.resolverEndpoint();
 
   constructor(private readonly http: HttpClient) {}
 
@@ -21,5 +21,19 @@ export class GraphqlService {
       query,
       variables
     });
+  }
+
+  private resolverEndpoint(): string {
+    const configurado = (window as { EIA_GRAPHQL_ENDPOINT?: string })?.EIA_GRAPHQL_ENDPOINT;
+    if (configurado) {
+      return configurado;
+    }
+
+    const enDev = window.location.port === '4200';
+    if (enDev) {
+      return 'http://localhost:4000/graphql';
+    }
+
+    return '/graphql';
   }
 }

--- a/web/frontend/src/app/services/usuarios.service.ts
+++ b/web/frontend/src/app/services/usuarios.service.ts
@@ -5,8 +5,8 @@ import { CREATE_USER_MUTATION } from '../operations/mutation';
 
 export interface CreateUserInput {
   email: string;
-  nombre: string;
-  apepaterno: string;
+  nombre?: string | null;
+  apepaterno?: string | null;
   apematerno?: string | null;
   rol: 'COORDINADOR_FEDERAL' | 'COORDINADOR_ESTATAL' | 'RESPONSABLE_CCT' | 'CONSULTA';
   clavesCCT: string[];


### PR DESCRIPTION
### Motivation
- Resolver el fallo al llamar la mutation `createUser` desde el cliente apuntando al host del frontend en vez del servidor GraphQL y asegurar que las credenciales se generen solo al confirmar/cargar el archivo.
- Permitir crear usuarios sin `nombre` ni `apepaterno` para soportar cuentas basadas solo en `email`/`password` y rol `RESPONSABLE_CCT`.

### Description
- Configuré el cliente GraphQL para resolver dinámicamente el endpoint con `resolverEndpoint()` y usar `http://localhost:4000/graphql` en desarrollo o la variable global `EIA_GRAPHQL_ENDPOINT` si está presente (archivo: `web/frontend/src/app/services/graphql.service.ts`).
- Aplazé la generación/registro de credenciales y añadí el flujo `registrarUsuarioYCredenciales` invocado desde `guardarArchivo`/reemplazo para crear el usuario y guardar credenciales solo al cargar (archivo: `web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts`).
- Cambié la firma de `registrarCredenciales` para aceptar una `contrasenaPersonalizada` y agregué `generarContrasenaTemporal()` para generar la contraseña justo antes de registrar al usuario (archivo: `web/frontend/src/app/services/auth.service.ts`).
- Actualicé el input cliente `CreateUserInput` para que `nombre` y `apepaterno` sean opcionales y adapté la llamada en `UsuariosService` para enviar solo los campos necesarios (archivo: `web/frontend/src/app/services/usuarios.service.ts`).
- Modifiqué el esquema GraphQL y el resolver `createUser` para permitir campos `nombre`/`apepaterno`/`apematerno` opcionales, normalizarlos antes de insertarlos y validar conflictos de email/rol (archivos: `graphql-server/src/schema/typeDefs.ts`, `graphql-server/src/schema/resolvers.ts`).
- Actualicé textos en la UI para dejar claro que las credenciales se generan al cargar el archivo (archivo: `web/frontend/src/app/components/carga-masiva/carga-masiva.component.html`).

### Testing
- En el trabajo previo a estos cambios se instaló dependencias con `npm --prefix web/frontend install` y se arrancó el frontend con `npm start`, y la compilación en modo watch finalizó correctamente (resultado: exitoso).  
- Se ejecutó un script de Playwright que abrió `http://127.0.0.1:4200/carga-masiva` y dejó una captura en `artifacts/carga-masiva.png` (resultado: exitoso).  
- El ajuste más reciente del endpoint GraphQL fue aplicado sin ejecutar pruebas automatizadas adicionales en este paso (no se ejecutaron `ng test`/Jest para este cambio).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa577ca1483208d3f0e3c3b944f88)