### PR TITLE
Aclarar desbloqueo y nullable en INTENTOS_LOGIN

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -393,7 +393,7 @@ especializada `NIVELES_INTEGRACION_ESTUDIANTE` con granularidad por Campo Format
 | Campo           | Tipo         | Descripción                                      |
 |-----------------|--------------|--------------------------------------------------|
 | id              | UUID         | Identificador único                              |
-| usuario_id      | UUID         | Relación con USUARIOS (NULL si no existe)        |
+| usuario_id      | UUID         | Relación con USUARIOS (nullable; NULL si no existe) |
 | email           | VARCHAR(100) | Email del intento de login                       |
 | ip_address      | INET         | Dirección IP de origen                           |
 | user_agent      | TEXT         | Navegador/cliente usado                          |
@@ -1909,12 +1909,13 @@ INSERT INTO EVALUACIONES (
 - Después de **5 intentos fallidos consecutivos** en 15 minutos, bloquear la cuenta por 30 minutos (RF-09.7).
 - Después de **10 intentos fallidos** en 1 hora desde diferentes IPs, bloquear cuenta y alertar administrador (posible ataque distribuido).
 - El campo `usuario_id` puede ser NULL si el email no existe en el sistema (registrar intentos con usuarios inválidos).
+- La tabla `INTENTOS_LOGIN` tiene PK propia (`id`); `usuario_id` es FK **nullable** y no participa en PK/UNIQUE.
 - El campo `email` siempre debe registrarse para trazabilidad, incluso si el usuario no existe.
 - Los intentos exitosos (`exito = TRUE`) deben registrar siempre usuario_id válido.
 - El campo `motivo_fallo` debe ser uno de: 'USUARIO_INVALIDO', 'PASSWORD_INCORRECTO', 'CUENTA_BLOQUEADA', 'CUENTA_INACTIVA', 'CUENTA_ELIMINADA', 'PASSWORD_EXPIRADO'.
 - El bloqueo automático debe registrarse en `bloqueado_hasta` con timestamp 30 minutos futuro.
-- Un usuario bloqueado no puede intentar login hasta que `bloqueado_hasta < NOW()`.
-- Los administradores pueden desbloquear manualmente una cuenta antes del tiempo establecido.
+- Un usuario bloqueado no puede intentar login hasta que `bloqueado_hasta < NOW()` o sea desbloqueado manualmente.
+- El desbloqueo puede ser **por tiempo** (expiración de `bloqueado_hasta`) o **manual**; si hay desbloqueo manual, **tiene prioridad** y debe limpiar `bloqueado_hasta` (NULL) inmediatamente.
 - Se debe enviar notificación email al usuario cuando su cuenta es bloqueada por intentos fallidos.
 - Los intentos desde IP sospechosas (múltiples cuentas fallidas) deben bloquearse temporalmente a nivel de firewall.
 - El campo `user_agent` debe registrarse para detectar patrones de bots/scripts.


### PR DESCRIPTION
### Motivation
- Aclarar reglas de bloqueo y la relación de la columna `usuario_id` en la tabla `INTENTOS_LOGIN` para evitar ambigüedades en el modelado de datos y en la implementación de seguridad de autenticación.

### Description
- Actualizar `ESTRUCTURA_DE_DATOS.md` para marcar `usuario_id` como `nullable` en la definición de campos de `INTENTOS_LOGIN` y explicar que puede ser NULL cuando el email no existe.
- Añadir la aclaración de que la tabla `INTENTOS_LOGIN` tiene PK propia (`id`) y que `usuario_id` es una FK nullable que no participa en PK/UNIQUE.
- Especificar que el desbloqueo puede ser por tiempo (`bloqueado_hasta`) o manual, y que el desbloqueo manual tiene prioridad y debe limpiar `bloqueado_hasta` (NULL) inmediatamente.
- Cambios aplicados en el archivo `ESTRUCTURA_DE_DATOS.md`.

### Testing
- Not run (documentación): este cambio es puramente de documentación y no se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d774488c833080df4d537e651c23)