### PR TITLE
Validate evaluation period overlaps and add end-of-cycle "first application" exception

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -500,6 +500,12 @@ formativo: ENS, HYC, LEN, SPC) en cada periodo de evaluación.
 | activo          | BOOLEAN      | Indica si el periodo está activo  |
 | created_at      | TIMESTAMP    | Fecha de creación                 |
 
+**Reglas de negocio / validaciones:**
+- No se permiten rangos de fechas traslapados entre periodos del mismo `ciclo_escolar` (incluye límites compartidos).
+- Se permiten periodos contiguos (fin + 1 día = inicio del siguiente).
+- Al editar un periodo, la validación compara contra el resto de registros del mismo ciclo, excluyendo el periodo editado.
+- Excepción operativa: si no existe carga válida de Periodo 1 en el ciclo y se recibe una carga etiquetada como Periodo 1 dentro del rango oficial de Periodo 2 o 3, se reclasifica como Periodo 2 (registrando la reasignación).
+
 ### PLANTILLAS_EMAIL
 
 | Campo                | Tipo         | Descripción                       |

--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -104,6 +104,20 @@
   - Periodo 2: Evaluación intermedia
   - Periodo 3: Evaluación final
 - **RF-08.2** El sistema debe identificar periodo en reportes
+- **RF-08.3** El sistema debe validar solapamientos de periodos por ciclo escolar (reglas de negocio):
+  - **RN-08.3.1** No se permite que dos periodos del mismo **ciclo_escolar** tengan rangos de fechas que se traslapen (incluye límites compartidos: si un periodo termina el 2024-11-15, el siguiente inicia **>= 2024-11-16**).
+  - **RN-08.3.2** Sí se permiten periodos contiguos (fin + 1 día = inicio del siguiente).
+  - **RN-08.3.3** Para cambios de fechas, la validación debe evaluar el rango completo ya almacenado contra todos los periodos del mismo ciclo, excluyendo el registro que se está editando.
+- **RF-08.4** Excepción de “primera aplicación a fin de ciclo que debería ser segunda”:
+  - **RN-08.4.1** Si en un ciclo escolar **no existe carga válida** de Periodo 1 y se recibe una carga etiquetada como Periodo 1 **cuyo rango/fecha de aplicación cae dentro del rango oficial del Periodo 2 o Periodo 3**, el sistema debe **reclasificarla como Periodo 2** para reportes y comparativos.
+  - **RN-08.4.2** La reclasificación solo aplica si **no hay datos previos** asociados a Periodo 1 en ese ciclo; si ya existe Periodo 1, la carga debe rechazarse por conflicto de periodo.
+  - **RN-08.4.3** El sistema debe registrar en bitácora la reasignación (periodo_original=1, periodo_asignado=2, motivo="primera aplicación a fin de ciclo").
+
+**Ejemplos (para evitar ambigüedades):**
+- *Ejemplo A (válido)*: Periodo 1: 2024-09-01 a 2024-10-15; Periodo 2: 2024-10-16 a 2024-12-15 → **No hay solapamiento** (contiguos).
+- *Ejemplo B (inválido)*: Periodo 1: 2024-09-01 a 2024-10-20; Periodo 2: 2024-10-15 a 2024-12-15 → **Solapamiento** (10-15 al 10-20).
+- *Ejemplo C (excepción)*: Ciclo 2024-2025 sin cargas en Periodo 1. Se carga “Periodo 1” con fecha 2025-05-10 que cae dentro del rango oficial del Periodo 2/3 → **Se reclasifica a Periodo 2**.
+- *Ejemplo D (rechazo)*: Ciclo 2024-2025 ya tiene datos de Periodo 1. Se intenta cargar “Periodo 1” con fecha 2025-05-10 → **Rechazo por conflicto de periodo**.
 
 ### RF-09: Autenticación y Autorización ✨ FASE 1
 - **RF-09.1** El sistema web debe autenticar directores con CCT + contraseña


### PR DESCRIPTION
### Motivation
- Prevent ambiguous or conflicting `PERIODOS_EVALUACION` date ranges so reporting and comparatives remain consistent across a `ciclo_escolar`.
- Handle the operational case where a late/first load labeled as Periodo 1 at the end of a cycle should be treated as Periodo 2 to avoid misclassification in reports.

### Description
- Added `RF-08.3` to `REQUERIMIENTOS_Y_CASOS_DE_USO.md` defining overlap validation rules (`RN-08.3.1`–`RN-08.3.3`) that forbid overlapping ranges within the same `ciclo_escolar` and allow contiguous periods.
- Added `RF-08.4` with `RN-08.4.1`–`RN-08.4.3` to document the exception that when no valid Periodo 1 exists for a cycle, an incoming load labeled Periodo 1 that falls inside the official Periodo 2/3 range is reclasified as Periodo 2 and is logged; if Periodo 1 already exists the load is rejected.
- Updated `ESTRUCTURA_DE_DATOS.md` `PERIODOS_EVALUACION` section to include the same business validation notes and the operational exception for reclasification.
- Added concrete examples (`Ejemplo A`–`Ejemplo D`) to clarify valid, invalid, exception, and rejection scenarios.

### Testing
- No automated tests were executed because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852d4a51308330b5dd499cfaef449f)