### PR TITLE
Alinear documentación y añadir autenticación GraphQL + flujo de credenciales por correo

### DIFF
--- a/graphql-server/src/schema/resolvers.ts
+++ b/graphql-server/src/schema/resolvers.ts
@@ -83,9 +83,10 @@ interface EstudianteRow {
 
 interface CreateUserInput {
   email: string;
-  nombre: string;
-  apepaterno: string;
-  apematerno: string;
+  nombre?: string | null;
+  apepaterno?: string | null;
+  apematerno?: string | null;
+  clavesCCT?: string[];
   rol: string;
   password: string;
 }
@@ -122,6 +123,12 @@ interface CreateUserResult {
   rol: string;
   activo: boolean;
   fechaRegistro: Date;
+}
+
+interface AuthPayload {
+  ok: boolean;
+  message?: string | null;
+  user?: UserRow | null;
 }
 
 interface UploadEvaluacionInput {
@@ -225,7 +232,7 @@ export const resolvers = {
             r.codigo as "rol",
             u.activo,
             u.fecha_registro as "fechaRegistro",
-            u.fecha_ultimo_acceso as "fechaUltimoAcceso"
+            u.updated_at as "fechaUltimoAcceso"
           FROM usuarios u
           INNER JOIN cat_roles_usuario r ON u.rol = r.id_rol
           WHERE u.id = $1`,
@@ -271,7 +278,7 @@ export const resolvers = {
             r.codigo as "rol",
             u.activo,
             u.fecha_registro as "fechaRegistro",
-            u.fecha_ultimo_acceso as "fechaUltimoAcceso"
+            u.updated_at as "fechaUltimoAcceso"
           FROM usuarios u
           INNER JOIN cat_roles_usuario r ON u.rol = r.id_rol
           ORDER BY u.fecha_registro DESC
@@ -364,6 +371,12 @@ export const resolvers = {
     createUser: async (_: any, { input }: { input: CreateUserInput }) => {
       try {
         const { email, nombre, apepaterno, apematerno, rol, password } = input;
+        const clavesCCT = Array.isArray((input as { clavesCCT?: string[] }).clavesCCT)
+          ? (input as { clavesCCT?: string[] }).clavesCCT
+          : [];
+        const nombreSeguro = (nombre ?? '').trim();
+        const apepaternoSeguro = (apepaterno ?? '').trim();
+        const apematernoSeguro = apematerno ? apematerno.trim() : null;
 
         // Validar que el email no exista
         const existingUser = await query('SELECT id FROM usuarios WHERE email = $1', [email]);
@@ -400,15 +413,90 @@ export const resolvers = {
             (SELECT codigo FROM cat_roles_usuario WHERE id_rol = usuarios.rol) as "rol",
             activo,
             fecha_registro as "fechaRegistro"`,
-          [email, nombre, apepaterno, apematerno, roleId, `${salt}:${passwordHash}`]
+          [email, nombreSeguro, apepaternoSeguro, apematernoSeguro, roleId, `${salt}:${passwordHash}`]
         );
 
         const createdUser = result.rows[0] as CreateUserResult;
+
+        if (clavesCCT.length) {
+          const centros = await query(
+            `SELECT id, clave_cct as "claveCCT"
+             FROM centros_trabajo
+             WHERE clave_cct = ANY($1)`,
+            [clavesCCT]
+          );
+
+          const centrosEncontrados = centros.rows as Array<{ id: string; claveCCT: string }>;
+          for (const centro of centrosEncontrados) {
+            await query(
+              `INSERT INTO usuarios_centros_trabajo (usuario_id, centro_trabajo_id)
+               VALUES ($1, $2)
+               ON CONFLICT DO NOTHING`,
+              [createdUser.id, centro.id]
+            );
+          }
+        }
+
         logger.info('User created successfully', { userId: createdUser.id });
 
         return createdUser;
       } catch (error) {
         logger.error('Error creating user', { input, error });
+        throw error;
+      }
+    },
+
+    /**
+     * Autenticar usuario
+     * @use-case CU-01: Autenticación de usuario
+     */
+    authenticateUser: async (_: unknown, { input }: { input: { email: string; password: string } }): Promise<AuthPayload> => {
+      try {
+        const { email, password } = input;
+        const result = await query(
+          `SELECT 
+            u.id,
+            u.email,
+            u.nombre,
+            u.apepaterno,
+            u.apematerno,
+            r.codigo as "rol",
+            u.password_hash,
+            u.activo,
+            u.fecha_registro as "fechaRegistro",
+            u.updated_at as "fechaUltimoAcceso"
+          FROM usuarios u
+          INNER JOIN cat_roles_usuario r ON u.rol = r.id_rol
+          WHERE u.email = $1`,
+          [email]
+        );
+
+        if (result.rows.length === 0) {
+          return { ok: false, message: 'Credenciales inválidas', user: null };
+        }
+
+        const usuario = result.rows[0] as UserRow & { password_hash: string | null };
+        if (!usuario.activo) {
+          return { ok: false, message: 'Usuario inactivo', user: null };
+        }
+
+        const hashGuardado = usuario.password_hash ?? '';
+        const [salt, hash] = hashGuardado.split(':');
+        if (!salt || !hash) {
+          return { ok: false, message: 'Credenciales inválidas', user: null };
+        }
+
+        const hashCalculado = crypto.scryptSync(password, salt, 64).toString('hex');
+        const coincide = crypto.timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(hashCalculado, 'hex'));
+        if (!coincide) {
+          return { ok: false, message: 'Credenciales inválidas', user: null };
+        }
+
+        await query('UPDATE usuarios SET updated_at = NOW() WHERE id = $1', [usuario.id]);
+
+        return { ok: true, message: 'Autenticación correcta', user: usuario };
+      } catch (error) {
+        logger.error('Error authenticating user', { input, error });
         throw error;
       }
     },

