### PR TITLE
Fix integration level names and add weighted consigna rule in ESTRUCTURA_DE_DATOS.md

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -1985,9 +1985,10 @@ INSERT INTO EVALUACIONES (
 
 - Las valoraciones deben estar en el rango **0-3** (validación estricta mediante CHECK constraint).
 - Cada estudiante debe tener **una evaluación por materia por periodo** (constraint UNIQUE en combinación estudiante_id, materia_id, periodo_id).
-- El campo `nivel_integracion` se calcula automáticamente por el sistema basado en la valoración y competencias.
-- Los niveles de integración son: 'EN DESARROLLO', 'SATISFACTORIO', 'SOBRESALIENTE', 'AVANZADO'.
-- El campo `competencia_alcanzada` se determina comparando valoración vs nivel esperado en COMPETENCIAS.
+- El campo `nivel_integracion` se calcula automáticamente por el sistema por cada combinación estudiante-asignatura, con base en la valoración y competencias.
+- Los niveles de integración son: "sin evidencia de aprendizaje", "requiere apoyo para el aprendizaje", "en proceso de desarrollo" y "aprendizaje desarrollado".
+- Cada reactivo tiene una valoración de 0 a 3 y un peso por consigna; la suma ponderada de consignas por campo formativo (suma de consignas × PESO del campo) determina el `nivel_integracion` conforme a las reglas vigentes.
+- El campo `competencia_alcanzada` se determina comparando la valoración contra los criterios de logro definidos en COMPETENCIAS; si no existe un "nivel esperado", se usa el criterio de logro vigente para la competencia evaluada.
 - Las evaluaciones importadas desde ARCHIVOS_FRV deben mantener referencia al archivo origen (campo `archivo_frv_id`).
 - Solo evaluaciones con `validado = TRUE` se consideran para generación de reportes oficiales.
 - La validación debe ser realizada por usuarios con rol 'VALIDADOR' o 'OPERADOR'.


### PR DESCRIPTION
### Motivation
- Correct previously incorrect, hard-coded integration level names and document that `nivel_integracion` is computed per estudiante-asignatura using weighted reactivo scores.
- Clarify `competencia_alcanzada` behavior when no `nivel esperado` exists by stating it falls back to the competency's `criterios de logro`.

### Description
- Replaced the static integration-level list with the correct four levels: "sin evidencia de aprendizaje", "requiere apoyo para el aprendizaje", "en proceso de desarrollo" and "aprendizaje desarrollado".
- Added that each `reactivo` has a `valoración` in the range `0-3` and a `peso` per consigna, and that the weighted sum (suma de consignas × `PESO` del campo) for a `campo formativo` determines the `nivel_integracion` according to the applicable rules.
- Made explicit that `nivel_integracion` is computed per `estudiante`-`asignatura` combination and that `competencia_alcanzada` compares the valoración against the `criterios de logro` when no `nivel esperado` is defined.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d89f1e5c8330afa55646fbf1d472)