### PR TITLE
Actualizar unicidad de GRUPOS a `escuela_id + grado_id + nombre`

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -1899,7 +1899,7 @@ INSERT INTO EVALUACIONES (
 - Todo usuario debe tener un rol asignado.
 - El campo `escuela_id` en GRUPOS es FK obligatorio a ESCUELAS.id.
 - El campo `grado_id` en GRUPOS es FK obligatorio a CAT_GRADOS.id.
-- No puede haber dos grupos con el mismo nombre en la misma escuela (UNIQUE en escuela_id + nombre).
+- No puede haber dos grupos con el mismo nombre dentro del mismo grado y escuela (UNIQUE en escuela_id + grado_id + nombre).
 - El campo `total_alumnos` debe actualizarse automáticamente al agregar/eliminar estudiantes.
 - Los grupos inactivos (`activo = FALSE`) no permiten asignación de nuevos estudiantes.
 
@@ -2052,7 +2052,7 @@ INSERT INTO EVALUACIONES (
 - `UNIQUE INDEX idx_cat_roles_codigo ON CAT_ROLES_USUARIO(codigo)`
 - `UNIQUE INDEX idx_credenciales_eia2_correo ON CREDENCIALES_EIA2(correo_validado)`
 - `UNIQUE INDEX idx_solicitudes_eia2_consecutivo ON SOLICITUDES_EIA2(consecutivo)`
-- `UNIQUE INDEX idx_grupos_escuela_nombre ON GRUPOS(escuela_id, nombre)`
+- `UNIQUE INDEX idx_grupos_escuela_grado_nombre ON GRUPOS(escuela_id, grado_id, nombre)`
 - `UNIQUE INDEX idx_materias_codigo ON MATERIAS(codigo)`
 
 ### Índices compuestos
@@ -5173,9 +5173,9 @@ ALTER TABLE GRUPOS ADD COLUMN IF NOT EXISTS activo BOOLEAN DEFAULT TRUE;
 ALTER TABLE GRUPOS ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT NOW();
 ALTER TABLE GRUPOS ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT NOW();
 
--- Paso 8: Agregar constraint UNIQUE en escuela_id + nombre
-ALTER TABLE GRUPOS ADD CONSTRAINT uq_grupos_escuela_nombre 
-    UNIQUE (escuela_id, nombre);
+-- Paso 8: Agregar constraint UNIQUE en escuela_id + grado_id + nombre
+ALTER TABLE GRUPOS ADD CONSTRAINT uq_grupos_escuela_grado_nombre 
+    UNIQUE (escuela_id, grado_id, nombre);
 
 -- Paso 9: Agregar índices
 CREATE INDEX idx_grupos_escuela_grado ON GRUPOS(escuela_id, grado_id);
@@ -5310,12 +5310,12 @@ BEGIN
     
     -- 5. Verificar constraints UNIQUE
     IF EXISTS (
-        SELECT escuela_id, nombre, COUNT(*)
+        SELECT escuela_id, grado_id, nombre, COUNT(*)
         FROM GRUPOS
-        GROUP BY escuela_id, nombre
+        GROUP BY escuela_id, grado_id, nombre
         HAVING COUNT(*) > 1
     ) THEN
-        v_errors := v_errors || 'ERROR: GRUPOS tiene duplicados en escuela_id + nombre' || E'\n';
+        v_errors := v_errors || 'ERROR: GRUPOS tiene duplicados en escuela_id + grado_id + nombre' || E'\n';
     END IF;
     
     IF LENGTH(v_errors) > 0 THEN

--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -37,6 +37,7 @@
 - **RF-02.4** El sistema debe validar formato de CURP
 - **RF-02.5** El sistema debe asignar estudiantes a grupos específicos
 - **RF-02.6** El sistema debe registrar datos del docente por grupo
+- **RF-02.7** El sistema debe validar unicidad de grupo por escuela, grado y nombre
 
 ### RF-03: Captura de Valoraciones
 - **RF-03.1** El sistema debe importar datos desde archivos Excel FRV


### PR DESCRIPTION
### Motivation
- Alinear las reglas de integridad y requerimientos para que la unicidad de grupos se aplique por combinación `escuela_id + grado_id + nombre` (evita conflictos de nombres iguales en distintos grados dentro de la misma escuela). 

### Description
- Se actualizó `ESTRUCTURA_DE_DATOS.md` reemplazando la regla y el índice único por `UNIQUE (escuela_id, grado_id, nombre)`, renombrando el índice/constraint a `idx_grupos_escuela_grado_nombre` / `uq_grupos_escuela_grado_nombre` y ajustando las consultas y scripts de migración/verificación que referencian la combinación antigua. 
- Se añadió `RF-02.7` en `REQUERIMIENTOS_Y_CASOS_DE_USO.md` para exigir la validación de unicidad de grupo por escuela, grado y nombre. 

### Testing
- No se ejecutaron pruebas automáticas porque los cambios son únicamente documentales y de migración (docs-only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852d5cfe64833080aa292a5199cdb0)