--- a/graphql-server/src/schema/typeDefs.ts
+++ b/graphql-server/src/schema/typeDefs.ts
@@ -61,6 +61,12 @@ export const typeDefs = `#graphql
     @psp Design Review - Validación de entrada
     """
     createUser(input: CreateUserInput!): User!
+
+    """
+    Autenticar usuario
+    @use-case CU-01: Autenticación de usuarios
+    """
+    authenticateUser(input: AuthenticateUserInput!): AuthPayload!
     
     """
     Actualizar usuario existente
@@ -206,6 +212,15 @@ export const typeDefs = `#graphql
     totalCount: Int!
     hasNextPage: Boolean!
   }
+
+  """
+  Resultado de autenticación
+  """
+  type AuthPayload {
+    ok: Boolean!
+    message: String
+    user: User
+  }
   
   """
   Input para crear usuario
@@ -213,11 +228,19 @@ export const typeDefs = `#graphql
   """
   input CreateUserInput {
     email: String!
-    nombre: String!
-    apepaterno: String!
+    nombre: String
+    apepaterno: String
     apematerno: String
     rol: UserRole!
     clavesCCT: [String!]!
+    password: String!
+  }
+
+  """
+  Input para autenticar usuario
+  """
+  input AuthenticateUserInput {
+    email: String!
     password: String!
   }
   

--- a/web/doc/arquitectura_software.md
+++ b/web/doc/arquitectura_software.md
@@ -5,7 +5,7 @@
 
 ## 1. Introducción
 
-Describe la arquitectura de alto nivel para la plataforma que **recibe archivos .xlsx sin autenticación previa** (solo en el primer envío), los valida automáticamente, genera credenciales en la primera carga válida y publica ligas de descarga generadas por un sistema externo. Si ya existen credenciales para el CCT/correo, los **reenvíos requieren autenticación previa**.
+Describe la arquitectura de alto nivel para la plataforma que **recibe archivos .xlsx sin autenticación previa** (solo en el primer envío), los valida automáticamente, genera credenciales al cargar la primera validación exitosa y publica ligas de descarga generadas por un sistema externo. Si ya existen credenciales para el CCT/correo, los **reenvíos requieren autenticación previa**.
 
 ---
 
@@ -35,13 +35,13 @@ Arquitectura web de tres capas y procesos desacoplados:
   - 10 verificaciones (CCT, correo, nivel, campos/columnas obligatorias, valores 0–3, estructura general, número/nombre de hojas, consistencia interna y **hash de contenido** para diferenciar archivos con el mismo nombre).
   - Rechazo inmediato con PDF de errores cuando falle; si el hash coincide con un envío previo del mismo CCT/correo se notifica que el archivo ya fue recibido.
 - **Generador de Credenciales y PDFs**
-  - Credenciales solo en primera carga válida (usuario = CCT, contraseña = correo validado).
+  - Credenciales solo al cargar la primera validación exitosa (usuario = correo, contraseña aleatoria).
   - PDFs de confirmación con fecha de consulta (hoy + 4 días) o PDFs de errores.
 - **Registro de Solicitudes**
   - Consecutivo por carga válida.
   - Almacenamiento del archivo validado en repositorio de recepción.
 - **Módulo de Descargas Autenticadas**
-  - Login con CCT + contraseña generada en primera carga válida.
+  - Login con correo + contraseña generada en la primera carga.
   - Listado de versiones de resultados (consecutivo + liga) depositados por el sistema externo.
   - Reutiliza la autenticación para permitir reenvío de archivos cuando ya existan credenciales.
 - **Servicios de integración frontend**

--- a/web/doc/casos_uso.md
+++ b/web/doc/casos_uso.md
@@ -65,9 +65,9 @@ flowchart LR
    - Actor: Escuela (anónima), Operador técnico SEP
    - Descripción: Ejecuta las verificaciones (CCT, correo, nivel, campos obligatorios por hoja, columnas obligatorias, valores 0–3, estructura general, número/nombre de hojas, consistencia interna y **huella de archivo/hash** para distinguir archivos con el mismo nombre) y muestra “Validando tu archivo…”.
 
-3. **CU-03 Generar credenciales en primera carga válida**
+3. **CU-03 Generar credenciales al cargar la primera validación exitosa**
    - Actor: Escuela (anónima)
-   - Descripción: Si es la primera carga válida, crea usuario = CCT validado y contraseña = correo validado.
+   - Descripción: Si es la primera carga exitosa, crea usuario = correo registrado y contraseña aleatoria.
 
 4. **CU-04 Emitir PDF de confirmación o errores**
    - Actor: Escuela (anónima)
@@ -83,7 +83,7 @@ flowchart LR
 
 7. **CU-07 Autenticarse para reenvío/descargas**
    - Actor: Escuela (autenticada)
-   - Descripción: Login con CCT + contraseña generada en la primera carga válida para habilitar el reenvío de archivos y el acceso a descargas.
+   - Descripción: Login con correo + contraseña generada en la primera carga para habilitar el reenvío de archivos y el acceso a descargas.
 
 8. **CU-08 Listar versiones y ligas de descarga**
    - Actores: Escuela (autenticada), Sistema externo de resultados

--- a/web/doc/glosario.md
+++ b/web/doc/glosario.md
@@ -2,8 +2,8 @@
 
 - **Archivo de recepción:** Archivo .xlsx enviado por la escuela y almacenado tras pasar las 10 validaciones (incluye hash para diferenciar archivos con el mismo nombre).
 - **Archivo de resultados:** ZIP/PDF depositado por el sistema externo para descarga de la escuela.
-- **CCT (Clave del Centro de Trabajo):** Identificador oficial de la escuela; se usa como usuario de acceso a descargas.
-- **Credenciales generadas:** Usuario = CCT y contraseña = correo validado creados solo en la primera carga válida.
+- **CCT (Clave del Centro de Trabajo):** Identificador oficial de la escuela para asociar archivos y resultados.
+- **Credenciales generadas:** Usuario = correo registrado y contraseña aleatoria creados solo al cargar el primer archivo validado.
 - **PDF de confirmación:** Comprobante descargado automáticamente cuando el archivo es válido; incluye mensaje, fecha de consulta (hoy + 4 días), usuario y contraseña.
 - **PDF de errores:** Comprobante descargado automáticamente cuando las validaciones fallan.
 - **Plataforma de recepción:** Módulo web que recibe, valida y registra solicitudes sin procesar resultados.

