### PR TITLE
Actualizar reglas de credenciales EIA2: permitir múltiples credenciales por CCT y login por correo

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -1998,9 +1998,9 @@ INSERT INTO EVALUACIONES (
 ### Plataforma EIA 2ª Aplicación (CREDENCIALES_EIA2)
 
 - Las credenciales se generan **únicamente en la primera carga válida** de cada CCT.
-- El campo `cct` debe ser UNIQUE - un CCT solo puede tener un registro de credenciales.
-- El usuario para login es el CCT validado en el archivo.
-- La contraseña es el correo electrónico validado, almacenado como hash seguro (bcrypt con salt rounds ≥12 o argon2id).
+- El campo `cct` **NO** es UNIQUE - un CCT puede tener múltiples registros de credenciales.
+- El usuario para login es el correo electrónico validado.
+- La contraseña es aleatoria o se apega al esquema vigente de seguridad, almacenada como hash seguro (bcrypt con salt rounds ≥12 o argon2id).
 - Las credenciales **NO se regeneran** en cargas posteriores, incluso si el correo cambia.
 - Si se requiere cambio de contraseña, debe implementarse un flujo de recuperación separado.
 - El campo `primera_carga_valida_fecha` es inmutable y sirve como auditoría.
@@ -2020,7 +2020,7 @@ INSERT INTO EVALUACIONES (
 - El campo `resultado_path` contiene la liga de descarga generada por el sistema externo.
 - El campo `resultado_disponible_desde` se calcula como `fecha_carga + 4 días` según requerimiento.
 - Las solicitudes se conservan indefinidamente para auditoría y trazabilidad completa.
-- La relación `credencial_id` permite consultar todas las solicitudes de un CCT.
+- La relación `credencial_id` permite consultar todas las solicitudes asociadas al correo/usuario validado.
 
 ### Reportes Generados (REPORTES_GENERADOS)
 
@@ -2049,7 +2049,7 @@ INSERT INTO EVALUACIONES (
 - `UNIQUE INDEX idx_cat_turnos_codigo ON CAT_TURNOS(codigo)`
 - `UNIQUE INDEX idx_cat_niveles_codigo ON CAT_NIVELES_EDUCATIVOS(codigo)`
 - `UNIQUE INDEX idx_cat_roles_codigo ON CAT_ROLES_USUARIO(codigo)`
-- `UNIQUE INDEX idx_credenciales_eia2_cct ON CREDENCIALES_EIA2(cct)`
+- `UNIQUE INDEX idx_credenciales_eia2_correo ON CREDENCIALES_EIA2(correo_validado)`
 - `UNIQUE INDEX idx_solicitudes_eia2_consecutivo ON SOLICITUDES_EIA2(consecutivo)`
 - `UNIQUE INDEX idx_grupos_escuela_nombre ON GRUPOS(escuela_id, nombre)`
 - `UNIQUE INDEX idx_materias_codigo ON MATERIAS(codigo)`


### PR DESCRIPTION
### Motivation
- Ajustar la especificación de credenciales de la Plataforma EIA 2ª Aplicación para reflejar que un mismo `cct` puede tener múltiples cuentas y que el login se realiza por correo validado. 
- Corregir la relación entre solicitudes y credenciales para que las consultas se asocien al `correo_validado`/usuario en lugar exclusivamente al `cct`.

### Description
- Actualiza `ESTRUCTURA_DE_DATOS.md` (sección `Plataforma EIA 2ª Aplicación (CREDENCIALES_EIA2)`) para indicar que el campo `cct` **NO** es `UNIQUE` y que un CCT puede tener múltiples registros de credenciales. 
- Cambia la regla de login para que el `usuario` sea el `correo_email` validado y que la `password` sea una cadena aleatoria o se ajuste al esquema vigente, almacenada como hash seguro (`bcrypt` ≥12 o `argon2id`).
- Modifica la sección `Solicitudes EIA 2ª Aplicación` para que la relación `credencial_id` permita consultar solicitudes asociadas al `correo/usuario` validado y actualiza el índice único de credenciales de `CREDENCIALES_EIA2` pasando de `idx_credenciales_eia2_cct` a `idx_credenciales_eia2_correo` (`correo_validado`).

### Testing
- No se ejecutaron pruebas automatizadas porque el cambio es solo en la documentación (`ESTRUCTURA_DE_DATOS.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d73db4708330857ab1a54a97a9f7)