### PR TITLE
Actualizar mensajes de email en `API_SPECIFICATION.md` para reflejar entrega por plataforma/PDF

### DIFF
--- a/API_SPECIFICATION.md
+++ b/API_SPECIFICATION.md
@@ -122,7 +122,7 @@ X-Request-ID: {uuid}
     "password_temporal": "Temp2024!xY7",
     "expira_en": "2026-01-19T12:00:00Z"
   },
-  "message": "Usuario creado. Se envió email con credenciales temporales."
+  "message": "Usuario creado. Credenciales temporales generadas y mostradas/descargadas en PDF."
 }
 ```
 
@@ -187,7 +187,7 @@ X-Request-ID: {uuid}
 ```json
 {
   "success": true,
-  "message": "Se envió un email con instrucciones para restablecer la contraseña",
+  "message": "Solicitud de restablecimiento registrada. El token se muestra en la plataforma.",
   "expira_en": "2026-01-12T14:30:00Z"
 }
 ```
@@ -196,7 +196,7 @@ X-Request-ID: {uuid}
 
 ### 6. POST /api/auth/reset-password
 
-**Descripción:** Restablecer contraseña con token enviado por email.
+**Descripción:** Restablecer contraseña con token generado en la plataforma (sin envío de email).
 
 **Request:**
 
@@ -855,7 +855,7 @@ Content-Disposition: attachment; filename="Reporte_09DPR1234A_2024.pdf"
     "ticket_id": "550e8400-e29b-41d4-a716-446655440400",
     "numero_ticket": "TKT-2026-001234"
   },
-  "message": "Ticket creado.Recibirá respuesta por email."
+  "message": "Ticket creado. La respuesta se dará seguimiento en el portal."
 }
 ```
 


### PR DESCRIPTION
### Motivación
- Alinear la especificación de la API con el flujo real de la plataforma donde no se envían credenciales por email sino que se muestran/descargan en PDF y los tokens se gestionan en la plataforma.
- Evitar menciones erróneas a envíos por correo en mensajes de respuesta y descripciones de endpoints relacionadas con credenciales y restablecimiento.

### Descripción
- Se actualizó `API_SPECIFICATION.md` para que la respuesta de registro indique: "Usuario creado. Credenciales temporales generadas y mostradas/descargadas en PDF.".
- Se cambió la respuesta de `POST /api/auth/forgot-password` a: "Solicitud de restablecimiento registrada. El token se muestra en la plataforma.".
- Se modificó la descripción de `POST /api/auth/reset-password` para indicar que el token es generado/gestionado en la plataforma (sin envío por email).
- Se ajustó el mensaje de creación de tickets para indicar que la respuesta se dará seguimiento en el portal en lugar de prometer respuesta por email.

### Testing
- No se ejecutaron pruebas automatizadas porque el cambio es solo de documentación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d8b6fc548330881c025fa5f1cab6)