--- a/web/doc/manual_usuario_frontend.md
+++ b/web/doc/manual_usuario_frontend.md
@@ -12,7 +12,7 @@ En el menú superior encontrarás los accesos principales al sistema:
 
 - **Inicio**: Página principal con el resumen del objetivo y el flujo rápido de carga. 【F:web/frontend/src/app/shared/nav/nav.component.html†L10-L38】
 - **Carga masiva**: Módulo para subir la plantilla oficial de Excel sin iniciar sesión. 【F:web/frontend/src/app/shared/nav/nav.component.html†L16-L21】
-- **Login**: Acceso para usuarios que ya generaron credenciales con su primera carga. 【F:web/frontend/src/app/shared/nav/nav.component.html†L65-L74】
+- **Login**: Acceso para usuarios que ya generaron credenciales al cargar su primer archivo validado. 【F:web/frontend/src/app/shared/nav/nav.component.html†L65-L74】
 - **Admin login**: Acceso exclusivo para administradores. 【F:web/frontend/src/app/shared/nav/nav.component.html†L106-L112】
 
 Cuando un usuario inicia sesión, el menú muestra un **submenú de usuario** con:
@@ -70,7 +70,7 @@ Una vez subido el archivo:
 
 - Se muestra el estado de validación (validando, con errores o validado). 【F:web/frontend/src/app/components/carga-masiva/carga-masiva.component.html†L146-L187】
 - Si hay errores, se despliega una lista detallada por hoja. 【F:web/frontend/src/app/components/carga-masiva/carga-masiva.component.html†L199-L214】
-- Si el archivo es válido, se confirma el resultado y se generan credenciales si es la primera carga. 【F:web/frontend/src/app/components/carga-masiva/carga-masiva.component.html†L223-L269】
+- Si el archivo es válido, se confirma el resultado y las credenciales se generan **al cargar** el archivo por primera vez. 【F:web/frontend/src/app/components/carga-masiva/carga-masiva.component.html†L223-L269】
 
 > 📷 **Pon aquí imagen del estado de validación con errores.**
 > 📷 **Pon aquí imagen del estado de validación exitoso.**
@@ -95,7 +95,7 @@ Al final de la página hay una guía rápida con reglas para llenar correctament
 ---
 
 ## 5. Login (usuarios)
-La página de login se usa cuando ya se generaron credenciales en una carga previa. 【F:web/frontend/src/app/components/login/login.component.html†L1-L18】
+La página de login se usa cuando ya se generaron credenciales en una carga previa. El acceso es con **correo y contraseña**. 【F:web/frontend/src/app/components/login/login.component.html†L1-L18】
 
 - Se ingresa correo y contraseña. 【F:web/frontend/src/app/components/login/login.component.html†L14-L46】
 - Hay un botón para mostrar/ocultar la contraseña. 【F:web/frontend/src/app/components/login/login.component.html†L32-L45】
@@ -199,8 +199,8 @@ El administrador puede cerrar su sesión desde el botón **Cerrar sesión** al f
 ---
 
 ## 13. Recomendaciones generales
-- Usa un correo válido para la carga masiva, ya que con ese correo se generan las credenciales de acceso. 【F:web/frontend/src/app/components/carga-masiva/carga-masiva.component.html†L68-L89】
-- Guarda la contraseña generada en la primera carga, ya que será necesaria para futuras sesiones. 【F:web/frontend/src/app/components/carga-masiva/carga-masiva.component.html†L151-L177】
+- Usa un correo válido para la carga masiva, ya que con ese correo se generan las credenciales de acceso cuando el archivo se **carga** correctamente. 【F:web/frontend/src/app/components/carga-masiva/carga-masiva.component.html†L68-L89】
+- Guarda la contraseña generada en la primera carga exitosa, ya que será necesaria para futuras sesiones. 【F:web/frontend/src/app/components/carga-masiva/carga-masiva.component.html†L151-L177】
 - Si no ves un registro en el panel de administrador, asegúrate de validar un Excel desde carga masiva. 【F:web/frontend/src/app/components/admin-panel/admin-panel.component.html†L27-L32】
 
 > 📷 **Pon aquí imagen de la sección de credenciales generadas.**
@@ -209,6 +209,6 @@ El administrador puede cerrar su sesión desde el botón **Cerrar sesión** al f
 
 ## 14. Glosario rápido
 - **Carga masiva:** Subida de plantilla Excel con validación automática.
-- **Credenciales:** Correo + contraseña generada en la primera carga.
+- **Credenciales:** Correo + contraseña aleatoria generada al cargar el primer archivo validado.
 - **Resultados:** Archivos de salida que el administrador asocia a un registro Excel.
 - **Ticket:** Solicitud de soporte enviada por el usuario.

--- a/web/doc/plan_iteraciones.md
+++ b/web/doc/plan_iteraciones.md
@@ -88,7 +88,7 @@
 ## Iteración C2 – Portal de descargas y publicación de ligas
 
 **Objetivos:**
-- Implementar login (CCT + contraseña generada) y módulo de descargas.
+- Implementar login (correo + contraseña generada) y módulo de descargas.
 - Consumir ligas/archivos provistos por el sistema externo y listarlos por versión/consecutivo (iniciando con datos simulados en frontend; conmutar a GraphQL en cuanto el equipo de backend entregue operaciones).
 - Ajustar monitoreo técnico (logs, espacio en disco, salud de workers).
 

