### PR TITLE
Actualizar unicidad de CCT por turno en documentación

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -1865,7 +1865,7 @@ INSERT INTO EVALUACIONES (
 
 ### Integridad de datos
 
-- No puede haber dos escuelas con el mismo CCT.
+- No puede haber dos escuelas con el mismo CCT + turno.
 - El CURP de cada estudiante debe ser único.
 - Un usuario solo puede estar activo en una escuela a la vez.
 - Los valores de valoración deben estar en el rango 0-3.
@@ -2043,7 +2043,7 @@ INSERT INTO EVALUACIONES (
 
 ### Índices únicos
 
-- `UNIQUE INDEX idx_escuelas_cct ON ESCUELAS(cct)`
+- `UNIQUE INDEX idx_escuelas_cct ON ESCUELAS(cct, id_turno)`
 - `UNIQUE INDEX idx_estudiantes_curp ON ESTUDIANTES(curp)`
 - `UNIQUE INDEX idx_usuarios_email ON USUARIOS(email)`
 - `UNIQUE INDEX idx_cat_turnos_codigo ON CAT_TURNOS(codigo)`

--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -165,11 +165,11 @@
 
 ### RF-13: Catálogo de Escuelas ✨ FASE 1
 - **RF-13.1** El sistema debe permitir CRUD de escuelas:
-  - Crear nueva escuela con CCT único
+  - Crear nueva escuela con CCT + turno únicos
   - Editar datos de contacto
   - Desactivar (no eliminar físicamente)
   - Listar con filtros y paginación
-- **RF-13.2** El sistema debe validar unicidad de CCT a nivel nacional
+- **RF-13.2** El sistema debe validar unicidad de CCT + turno a nivel nacional
 - **RF-13.3** El sistema debe asignar nivel educativo (enum)
 - **RF-13.4** El sistema debe mantener histórico de cambios (auditoría)
 - **RF-13.5** El sistema debe permitir búsqueda por CCT, nombre o ubicación
@@ -791,10 +791,10 @@ graph TB
 2. Administrador selecciona "Nueva Escuela"
 3. Sistema muestra formulario:
    ```
-   CCT: [__________] (requerido, único, 11 caracteres)
+   CCT: [__________] (requerido, 11 caracteres)
    Nombre: [_____________________] (requerido)
    Nivel Educativo: [Dropdown: Preescolar/Primaria/Secundaria/Telesecundaria]
-   Turno: [Dropdown: Matutino/Vespertino/Tiempo Completo]
+   Turno: [Dropdown: Matutino/Vespertino/Tiempo Completo] (requerido, único con CCT)
    
    Datos de Contacto:
    Dirección: [______________________]
@@ -807,7 +807,7 @@ graph TB
    Director Actual: [___________]
    ```
 4. Sistema valida en tiempo real:
-   - CCT único (consulta a BD)
+   - CCT + turno únicos (consulta a BD)
    - Formato de email válido
    - Teléfono 10 dígitos
 5. Administrador guarda escuela


### PR DESCRIPTION
### Motivation
- Alinear la documentación con la regla de negocio que exige unicidad por la combinación CCT + turno, para que índices, validaciones y la UI reflejen el modelo de datos correcto.

### Description
- Se actualizaron los documentos `ESTRUCTURA_DE_DATOS.md` y `REQUERIMIENTOS_Y_CASOS_DE_USO.md` para sustituir la regla de unicidad por "CCT" por "CCT + turno", cambiar la entrada de índices únicos a `UNIQUE INDEX idx_escuelas_cct ON ESCUELAS(cct, id_turno)` y ajustar RF-13 y el formulario de alta de escuelas para indicar y validar "CCT + turno".

### Testing
- No se ejecutaron pruebas automatizadas porque es un cambio únicamente en documentación (docs-only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d4d57a8c8330b2fa9f68992f61e7)