### PR TITLE
Aclarar flujo de desbloqueo y manejo de intentos con usuario NULL

### DIFF
--- a/ESTRUCTURA_DE_DATOS.md
+++ b/ESTRUCTURA_DE_DATOS.md
@@ -403,6 +403,13 @@ especializada `NIVELES_INTEGRACION_ESTUDIANTE` con granularidad por Campo Format
 | metadata        | JSONB        | Datos adicionales (dispositivo, ubicación, etc.) |
 | created_at      | TIMESTAMP    | Fecha/hora del intento                           |
 
+**Integridad y relación con USUARIOS**
+
+- `usuario_id` es nullable para preservar intentos con credenciales inválidas (email inexistente o usuario eliminado).
+- Cuando `usuario_id` es NULL, la integridad se conserva mediante los campos `email`, `ip_address`, `user_agent` y `created_at` (auditoría), sin violar PK/unique de otros módulos.
+- Cuando el usuario existe, `usuario_id` **debe** corresponder a `USUARIOS.id` (PK/unique) y el `email` del intento debe coincidir con `USUARIOS.email` para trazabilidad.
+- Los intentos con `usuario_id` NULL no generan relaciones en cascada ni afectan restricciones UNIQUE de usuarios; se consultan por `email`/IP para análisis de seguridad.
+
 ### LOG_ACTIVIDADES
 
 **Consolidado** - Incluye funcionalidad de BITACORA_DETALLADA eliminada
@@ -1913,8 +1920,10 @@ INSERT INTO EVALUACIONES (
 - Los intentos exitosos (`exito = TRUE`) deben registrar siempre usuario_id válido.
 - El campo `motivo_fallo` debe ser uno de: 'USUARIO_INVALIDO', 'PASSWORD_INCORRECTO', 'CUENTA_BLOQUEADA', 'CUENTA_INACTIVA', 'CUENTA_ELIMINADA', 'PASSWORD_EXPIRADO'.
 - El bloqueo automático debe registrarse en `bloqueado_hasta` con timestamp 30 minutos futuro.
-- Un usuario bloqueado no puede intentar login hasta que `bloqueado_hasta < NOW()`.
-- Los administradores pueden desbloquear manualmente una cuenta antes del tiempo establecido.
+- Un usuario bloqueado no puede intentar login hasta que `bloqueado_hasta < NOW()` **o** un administrador restablezca el bloqueo.
+- **Desbloqueo automático**: al cumplirse el tiempo (`bloqueado_hasta < NOW()`), la cuenta queda habilitada sin intervención adicional.
+- **Desbloqueo administrativo**: un administrador puede poner `bloqueado_hasta = NULL` antes del tiempo, registrar la acción en LOG_ACTIVIDADES y opcionalmente resetear el contador de fallos.
+- Flujo exacto: (1) detectar umbral de fallos, (2) setear `bloqueado_hasta` y registrar intento, (3) rechazar login mientras `bloqueado_hasta` vigente, (4) permitir login al expirar o al desbloqueo admin, (5) al primer login exitoso posterior, resetear contador de fallos.
 - Se debe enviar notificación email al usuario cuando su cuenta es bloqueada por intentos fallidos.
 - Los intentos desde IP sospechosas (múltiples cuentas fallidas) deben bloquearse temporalmente a nivel de firewall.
 - El campo `user_agent` debe registrarse para detectar patrones de bots/scripts.


### PR DESCRIPTION
### Motivation

- Aclarar reglas de integridad y trazabilidad para registros en `INTENTOS_LOGIN` cuando `usuario_id` es NULL. 
- Especificar comportamiento de desbloqueo (automático vs. administrativo) y el flujo exacto de bloqueo/desbloqueo para seguridad de autenticación.

### Description

- Añadida la sección “Integridad y relación con USUARIOS” en `INTENTOS_LOGIN` que explica por qué `usuario_id` es nullable y cómo conservar trazabilidad mediante `email`, `ip_address`, `user_agent` y `created_at`.
- Establecido que cuando existe el usuario, `usuario_id` debe corresponder a `USUARIOS.id` y el `email` del intento debe coincidir para asegurar trazabilidad.
- Clarificado que el desbloqueo puede ocurrir automáticamente al expirar `bloqueado_hasta` o manualmente por un administrador que pone `bloqueado_hasta = NULL`, y que la acción administrativa debe registrarse en `LOG_ACTIVIDADES` y opcionalmente resetear contadores.
- Descrito el flujo exacto de bloqueo/desbloqueo: detectar umbral, setear `bloqueado_hasta` y registrar intento, rechazar logins mientras esté vigente, permitir login al expirar o tras desbloqueo admin, y resetear contador al primer login exitoso.

### Testing

- Cambio únicamente en documentación, no se ejecutaron pruebas automatizadas porque no hay código afectado. 
- No aplica a suites de integración o unitarias; revisión manual del archivo `ESTRUCTURA_DE_DATOS.md` realizada para verificar consistencia del texto.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852d652af483309e15f1fcde4cb03c)