--- a/web/doc/riesgos.md
+++ b/web/doc/riesgos.md
@@ -5,7 +5,7 @@
 | R1 | Operativo | Escuelas continúan usando correo en lugar de la carga anónima .xlsx         | Media | Alta    | Comunicación oficial, instrucciones claras en portal, monitoreo de buzones |
 | R2 | Técnico   | Sobrecarga de validaciones (pico cercano al cierre, objetivo 120,000)       | Alta  | Alta    | Escalar workers GraphQL/Redis, pruebas de carga, autoescalado en infraestructura |
 | R3 | Datos     | Archivos con estructura/nombres de hoja alterados rompen validación         | Alta  | Media   | Validación estricta de 10 reglas (incluye hash para detectar duplicados por contenido), mensajes claros en PDF de errores, plantillas oficiales |
-| R4 | Seguridad | Compromiso de credenciales (CCT + contraseña correo validado)               | Media | Alta    | Hashing de contraseñas, HTTPS obligatorio, bitácora de accesos, bloqueo por intentos fallidos |
+| R4 | Seguridad | Compromiso de credenciales (correo + contraseña generada)                   | Media | Alta    | Hashing de contraseñas, HTTPS obligatorio, bitácora de accesos, bloqueo por intentos fallidos |
 | R5 | Integración | Retraso o falla en depósito de resultados por el sistema externo           | Media | Alta    | Acuerdos de entrega, monitoreo de repositorio de resultados, alertas tempranas |
 | R6 | Infraestructura | Falta de espacio en repositorios (mínimo 1 TB para recepción/resultados) | Media | Alta    | Monitoreo de disco, planes de expansión en caliente, limpieza controlada de archivos obsoletos |
 | R7 | Cambio    | Resistencia de usuarios a la credencial generada automáticamente            | Media | Media   | Manuales y FAQs, recordatorio en PDF de confirmación, soporte de mesa de ayuda |

--- a/web/doc/srs.md
+++ b/web/doc/srs.md
@@ -19,7 +19,7 @@ La plataforma cubre únicamente el flujo de recepción–validación–descarga 
 - Carga anónima de archivos .xlsx.
 - Validación automática de estructura y contenido.
 - Emisión de **PDF de confirmación** (válidos) o **PDF de errores** (inválidos).
-- Generación de credenciales solo en la primera carga válida (usuario = CCT, contraseña = correo validado).
+- Generación de credenciales solo al cargar la primera validación exitosa (usuario = correo, contraseña aleatoria).
 - Registro de cada carga válida como solicitud independiente con consecutivo.
 - Exposición de ligas de descarga depositadas por un **sistema externo** que procesa los archivos.
 
@@ -47,7 +47,7 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend G
 - Pantalla de carga anónima de archivo.
 - Mensaje de validación en línea con etiqueta “Validando tu archivo…”.
 - Descarga automática de PDF (confirmación o errores).
-- Pantalla protegida para consulta de ligas de descarga (login con CCT + correo validado).
+- Pantalla protegida para consulta de ligas de descarga (login con correo + contraseña).
 - Panel técnico básico para monitoreo de solicitudes.
 - Módulo de carga masiva con estado de validaciones y credenciales generadas.
 - Vista de archivos guardados con búsqueda, descarga y gestión de resultados asociados.
@@ -74,7 +74,7 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend G
 ### 3.1 Actores
 
 - **Escuela (anónima):** carga archivo .xlsx sin autenticarse cuando es su primer envío; recibe PDF de confirmación/errores.
-- **Escuela autenticada:** usa CCT + contraseña (correo validado en primera carga) para reenviar archivos, cargar nuevas versiones (identificadas por hash) y descargar resultados publicados.
+- **Escuela autenticada:** usa correo + contraseña generada en la primera carga para reenviar archivos, cargar nuevas versiones (identificadas por hash) y descargar resultados publicados.
 - **Sistema externo de procesamiento:** genera resultados y deposita ligas/archivos para publicación.
 - **Operador técnico SEP:** supervisa logs y repositorios de archivos.
 - **Administrador SEP:** carga resultados asociados a solicitudes validadas y gestiona tickets de soporte.
@@ -83,11 +83,11 @@ Aplicación web de tres capas con **frontend Angular 19 (signals)**, **backend G
 
 - CU-01 Cargar archivo .xlsx sin login (primer envío).
 - CU-02 Validar estructura y contenido (10 verificaciones, incluye hash de archivo).
-- CU-03 Generar credenciales en primera carga válida.
+- CU-03 Generar credenciales al cargar la primera validación exitosa.
 - CU-04 Emitir PDF de confirmación o errores.
 - CU-05 Registrar solicitud con consecutivo y repositorio de archivos válidos.
 - CU-06 Detectar reenvío y requerir login.
-- CU-07 Autenticarse para reenvío de archivos y descargas (CCT + correo validado).
+- CU-07 Autenticarse para reenvío de archivos y descargas (correo + contraseña).
 - CU-08 Listar versiones y ligas de descarga provenientes del sistema externo.
 - CU-09 Consultar archivos guardados con acciones de descarga/limpieza.
 - CU-10 Seguimiento de solicitudes y descargas con filtros por CCT/fecha.
@@ -122,12 +122,12 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 - RF-01: Permitir carga de archivo .xlsx sin autenticación previa **solo cuando no existan credenciales previas para el mismo CCT/correo**.
 - RF-02: Mostrar estado “Validando tu archivo…” mientras se procesa.
 - RF-03: Ejecutar las **10 reglas de validación** descritas en la sección 4 (incluida la huella hash para evitar duplicados por nombre).
-- RF-04: Si el archivo es válido, generar **PDF de confirmación** con mensaje, fecha futura de consulta (hoy + 4 días), usuario (CCT), contraseña (correo validado solo en primera carga) y marca de tiempo.
+- RF-04: Si el archivo es válido y se carga, generar **PDF de confirmación** con mensaje, fecha futura de consulta (hoy + 4 días), usuario (correo), contraseña (aleatoria solo en primera carga) y marca de tiempo.
 - RF-05: Si el archivo es inválido, generar **PDF de errores** con detalle de fallas.
