### PR TITLE
Consolidar variantes FRV y ajustar escala de valoración (RF-03.2, RF-03.4)

### DIFF
--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -40,17 +40,16 @@
 
 ### RF-03: Captura de Valoraciones
 - **RF-03.1** El sistema debe importar datos desde archivos Excel FRV
-- **RF-03.2** El sistema debe soportar 4 variantes de FRV:
+- **RF-03.2** El sistema debe soportar 3 variantes de FRV por nivel educativo:
   - Preescolar (52 KB)
   - Primaria (228 KB)
-  - Secundarias Técnicas (87 KB)
-  - Telesecundarias (88 KB)
+  - Secundaria (incluye formatos técnicos y telesecundarias, 87-88 KB)
 - **RF-03.3** El sistema debe capturar valoraciones por campo formativo:
   - ENS (Enseñanza: Español y Matemáticas)
   - HYC (Historia y Civismo)
   - LEN (Lenguaje y Comunicación)
   - SPC (Saberes y Pensamiento Científico)
-- **RF-03.4** El sistema debe validar rangos de valoración (escala 1-4)
+- **RF-03.4** El sistema debe validar rangos de valoración (escala 0-3)
 - **RF-03.5** El sistema debe permitir captura de observaciones por estudiante
 
 ### RF-04: Procesamiento y Validación (DGADAE)


### PR DESCRIPTION
### Motivation
- Alinear la especificación de captura de FRV con las reglas de validación de la plataforma, eliminando la separación logística de secundaria como una variante distinta y sincronizando la escala de valoración con la validación (0–3). 

### Description
- Se actualizó `REQUERIMIENTOS_Y_CASOS_DE_USO.md` para consolidar RF-03.2 en 3 variantes por nivel (Preescolar, Primaria, Secundaria —incluye técnicos y telesecundarias—) y para cambiar RF-03.4 a la escala de valoración `0-3`, de modo que quede consistente con `plataforma_recepcion_validacion_descarga_EIA.md`.

### Testing
- Cambio de documentación únicamente; no se ejecutaron pruebas automatizadas porque es una corrección de especificación en `REQUERIMIENTOS_Y_CASOS_DE_USO.md` y el commit fue aplicado exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852d8213fc83308d449339e08d0603)