### PR TITLE
Unify EIA2 authentication to correo + contraseña

### DIFF
--- a/REQUERIMIENTOS_Y_CASOS_DE_USO.md
+++ b/REQUERIMIENTOS_Y_CASOS_DE_USO.md
@@ -106,7 +106,7 @@
 - **RF-08.2** El sistema debe identificar periodo en reportes
 
 ### RF-09: Autenticación y Autorización ✨ FASE 1
-- **RF-09.1** El sistema web debe autenticar directores con CCT + contraseña
+- **RF-09.1** El sistema web debe autenticar directores con correo + contraseña
 - **RF-09.2** El sistema debe implementar recuperación de contraseña por email
 - **RF-09.3** El sistema debe gestionar sesiones con timeout configurable (default: 60 min)
 - **RF-09.4** El sistema debe implementar control de acceso basado en CCT

--- a/plataforma_recepcion_validacion_descarga_EIA.md
+++ b/plataforma_recepcion_validacion_descarga_EIA.md
@@ -126,6 +126,8 @@ La plataforma únicamente mostrará las ligas de descarga generadas externamente
 
 ### 5. Módulo de Descarga de Resultados
 
+El criterio único de autenticación para EIA2 es **correo + contraseña**.
+
 El usuario accede con su **correo y contraseña aleatoria generada en la primera carga válida** para consultar todas las versiones de resultados que se hayan generado externamente, aun cuando el mismo correo se use para varios CCT.
 
 Cada versión aparecerá con:


### PR DESCRIPTION
### Motivation
- Definir un único criterio de autenticación para EIA2 y eliminar la referencia a `CCT + contraseña` para evitar inconsistencias en los flujos de acceso (`correo + contraseña`).

### Description
- Actualicé `RF-09.1` en `REQUERIMIENTOS_Y_CASOS_DE_USO.md` para requerir autenticación con `correo + contraseña` y añadí la línea que establece explícitamente que el criterio único de autenticación para EIA2 es `correo + contraseña` en `plataforma_recepcion_validacion_descarga_EIA.md`.

### Testing
- Cambio de documentación únicamente; no se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852d907b348330837e376f019b8531)