-- RF-06: Crear credenciales **solo en la primera carga válida** (usuario = CCT, contraseña = correo validado) y reutilizarlas en cargas posteriores.
+- RF-06: Crear credenciales **solo al cargar la primera validación exitosa** (usuario = correo, contraseña aleatoria) y reutilizarlas en cargas posteriores.
 - RF-07: Bloquear reenvíos anónimos cuando ya existan credenciales para el CCT/correo y exigir login previo para permitir la nueva carga.
 - RF-08: Registrar cada carga válida como **solicitud independiente** con consecutivo, guardar el archivo en repositorio de recepción y **asociar su hash** para diferenciar envíos con nombres repetidos.
-- RF-09: Habilitar autenticación (CCT + contraseña) para reenviar archivos y consultar las ligas de descarga.
+- RF-09: Habilitar autenticación (correo + contraseña) para reenviar archivos y consultar las ligas de descarga.
 - RF-10: Mostrar **todas las versiones** de resultados que el sistema externo haya depositado, con consecutivo y liga.
 - RF-11: Mantener repositorios separados para archivos recibidos y resultados publicados.
 - RF-12: Implementar servicios frontend tipificados hacia GraphQL que, mientras no exista backend disponible, devuelvan datos simulados/localStorage usando el mismo contrato esperado de las operaciones.
@@ -166,6 +166,6 @@ Si la estructura o los valores no cumplen, el archivo se **rechaza** y se entreg
 
 - Cualquier escuela puede subir un archivo .xlsx y recibir PDF de confirmación o errores sin iniciar sesión **solo si es su primer envío (no existen credenciales previas para su CCT/correo)**.
 - Las 10 reglas de validación se ejecutan y rechazan archivos que no cumplan estructura/valores o que sean idénticos a un envío previo (mismo hash para el mismo CCT/correo).
-- La primera carga válida genera credenciales (usuario = CCT, contraseña = correo validado) y las mantiene para descargas futuras y reenvíos autenticados.
+- La primera carga exitosa genera credenciales (usuario = correo, contraseña aleatoria) y las mantiene para descargas futuras y reenvíos autenticados.
 - Cada carga válida queda registrada como solicitud independiente con consecutivo y archivo almacenado.
 - Los reenvíos requieren autenticación cuando ya existen credenciales, y las ligas de descarga provienen del sistema externo y se listan con su versión/consecutivo al autenticarse.

--- a/web/doc/vision_document.md
+++ b/web/doc/vision_document.md
@@ -18,7 +18,7 @@ El sistema realiza:
 
 - **Recepción anónima** de archivos .xlsx con etiqueta “Validando tu archivo…” **solo para el primer envío por CCT/correo**.
 - **Validación automática** con 10 verificaciones (CCT, correo, nivel, campos y columnas obligatorias, valores 0–3, estructura general, número/nombre de hojas, consistencia interna y **huella hash** para distinguir archivos con el mismo nombre).
-- **Generación de credenciales** solo en la primera carga válida (usuario = CCT validado, contraseña = correo validado; no se regenera en cargas posteriores).
+- **Generación de credenciales** solo en la primera carga validada **y cargada** (usuario = correo registrado, contraseña aleatoria; no se regenera en cargas posteriores).
 - **Emisión de PDFs** de confirmación (mensaje, fecha hoy + 4 días, usuario/contraseña, marca de tiempo) o de errores cuando aplica.
 - **Registro de solicitudes**: cada carga válida es independiente con consecutivo; repositorio de archivos recibidos.
 - **Publicación de ligas de descarga** entregadas por un sistema externo que procesa los archivos.
@@ -75,7 +75,7 @@ Sustituir el envío de archivos por correo en la segunda aplicación EIA por un 
 - Recibe PDF de confirmación/errores.
 
 ### Escuela autenticada
-- Accede con usuario = CCT y contraseña = correo validado en la primera carga.
+- Accede con usuario = correo registrado y contraseña aleatoria generada en la primera carga.
 - Puede reenviar archivos cuando ya existan credenciales y consulta todas las versiones de resultados disponibles y sus ligas de descarga.
 
 ### Operador técnico SEP
@@ -97,9 +97,9 @@ Aplicación web de tres capas con **Angular 19 (signals)**, **backend GraphQL** 
 - Cargar archivo .xlsx sin autenticación **solo para el primer envío del CCT/correo**.
 - Ejecutar 10 validaciones y mostrar estado “Validando tu archivo…” (incluye hash para detectar archivos idénticos).
 - Generar PDF de confirmación o errores y descargarlo automáticamente.
-- Crear credenciales en la primera carga válida y mantenerlas en cargas posteriores.
+- Crear credenciales al cargar la primera validación exitosa y mantenerlas en cargas posteriores.
 - Registrar cada solicitud con consecutivo y almacenar el archivo en repositorio de recepción.
-- Permitir login (CCT + contraseña) para reenviar archivos cuando ya existan credenciales y consultar versiones y ligas de descarga depositadas externamente.
+- Permitir login (correo + contraseña) para reenviar archivos cuando ya existan credenciales y consultar versiones y ligas de descarga depositadas externamente.
 
 ## 4.3 Suposiciones y dependencias
 - Las plantillas .xlsx mantienen nombres de hojas y columnas esperadas.
@@ -116,7 +116,7 @@ Aplicación web de tres capas con **Angular 19 (signals)**, **backend GraphQL** 
 ## 5.1 Requerimientos funcionales (resumen)
 - RF-01: Recepción anónima de archivo .xlsx con etiqueta de validación en línea **solo en el primer envío**; si ya existe credencial se exige login antes de reenviar.
 - RF-02: Validación automática con 10 reglas (incluye hash) y rechazo con PDF de errores cuando falle.
