### PR TITLE
Permitir usuario activo en múltiples escuelas y alinear RF-14.2

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -1867,7 +1867,7 @@ INSERT INTO EVALUACIONES (
 
 - No puede haber dos escuelas con el mismo CCT + turno.
 - El CURP de cada estudiante debe ser único.
-- Un usuario solo puede estar activo en una escuela a la vez.
+- Un usuario puede estar activo en múltiples escuelas según su asignación en USUARIO_CCT.
 - Los valores de valoración deben estar en el rango 0-3.
 - Los periodos deben estar correctamente definidos y no solaparse.
 

--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -176,7 +176,7 @@
 
 ### RF-14: Gestión de Usuarios ✨ FASE 1
 - **RF-14.1** El sistema debe permitir CRUD de usuarios directores y supervisores
-- **RF-14.2** El sistema debe vincular usuario ↔ CCT mediante relación **1:N** (un usuario puede gestionar múltiples CCT: supervisor de zona, director con varios planteles)
+- **RF-14.2** El sistema debe vincular usuario ↔ CCT mediante relación **1:N** (un usuario puede estar activo y gestionar múltiples CCT según su asignación)
 - **RF-14.3** El sistema debe implementar tabla intermedia USUARIO_CCT para gestión granular de permisos por plantel
 - **RF-14.4** El sistema debe soportar roles:
   - Director: Acceso a su(s) escuela(s) asignadas


### PR DESCRIPTION
### Motivation
- Ajustar la regla de integridad para reflejar la relación 1:N entre usuarios y CCT y garantizar consistencia entre la documentación de datos y los requisitos RF-14.2/RF-14.3.

### Description
- Se actualizó `ESTRUCTURA_DE_DATOS.md` reemplazando la regla "Un usuario solo puede estar activo en una escuela a la vez" por "Un usuario puede estar activo en múltiples escuelas según su asignación en USUARIO_CCT", y se modificó el texto de `RF-14.2` en `REQUERIMIENTOS_Y_CASOS_DE_USO.md` para indicar que un usuario puede estar activo y gestionar múltiples CCT según su asignación.

### Testing
- No se ejecutaron pruebas automatizadas porque el cambio es únicamente de documentación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d5c1070083308f59e6dda8d0ae08)