### PR TITLE
Aclarar clasificación de periodos al cierre de ciclo

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -1870,6 +1870,7 @@ INSERT INTO EVALUACIONES (
 - Un usuario solo puede estar activo en una escuela a la vez.
 - Los valores de valoración deben estar en el rango 0-3.
 - Los periodos deben estar correctamente definidos y no solaparse.
+  - Si la primera aplicación ocurre al cierre de ciclo, se debe clasificar como segunda aplicación para efectos de periodización.
 
 ### Control de acceso
 

--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -103,6 +103,7 @@
   - Periodo 1: Diagnóstico inicial (septiembre)
   - Periodo 2: Evaluación intermedia
   - Periodo 3: Evaluación final
+  - Nota: si la primera aplicación ocurre al cierre de ciclo, debe tratarse como segunda aplicación para efectos de clasificación.
 - **RF-08.2** El sistema debe identificar periodo en reportes
 
 ### RF-09: Autenticación y Autorización ✨ FASE 1


### PR DESCRIPTION
### Motivation
- Clarificar la regla de periodos para que una primera aplicación que ocurra al cierre de ciclo se trate como segunda aplicación y mantener coherencia entre la especificación de integridad de datos y RF-08.

### Description
- Se agregó una subregla en `ESTRUCTURA_DE_DATOS.md` y una nota en RF-08 dentro de `REQUERIMIENTOS_Y_CASOS_DE_USO.md` indicando que la primera aplicación al cierre de ciclo debe clasificarse como segunda aplicación.

### Testing
- Cambio documental; no se ejecutaron pruebas automáticas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d623a97883308ef391b2d2de3ae8)