-- RF-03: Generación de credenciales solo en primera carga válida (usuario = CCT, contraseña = correo validado).
+- RF-03: Generación de credenciales solo al cargar la primera validación exitosa (usuario = correo, contraseña aleatoria).
 - RF-04: Emisión de PDF de confirmación con fecha de consulta (hoy + 4 días), usuario, contraseña y marca de tiempo.
 - RF-05: Registro de solicitudes con consecutivo y almacenamiento de archivos válidos en repositorio de recepción.
 - RF-06: Portal autenticado para listar versiones y ligas de descarga provenientes del sistema externo.

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.html
@@ -37,7 +37,7 @@
           Ya generaste credenciales con tu primer envío. Inicia sesión con tu correo y la contraseña generada para continuar con la siguiente carga.
         </p>
         <p class="carga__sesion-detalle" *ngIf="!sesionActiva && !tieneCredenciales">
-          Es tu primera carga: valida el archivo para generar automáticamente tu contraseña y credenciales de acceso.
+          Es tu primera carga: valida el archivo y cárgalo para generar automáticamente tu contraseña y credenciales de acceso.
         </p>
       </div>
     </div>
@@ -300,7 +300,7 @@
         <h3>Estatus de validación</h3>
         <ul>
           <li>Al seleccionar el archivo se muestra “Validando tu archivo…”.</li>
-          <li>Si las reglas se cumplen, se confirma la fecha disponible (hoy + 4 días) y las credenciales generadas.</li>
+          <li>Si las reglas se cumplen, se confirma la fecha disponible (hoy + 4 días) y al cargar se generan las credenciales.</li>
           <li>Si hay errores, revisa la lista anterior, corrige en Excel y vuelve a cargar.</li>
         </ul>
       </div>

--- a/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
+++ b/web/frontend/src/app/components/carga-masiva/carga-masiva.component.ts
@@ -306,6 +306,10 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
         nivel: resultado.tipoDetectado ?? undefined
       });
       await this.mostrarConfirmacionGuardado(guardado, 'guardado', resultado);
+      const credencialesListas = await this.registrarUsuarioYCredenciales(resultado);
+      if (!credencialesListas) {
+        return;
+      }
       if (resultado.escDatos && resultado.resultadoExito && resultado.pdfTipo !== 'exito') {
         await this.generarPdfExito(
           resultado,
@@ -337,6 +341,10 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
               }
             );
             await this.mostrarConfirmacionGuardado(resultadoReemplazo, 'reemplazo', resultado);
+            const credencialesListas = await this.registrarUsuarioYCredenciales(resultado);
+            if (!credencialesListas) {
+              return;
+            }
             if (resultado.escDatos && resultado.resultadoExito && resultado.pdfTipo !== 'exito') {
               await this.generarPdfExito(
                 resultado,
@@ -368,6 +376,98 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       });
     } finally {
       resultado.guardando = false;
+    }
+  }
+
+  private async registrarUsuarioYCredenciales(resultado: ResultadoArchivo): Promise<boolean> {
+    if (!resultado.escDatos || !resultado.resultadoExito) {
+      resultado.errorGuardado = 'No se encontró la información de la escuela para registrar tus credenciales.';
+      await Swal.fire({
+        icon: 'error',
+        title: 'No se pudo registrar',
+        text: resultado.errorGuardado
+      });
+      return false;
+    }
+
+    const credencialesExistentes = this.authService.obtenerCredenciales();
+
+    if (credencialesExistentes) {
+      resultado.resultadoExito.credenciales = {
+        usuario: credencialesExistentes.correo,
+        contrasena: credencialesExistentes.contrasena,
+        esNueva: false
+      };
+      this.credencialesMostradas = {
+        usuario: credencialesExistentes.correo,
+        contrasena: credencialesExistentes.contrasena,
+        esNueva: false
+      };
+      this.estadoCredencialesService.actualizar(
+        credencialesExistentes.correo,
+        credencialesExistentes.contrasena
+      );
+      this.actualizarEstadoSesion();
+      return true;
+    }
+
+    const contrasenaGenerada = this.authService.generarContrasenaTemporal();
+
+    try {
+      await firstValueFrom(
+        this.usuariosService.crearUsuario({
+          email: resultado.escDatos.correo,
+          rol: 'RESPONSABLE_CCT',
+          clavesCCT: [resultado.escDatos.cct],
+          password: contrasenaGenerada
+        })
+      );
+    } catch (error) {
+      resultado.errorGuardado =
+        error instanceof Error
+          ? error.message
+          : 'No pudimos registrar el usuario en el sistema. Intenta nuevamente.';
+      await Swal.fire({
+        icon: 'error',
+        title: 'No se pudo registrar',
+        text: resultado.errorGuardado
+      });
+      return false;
+    }
+
+    try {
+      const nuevasCredenciales = this.authService.registrarCredenciales(
+        resultado.escDatos.cct,
+        resultado.escDatos.correo,
+        contrasenaGenerada
+      );
+      this.estadoCredencialesService.actualizar(
+        resultado.escDatos.correo,
+        nuevasCredenciales.contrasena
+      );
+      resultado.resultadoExito.credenciales = {
+        usuario: resultado.escDatos.correo,
+        contrasena: nuevasCredenciales.contrasena,
+        esNueva: nuevasCredenciales.esNueva
+      };
+      this.credencialesMostradas = {
+        usuario: resultado.escDatos.correo,
+        contrasena: nuevasCredenciales.contrasena,
+        esNueva: nuevasCredenciales.esNueva
+      };
+      this.actualizarEstadoSesion();
+      return true;
+    } catch (error) {
+      resultado.errorGuardado =
+        error instanceof Error
+          ? error.message
+          : 'No pudimos registrar tus credenciales. Intenta nuevamente.';
+      await Swal.fire({
+        icon: 'error',
+        title: 'No se pudo registrar',
+        text: resultado.errorGuardado
+      });
+      return false;
     }
   }
 
@@ -419,46 +519,18 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       return;
     }
 
-    let habiaCredenciales = false;
-    let nuevasCredenciales: { contrasena: string; esNueva: boolean } | null = null;
     const fechaDisponible = this.calcularFechaDisponible();
+    const credencialesValidas = this.authService.coincidenCredenciales(
+      resultado.esc.cct,
+      resultado.esc.correo
+    );
 
