### PR TITLE
Actualizar volumetría de reportes: regla por grupo

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -2025,7 +2025,7 @@ INSERT INTO EVALUACIONES (
 ### Reportes Generados (REPORTES_GENERADOS)
 
 - Se generan **5 tipos de reportes** por escuela según RF-05: ENS, HYC, LEN, SPC (reportes por campo formativo) y F5 (reporte por grupo).
-- **Volumenétrica esperada**: Preescolar (5 reportes/escuela), Primaria (30 reportes/escuela), Secundaria (15 reportes/escuela).
+- **Volumenétrica esperada (regla actual)**: por cada grupo se genera **1 reporte de resultados (F5)** y, **si aplica**, **1 reporte comparativo adicional**. Los reportes por campo formativo (ENS, HYC, LEN, SPC) se generan a nivel escuela.
 - La nomenclatura de archivos debe seguir estándar: `[CCT].[PERIODO].Reporte_[TIPO]_[CAMPO][FORMATO].[GRADO]°.[GRUPO].pdf`
 - El campo `checksum_sha256` es obligatorio para verificar integridad del archivo descargado.
 - Los reportes deben estar **disponibles por 2 ciclos escolares** (campo `disponible_hasta`).

--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -73,10 +73,10 @@
   - Reporte SPC (Saberes) - 670 KB aprox
 - **RF-05.2** El sistema debe generar reportes individuales por grupo:
   - Formato F5 - 2.71 MB aprox por grupo
-- **RF-05.3** El sistema debe generar reportes según volumetría:
-  - Preescolar: 5 reportes/escuela
-  - Primaria: 30 reportes/escuela
-  - Secundaria: 15 reportes/escuela
+- **RF-05.3** El sistema debe generar reportes según volumetría por grupo:
+  - Por cada grupo se genera 1 reporte de resultados (F5).
+  - Si aplica comparativo, se genera 1 reporte comparativo adicional por grupo.
+  - Los reportes por campo formativo (ENS, HYC, LEN, SPC) se generan a nivel escuela.
 - **RF-05.4** El sistema debe generar reportes en formato PDF
 - **RF-05.5** El sistema debe aplicar nomenclatura estándar:
   ```


### PR DESCRIPTION
### Motivation
- Aclarar la regla de generación de reportes reemplazando la volumetría fija por escuela por la regla actual que cuenta reportes por grupo y diferencia resultados/comparativos mientras mantiene los reportes por campo formativo a nivel escuela.

### Description
- Actualiza `ESTRUCTURA_DE_DATOS.md` en la sección "Reportes Generados (REPORTES_GENERADOS)" para describir la regla: por cada grupo se genera `1` reporte de resultados (F5) y, si aplica, `1` reporte comparativo adicional, y los reportes ENS/HYC/LEN/SPC se generan a nivel escuela.
- Modifica `REQUERIMIENTOS_Y_CASOS_DE_USO.md` en `RF-05.3` para reflejar la volumetría por grupo y el alcance de los reportes por campo formativo.

### Testing
- No se ejecutaron pruebas automatizadas porque el cambio es únicamente documental.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d8a55d6c8330b00128c14790f790)