-    try {
-      habiaCredenciales = !!this.authService.obtenerCredenciales();
-      nuevasCredenciales = this.authService.registrarCredenciales(resultado.esc.cct, resultado.esc.correo);
-      this.estadoCredencialesService.actualizar(resultado.esc.correo, nuevasCredenciales.contrasena);
-    } catch (error) {
+    if (!credencialesValidas) {
       this.agregarErrores(resultadoArchivo, [
-        error instanceof Error
-          ? error.message
-          : 'No pudimos validar tus credenciales. Usa el CCT y correo originales.'
+        'Ya existe un acceso asociado a otro CCT o correo. Usa las credenciales originales.'
       ]);
       await this.finalizarConError(resultadoArchivo);
       return;
-    }
-
-    if (resultado.esc && nuevasCredenciales?.esNueva) {
-      try {
-        await firstValueFrom(
-          this.usuariosService.crearUsuario({
-            email: resultado.esc.correo,
-            nombre: resultado.esc.nombreEscuela,
-            apepaterno: 'Responsable',
-            apematerno: 'CCT',
-            rol: 'RESPONSABLE_CCT',
-            clavesCCT: [resultado.esc.cct],
-            password: nuevasCredenciales.contrasena
-          })
-        );
-      } catch (error) {
-        this.agregarErrores(resultadoArchivo, [
-          error instanceof Error
-            ? error.message
-            : 'No pudimos registrar el usuario en el sistema. Intenta nuevamente.'
-        ]);
-        await this.finalizarConError(resultadoArchivo);
-        return;
-      }
     }
 
     resultadoArchivo.estado = 'exito';
@@ -470,20 +542,11 @@ export class CargaMasivaComponent implements OnInit, OnDestroy {
       fechaDisponible,
       credenciales: {
         usuario: resultado.esc.correo,
-        contrasena: nuevasCredenciales?.contrasena ?? '',
-        esNueva: (nuevasCredenciales?.esNueva ?? false) && !habiaCredenciales
+        contrasena: '',
+        esNueva: false
       },
       totalAlumnos: resultado.alumnos?.length ?? 0
     };
-
-    this.credencialesMostradas = {
-      usuario: resultadoArchivo.resultadoExito.credenciales.usuario,
-      contrasena: resultadoArchivo.resultadoExito.credenciales.contrasena,
-      esNueva: resultadoArchivo.resultadoExito.credenciales.esNueva
-    };
-
-    this.actualizarEstadoSesion();
-
   }
 
   private validarPorTipo(tipo: TipoArchivoCarga, buffer: ArrayBuffer): Promise<ResultadoValidacion> {

--- a/web/frontend/src/app/components/login/login.component.ts
+++ b/web/frontend/src/app/components/login/login.component.ts
@@ -3,8 +3,10 @@ import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import Swal from 'sweetalert2';
+import { firstValueFrom } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 import { EstadoCredencialesService } from '../../services/estado-credenciales.service';
+import { UsuariosService } from '../../services/usuarios.service';
 
 @Component({
   selector: 'app-login',
@@ -27,6 +29,7 @@ export class LoginComponent implements OnInit {
   constructor(
     private readonly authService: AuthService,
     private readonly estadoCredencialesService: EstadoCredencialesService,
+    private readonly usuariosService: UsuariosService,
     private readonly router: Router,
     private readonly route: ActivatedRoute
   ) {}
@@ -54,7 +57,23 @@ export class LoginComponent implements OnInit {
     this.autenticando = true;
 
     try {
-      this.authService.iniciarSesion(this.correo, this.contrasena);
+      const usuario = await firstValueFrom(
+        this.usuariosService.autenticarUsuario(this.correo, this.contrasena)
+      );
+
+      const cct = usuario.centrosTrabajo?.[0]?.claveCCT ?? null;
+      if (cct) {
+        const nuevasCredenciales = this.authService.registrarCredenciales(
+          cct,
+          this.correo,
+          this.contrasena
+        );
+        this.estadoCredencialesService.actualizar(this.correo, nuevasCredenciales.contrasena);
+        this.authService.iniciarSesion(this.correo, this.contrasena);
+      } else {
+        this.authService.iniciarSesionSinCredenciales(this.correo);
+      }
+
       await Swal.fire({
         icon: 'success',
         title: 'Sesión iniciada',

--- a/web/frontend/src/app/operations/mutation.ts
+++ b/web/frontend/src/app/operations/mutation.ts
@@ -12,3 +12,20 @@ export const CREATE_USER_MUTATION = `
     }
   }
 `;
+
+export const AUTHENTICATE_USER_MUTATION = `
+  mutation AuthenticateUser($input: AuthenticateUserInput!) {
+    authenticateUser(input: $input) {
+      ok
+      message
+      user {
+        id
+        email
+        rol
+        centrosTrabajo {
+          claveCCT
+        }
+      }
+    }
+  }
+`;

--- a/web/frontend/src/app/services/auth.service.ts
+++ b/web/frontend/src/app/services/auth.service.ts
@@ -33,7 +33,11 @@ export class AuthService {
     }
   }
 
-  registrarCredenciales(cct: string, correo: string): { contrasena: string; esNueva: boolean } {
+  registrarCredenciales(
+    cct: string,
+    correo: string,
+    contrasenaPersonalizada?: string
+  ): { contrasena: string; esNueva: boolean } {
     const credencialesActuales = this.obtenerCredenciales();
     const cctNormalizado = this.normalizarCct(cct);
     const correoNormalizado = this.normalizarCorreo(correo);
@@ -46,7 +50,8 @@ export class AuthService {
     }
 
     const esNueva = !credencialesActuales;
-    const contrasena = credencialesActuales?.contrasena ?? this.generarContrasena();
+    const contrasena =
+      credencialesActuales?.contrasena ?? contrasenaPersonalizada ?? this.generarContrasena();
 
     localStorage.setItem(
       this.credencialesKey,
@@ -54,6 +59,10 @@ export class AuthService {
     );
 
     return { contrasena, esNueva };
+  }
+
+  generarContrasenaTemporal(): string {
+    return this.generarContrasena();
   }
 
   coincidenCredenciales(cct: string, correo: string): boolean {
@@ -77,6 +86,11 @@ export class AuthService {
       throw new Error('El correo o la contraseña no coinciden con tu primer envío.');
     }
 
+    this.marcarSesionActiva();
+    localStorage.setItem(this.sesionCorreoKey, this.normalizarCorreo(correo));
+  }
+
+  iniciarSesionSinCredenciales(correo: string): void {
     this.marcarSesionActiva();
     localStorage.setItem(this.sesionCorreoKey, this.normalizarCorreo(correo));
   }

--- a/web/frontend/src/app/services/graphql.service.ts
+++ b/web/frontend/src/app/services/graphql.service.ts
@@ -12,7 +12,7 @@ export interface GraphQlResponse<T> {
 
 @Injectable({ providedIn: 'root' })
 export class GraphqlService {
-  private readonly graphqlEndpoint = '/graphql';
+  private readonly graphqlEndpoint = this.resolverEndpoint();
 
   constructor(private readonly http: HttpClient) {}
 
@@ -21,5 +21,19 @@ export class GraphqlService {
       query,
       variables
     });
+  }
+
+  private resolverEndpoint(): string {
+    const configurado = (window as { EIA_GRAPHQL_ENDPOINT?: string })?.EIA_GRAPHQL_ENDPOINT;
+    if (configurado) {
+      return configurado;
+    }
+
+    const enDev = window.location.port === '4200';
+    if (enDev) {
+      return 'http://localhost:4000/graphql';
+    }
+
+    return '/graphql';
   }
 }

--- a/web/frontend/src/app/services/usuarios.service.ts
+++ b/web/frontend/src/app/services/usuarios.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 import { map, Observable } from 'rxjs';
 import { GraphqlService } from './graphql.service';
-import { CREATE_USER_MUTATION } from '../operations/mutation';
+import { AUTHENTICATE_USER_MUTATION, CREATE_USER_MUTATION } from '../operations/mutation';
 
 export interface CreateUserInput {
   email: string;
-  nombre: string;
-  apepaterno: string;
+  nombre?: string | null;
+  apepaterno?: string | null;
   apematerno?: string | null;
   rol: 'COORDINADOR_FEDERAL' | 'COORDINADOR_ESTATAL' | 'RESPONSABLE_CCT' | 'CONSULTA';
   clavesCCT: string[];
@@ -24,8 +24,23 @@ export interface UsuarioCreado {
   rol: string;
 }
 
+export interface UsuarioAutenticado {
+  id: string;
+  email: string;
+  rol: string;
+  centrosTrabajo: Array<{ claveCCT: string }>;
+}
+
 interface CreateUserResponse {
   createUser: UsuarioCreado;
+}
+
+interface AuthenticateUserResponse {
+  authenticateUser: {
+    ok: boolean;
+    message?: string | null;
+    user?: UsuarioAutenticado | null;
+  };
 }
 
 @Injectable({ providedIn: 'root' })
@@ -44,6 +59,23 @@ export class UsuariosService {
             throw new Error('No se recibió respuesta al crear el usuario.');
           }
           return response.data.createUser;
+        })
+      );
+  }
+
+  autenticarUsuario(email: string, password: string): Observable<UsuarioAutenticado> {
+    return this.graphqlService
+      .execute<AuthenticateUserResponse>(AUTHENTICATE_USER_MUTATION, { input: { email, password } })
+      .pipe(
+        map((response) => {
+          if (response.errors?.length) {
+            throw new Error(response.errors[0].message ?? 'No se pudo autenticar el usuario.');
+          }
+          const resultado = response.data?.authenticateUser;
+          if (!resultado?.ok || !resultado.user) {
+            throw new Error(resultado?.message ?? 'Credenciales inválidas.');
+          }
+          return resultado.user;
         })
       );
   }


### PR DESCRIPTION
### Motivation
- Alinear la documentación con el comportamiento implementado: las credenciales se crean al cargar la primera validación exitosa y el login usa correo + contraseña aleatoria asignada en esa primera carga. 
- Proveer soporte en el backend y frontend para autenticación real, asociación de usuario a CCTs y registro seguro de contraseñas.

### Description
- Backend: se añadió la mutation `authenticateUser` y el tipo `AuthPayload`, `createUser` acepta ahora `clavesCCT` y campos de nombre opcionales, las contraseñas se almacenan con salt+hash, se asocian usuarios a `usuarios_centros_trabajo` y se mapea `updated_at` como `fechaUltimoAcceso` en consultas de usuario (`graphql-server/src/schema/*`).
- Frontend: se añadió la mutation `AUTHENTICATE_USER_MUTATION`, `UsuariosService.autenticarUsuario`, lógica en `LoginComponent` para autenticar vía GraphQL y registrar credenciales locales si procede, y se implementó `registrarUsuarioYCredenciales` en `CargaMasivaComponent` para crear usuario/credenciales al guardar el primer archivo validado (`web/frontend/src/app/**`).
- Servicios y utilidades: `AuthService` ahora acepta una contraseña personalizada en `registrarCredenciales`, añade `generarContrasenaTemporal` e `iniciarSesionSinCredenciales`, y `GraphqlService` resuelve dinámicamente el endpoint con `resolverEndpoint()`.
- Documentación: se actualizaron múltiples documentos bajo `web/doc/` (manual de usuario, SRS, visión, arquitectura, casos de uso, plan de iteraciones, riesgos, glosario) para reflejar que el usuario es el correo y la contraseña es aleatoria generada al cargar la primera validación exitosa.

### Testing
- No se ejecutaron pruebas automatizadas sobre estos cambios (no se corrieron `ng test`, Jest, E2E ni tests de integración) y no se añadieron suites de prueba en este PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa577ca1483208d3f0e3c3b944f88)