### PR TITLE
docs: crear entregable de estándares y criterios técnicos Frontend (dic-ene) y reportes complementarios

### DIFF
--- a/ANALISIS_FRONTEND_FALTANTE_VS_PAGINAS_EIA.md
+++ b/ANALISIS_FRONTEND_FALTANTE_VS_PAGINAS_EIA.md
@@ -1,0 +1,110 @@
+# Revisión de frontend vs `Paginas_EIA.pdf` (segunda verificación)
+
+## Resultado de la verificación del archivo PDF
+Se realizó una segunda búsqueda en el repositorio y en `/workspace` para localizar `web/frontend/src/assets/archivos/Paginas_EIA.pdf` (incluyendo variantes por mayúsculas/minúsculas), pero **el archivo no está disponible en este entorno de trabajo**.
+
+Mientras se sincroniza ese archivo, dejo el análisis del frontend **actualmente implementado** para que puedas contrastarlo en cuanto el PDF aparezca en el árbol local.
+
+---
+
+## Páginas implementadas hoy (SPA Angular)
+Rutas detectadas:
+- `/inicio`
+- `/carga-masiva`
+- `/archivos-preescolar`
+- `/login`
+- `/descargas`
+- `/tickets`
+- `/tickets-historial`
+- `/admin/login`
+- `/admin/panel`
+
+---
+
+## Funcionalidades ya implementadas que debes reflejar en el PDF (si aún no están)
+
+## 1) Soporte: alta de tickets
+### Página: `/tickets`
+Ya existe:
+- Formulario de creación de ticket con motivo y descripción.
+- Motivo libre cuando se selecciona “otro”.
+- Validaciones de campos y manejo de errores.
+
+**Imágenes sugeridas para documento**
+1. Formulario en estado inicial.
+2. Formulario con validaciones activas.
+3. Confirmación de envío exitoso.
+
+## 2) Soporte: historial de tickets
+### Página: `/tickets-historial`
+Ya existe:
+- Tabla de tickets por usuario.
+- Visualización de folio, motivo, respuesta, fecha, evidencias y estatus.
+
+**Imágenes sugeridas**
+1. Tabla con varios tickets y estatus distintos.
+2. Ticket con respuesta del administrador.
+3. Vista responsiva (pantalla angosta).
+
+## 3) Seguimiento de solicitudes/descargas
+### Página: `/descargas` (módulo de seguimiento)
+Ya existe:
+- Filtro por CCT y rango de fechas.
+- Simulación de fallo y reintento.
+- Resumen de solicitudes recientes.
+
+**Imágenes sugeridas**
+1. Encabezado con filtros completos.
+2. Tarjetas/resumen con conteos.
+3. Estado de error con botón de reintento.
+
+## 4) Flujo administrativo de carga de resultados
+### Página: `/admin/panel`
+Ya existe:
+- Selección de nivel (preescolar/primaria/secundaria).
+- Listado de exceles con filtros y selección por registro.
+- Carga de archivos de resultados.
+- Gestión de tickets desde panel (detalle + respuesta + cambio de estatus).
+
+**Imágenes sugeridas**
+1. Vista general del panel.
+2. Bloque de filtros y lista de Excel.
+3. Bloque de carga de archivos.
+4. Bloque de seguimiento de tickets.
+
+## 5) Flujo de autenticación de usuario operativo
+### Páginas: `/carga-masiva` y `/login`
+Ya existe:
+- Estados visuales de sesión activa/inactiva.
+- Login con correo/contraseña y validaciones.
+- Flujo relacionado con credenciales generadas tras primera carga exitosa.
+
+**Imágenes sugeridas**
+1. Estado sin sesión (módulo carga).
+2. Estado con sesión activa.
+3. Pantalla de login con validación.
+
+## 6) Consulta de archivos guardados
+### Página: `/archivos-preescolar`
+Ya existe:
+- Tabla de archivos guardados.
+- Búsqueda por nombre o CCT.
+- Acciones sobre registros.
+
+**Imágenes sugeridas**
+1. Tabla con registros.
+2. Búsqueda aplicada.
+3. Estado vacío (sin registros).
+
+---
+
+## Plantilla recomendada para `Paginas_EIA.pdf`
+Para que el reporte quede claro y trazable, por cada módulo incluye:
+1. Objetivo del módulo.
+2. Pantallas implementadas.
+3. Flujo funcional.
+4. Reglas de validación.
+5. Estado (Terminado / En ajuste / Pendiente).
+6. Evidencia visual (2–4 capturas).
+
+> En cuanto el PDF esté disponible localmente en la ruta indicada, hago la comparación exacta página por página (contenido del PDF vs frontend real).

--- a/AVANCES_APIS_CONECTADAS_DB.md
+++ b/AVANCES_APIS_CONECTADAS_DB.md
@@ -1,0 +1,104 @@
+# Avances de APIs conectadas a base de datos (estado actual)
+
+Este documento resume las APIs del backend `graphql-server` que hoy ya ejecutan operaciones contra PostgreSQL.
+
+## 1) Base técnica ya operativa
+
+- API GraphQL montada con Apollo Server.
+- Conexión a PostgreSQL mediante pool (`pg.Pool`).
+- Helper de consultas central (`query`) y cliente transaccional (`getClient`).
+- Verificación de salud por GraphQL y por endpoint REST.
+
+---
+
+## 2) Queries implementadas y conectadas a BD
+
+## `healthCheck`
+- Ejecuta `SELECT NOW()` para comprobar conectividad.
+- Devuelve estado de BD y latencia.
+
+## `getUser(id)`
+- Consulta usuario por ID.
+- Integra catálogo de roles con `JOIN`.
+
+## `listUsers(limit, offset)`
+- Cuenta total de usuarios.
+- Lista usuarios paginados con `LIMIT/OFFSET`.
+
+## `getCCT(clave)`
+- Recupera un centro de trabajo por clave CCT.
+
+## `getEvaluacion(id)`
+- Recupera evaluación por identificador.
+
+## `getSolicitudes(limit, offset)`
+- Lista solicitudes EIA2 ordenadas por fecha.
+- Incluye estado de validación y metadatos del archivo.
+
+---
+
+## 3) Mutations implementadas y conectadas a BD
+
+## `createUser(input)`
+- Verifica duplicidad de correo.
+- Resuelve rol desde catálogo.
+- Genera hash de contraseña (`scrypt` + salt).
+- Inserta usuario y relaciona CCTs.
+
+## `authenticateUser(input)`
+- Busca usuario por correo.
+- Valida usuario activo.
+- Compara contraseña con hash almacenado.
+- Actualiza último acceso al autenticar.
+
+## `updateUser(id, input)`
+- Actualización dinámica de campos enviados.
+- Persistencia directa en `usuarios`.
+
+## `deleteUser(id)`
+- Baja de usuario por id.
+- Retorna éxito/mensaje de operación.
+
+## `uploadExcelAssessment(input)`
+- Procesa archivo Excel en base64.
+- Detecta CCT, nivel y grado.
+- Registra solicitud en `solicitudes_eia2`.
+- Inserta/actualiza escuela, grupos y estudiantes.
+- Inserta evaluaciones por materia.
+- Usa transacción completa (`BEGIN/COMMIT/ROLLBACK`).
+
+---
+
+## 4) Endpoints REST de soporte en el mismo servidor
+
+- `GET /health`
+  - Reporta disponibilidad y estado de conexión a BD.
+- `GET /`
+  - Reporta metadata del servicio y rutas.
+
+---
+
+## 5) Tablas alcanzadas por la capa API
+
+- `usuarios`
+- `cat_roles_usuario`
+- `usuarios_centros_trabajo`
+- `centros_trabajo`
+- `solicitudes_eia2`
+- `escuelas`
+- `grupos`
+- `estudiantes`
+- `evaluaciones`
+- `periodos_evaluacion`
+- `materias`
+
+---
+
+## 6) Conclusión
+
+A la fecha, el backend ya cuenta con operaciones funcionales conectadas a PostgreSQL para:
+- autenticación y administración de usuarios,
+- consulta de catálogos y entidades clave,
+- y carga masiva EIA2 con persistencia transaccional.
+
+Esto confirma que la capa API ya está integrada a base de datos para los flujos críticos del sistema.

--- a/DOCUMENTO_ESTANDARES_CRITERIOS_TECNICOS_FRONTEND_DIC_ENE_2025_2026.md
+++ b/DOCUMENTO_ESTANDARES_CRITERIOS_TECNICOS_FRONTEND_DIC_ENE_2025_2026.md
@@ -1,0 +1,169 @@
+# Documento de estándares y criterios técnicos de desarrollo Frontend
+## Periodo evaluado: diciembre 2025 – enero 2026 (excluye febrero)
+
+## 1) Objetivo del entregable
+Este documento establece y verifica los criterios técnicos, estándares de desarrollo y buenas prácticas aplicadas al Frontend del sistema EIA durante **diciembre 2025 y enero 2026**, incorporando:
+
+- lineamientos establecidos,
+- validaciones realizadas,
+- observaciones técnicas,
+- acciones correctivas implementadas,
+- evidencia de verificación de cumplimiento.
+
+> **Corte temporal explícito:** este entregable analiza únicamente evidencia de diciembre y enero. Cualquier trabajo de febrero queda fuera y se reserva para su informe mensual independiente.
+
+---
+
+## 2) Fuentes de evidencia usadas
+1. Bitácora de cambios del proyecto (hitos funcionales y correctivos en dic/ene).
+2. Código fuente frontend Angular (rutas, servicios, guardas, validaciones y componentes).
+3. Pruebas unitarias existentes en frontend (servicios críticos y componentes clave).
+4. Documentación funcional/arquitectónica ya integrada en repositorio.
+5. Trazabilidad por commits de fecha diciembre-enero para verificar evolución técnica.
+
+---
+
+## 3) Alcance técnico evaluado
+- **Arquitectura frontend SPA en Angular 19** y navegación por rutas.
+- **Calidad de validación de archivos Excel** (tipo, estructura, datos mínimos y reglas de negocio).
+- **Gestión de sesión/credenciales y almacenamiento local** para continuidad operativa.
+- **Capa de integración API (GraphQL)** con estrategia híbrida (mock/localStorage + integración real gradual).
+- **Trazabilidad y control de cambios** sobre funcionalidades frontend implementadas.
+
+---
+
+## 4) Lineamientos y estándares técnicos establecidos
+
+### 4.1 Estructura y modularidad
+- Separación por capas en frontend: `components/`, `services/`, `guards/`, `operations/`.
+- Enfoque de responsabilidad única por servicio (autenticación, validación, almacenamiento, GraphQL, usuarios, evaluaciones).
+- Enrutamiento centralizado y explícito para módulos funcionales de usuario y administración.
+
+### 4.2 Calidad de código y tipado
+- Uso de **TypeScript tipado** con interfaces de dominio (respuestas GraphQL, entradas de carga, estado de credenciales, registros de archivo).
+- Normalización de datos de entrada sensibles a reglas de negocio (correo/cct) antes de persistir o comparar.
+- Manejo de errores de negocio con mensajes claros al usuario y control de flujo en servicios/componentes.
+
+### 4.3 Validación funcional y de datos
+- Validación previa obligatoria de correo antes de aceptar cargas.
+- Validación de tipo de archivo (`.xlsx`) y tamaño máximo permitido.
+- Validación estructural de plantillas por nivel educativo en servicio centralizado.
+- Prevención de duplicados con huella SHA-256 y opción de reemplazo controlado.
+
+### 4.4 Seguridad y control de acceso
+- Regla de continuidad: si ya existen credenciales, se exige login para nuevas cargas.
+- Persistencia controlada de estado de sesión y correo asociado en localStorage.
+- Separación de acceso usuario/admin por rutas y componentes de autenticación diferenciados.
+
+### 4.5 Integración API y portabilidad de ambientes
+- Cliente GraphQL encapsulado en un servicio único (`GraphqlService`).
+- Resolución de endpoint por ambiente (variable inyectada, modo dev localhost o ruta relativa en despliegue).
+- Servicios de dominio (`UsuariosService`, `EvaluacionesService`) aislando queries/mutations del resto de componentes.
+
+### 4.6 Trazabilidad y evidencia técnica
+- Registro cronológico de cambios en bitácora.
+- Evidencia por commits con mensajes que documentan correcciones/ajustes.
+- Evidencia verificable por pruebas unitarias en funcionalidades críticas.
+
+---
+
+## 5) Validaciones realizadas (dic/ene)
+
+### 5.1 Validaciones de entrada y negocio en carga
+- Correo requerido y con formato válido antes de procesar archivos.
+- Rechazo de extensiones no permitidas y archivos excedidos de tamaño.
+- Checklist de consistencia de plantilla y campos obligatorios por nivel.
+- Mensajería de estado de validación (validando, error, éxito) para trazabilidad operativa.
+
+### 5.2 Validaciones de persistencia local
+- Guardado de archivos en localStorage con metadatos (correo, CCT, nivel, hash, fecha).
+- Rechazo de duplicado exacto por hash + CCT en mismo correo.
+- Reemplazo explícito de duplicado sólo cuando se activa bandera de reemplazo.
+- Conservación de clave estable de registro para trazabilidad de elementos guardados.
+
+### 5.3 Validaciones de sesión/autenticación
+- Verificación de credenciales previas antes de permitir nueva carga.
+- Inicio/cierre de sesión y sincronización de estado de sesión en UI.
+- Validación de coincidencia entre correo en sesión y credenciales persistidas.
+
+### 5.4 Validaciones de integración GraphQL
+- Validación de respuesta GraphQL con control de errores (`errors[]`) y datos faltantes.
+- Reglas explícitas de error en creación/autenticación de usuario y carga de Excel.
+- Estrategia de fallback operativo local mientras se consolidan flujos API.
+
+---
+
+## 6) Observaciones técnicas identificadas
+
+1. **Dependencia operativa en localStorage durante diciembre**: adecuada para continuidad temprana, pero con límites de persistencia, seguridad y auditoría de largo plazo.
+2. **Convivencia híbrida mock + GraphQL en enero**: correcta para transición incremental, aunque exige disciplina para evitar divergencias de comportamiento entre ambos flujos.
+3. **Fuerte concentración de reglas en validación Excel**: técnicamente útil para centralizar reglas, pero requiere mantenimiento riguroso por volumen de variantes por nivel/grado.
+4. **Buenas prácticas de UX técnica presentes**: alertas de estado, mensajes de error/sugerencia y bloqueo preventivo de acciones inválidas.
+5. **Necesidad de ampliar automatización de pruebas**: ya existen tests relevantes, pero el crecimiento funcional sugiere ampliar cobertura (especialmente autenticación/integración).
+
+---
+
+## 7) Acciones correctivas implementadas (evidencia dic/ene)
+
+### 7.1 Diciembre
+- Ajustes para robustecer validación y captura de correo previo a carga.
+- Correcciones de consistencia en guardado local y prevención de duplicados.
+- Mejora de mensajes/flujo de sesión y control de credenciales en primera carga.
+- Corrección de cálculo y uso de fecha disponible en mensajes de éxito.
+
+### 7.2 Enero
+- Reorganización de navegación (submenús y visibilidad condicional por sesión/rol).
+- Correcciones sucesivas al flujo de tickets, historial y persistencia local asociada.
+- Integración progresiva GraphQL para autenticación y creación de usuario.
+- Alineación de campos y endpoint GraphQL para compatibilidad con backend/DB.
+
+---
+
+## 8) Evidencia de verificación de cumplimiento
+
+## 8.1 Cumplimiento de estándares de arquitectura frontend
+- Se verifica separación por módulos/rutas/servicios y configuración central de providers.
+- Se verifica existencia de rutas funcionales para módulos comprometidos (inicio, carga, login, descargas, tickets, admin).
+
+## 8.2 Cumplimiento de validaciones técnicas
+- Servicio de validación Excel centralizado con reglas por nivel y catálogos de encabezados/columnas esperadas.
+- Servicio de almacenamiento con hash SHA-256 y política de duplicados.
+- Servicio de autenticación con reglas de normalización y control de sesión.
+
+## 8.3 Cumplimiento de trazabilidad
+- Bitácora con hitos de diciembre y enero que documentan acciones y correcciones.
+- Historial de commits de enero con mensajes de integración/corrección alineados al avance funcional.
+
+## 8.4 Cumplimiento de verificación por pruebas
+- Existen pruebas unitarias enfocadas en: detección de duplicados/reemplazo (`ArchivoStorageService`) y creación de componentes clave.
+- La existencia de pruebas demuestra práctica de verificación técnica en funcionalidades críticas del frontend.
+
+---
+
+## 9) Matriz de cumplimiento del entregable contractual
+
+| Requisito del entregable | Evidencia del proyecto (dic/ene) | Estado |
+|---|---|---|
+| Lineamientos establecidos | Estructura por capas, tipado, validación y seguridad de sesión en frontend | Cumple |
+| Validaciones realizadas | Reglas de correo/archivo/plantilla/hash/sesión/integración GraphQL | Cumple |
+| Observaciones técnicas | Identificación de límites localStorage y complejidad de esquema híbrido | Cumple |
+| Acciones correctivas implementadas | Correcciones de flujo, navegación, tickets, credenciales e integración GraphQL | Cumple |
+| Evidencia de verificación de cumplimiento | Bitácora, commits, código y pruebas unitarias en repositorio | Cumple |
+
+---
+
+## 10) Criterios de aceptación para auditoría interna
+Para considerar conforme este entregable en futuras revisiones mensuales:
+
+1. Mantener corte temporal explícito por mes evaluado.
+2. Adjuntar evidencia reproducible (bitácora + commits + rutas de código + pruebas).
+3. Reportar desviaciones técnicas y acción correctiva asociada.
+4. Mantener consistencia entre reglas de frontend y contratos de API.
+5. Actualizar matriz de cumplimiento con estatus verificable.
+
+---
+
+## 11) Conclusión ejecutiva
+Con base en la evidencia revisada del repositorio, **sí existe un marco técnico de desarrollo frontend aplicado y verificable para diciembre-enero**, con lineamientos claros, validaciones operativas, acciones correctivas documentadas y trazabilidad suficiente para sustentar el cumplimiento contractual del entregable solicitado.
+
+> **Nota final de alcance:** este documento excluye deliberadamente avances de febrero para no mezclar periodos de reporte.

--- a/INFORME_MENSUAL_ARQUITECTURA_DIC_ENE_2025_2026.md
+++ b/INFORME_MENSUAL_ARQUITECTURA_DIC_ENE_2025_2026.md
@@ -1,0 +1,319 @@
+# Informe mensual de arquitectura y componentes (Diciembre 2025 – Enero 2026)
+
+## 1) Propósito del entregable (alineado a contrato)
+Este informe documenta el **análisis de arquitectura Frontend de sistemas web** orientados al Sector Educativo y presenta el **diagrama de arquitectura y componentes** solicitado: estructura lógica/tecnológica, módulos de Angular, librerías complementarias, servicios API, conexiones GraphQL y frameworks involucrados.
+
+> En diciembre y gran parte de enero, el comportamiento funcional se sostuvo principalmente con **localStorage y servicios mock**; durante enero se consolidó la **preparación e integración GraphQL** para autenticación y carga.
+
+---
+
+## 2) Resumen ejecutivo por mes
+
+### Diciembre 2025 (foco frontend + simulación local)
+- Consolidación del frontend Angular y flujo de carga masiva.
+- Validación de plantillas Excel en cliente.
+- Generación y control de credenciales locales.
+- Persistencia con localStorage (archivos, sesión, estado de credenciales).
+- Gestión de duplicados por hash y reglas de negocio de primera carga.
+
+### Enero 2026 (foco integración + madurez funcional)
+- Reorganización de navegación y módulos de usuario/admin.
+- Fortalecimiento de soporte (tickets, historial, seguimiento).
+- Ajustes de UX/validaciones de carga.
+- Integración progresiva con GraphQL para operaciones de usuario y carga de Excel.
+- Backend GraphQL operativo con PostgreSQL para autenticar, crear usuario y procesar cargas.
+
+---
+
+## 3) Evidencia de trabajo diciembre/enero (fuentes del proyecto)
+
+## 3.1 Bitácora del proyecto
+- La bitácora documenta explícitamente avances de **2025-12-12, 2025-12-15 y 2025-12-18** con foco en autenticación, carga masiva, validación y almacenamiento local.
+- También refleja avances de enero con correcciones, consolidación funcional y lineamientos de negocio.
+
+## 3.2 Trazabilidad por commits (enero)
+- En enero aparecen hitos de integración GraphQL y ajuste funcional, por ejemplo:
+  - `Agregar autenticación GraphQL para login`
+  - `Integrar CreateUser en carga masiva`
+  - `Ajustar endpoint GraphQL en frontend`
+  - `Usar updated_at en autenticacion`
+
+---
+
+## 4) Arquitectura lógica y tecnológica del sistema
+
+**Descripción del diagrama:** este flujo resume cómo conviven dos modos de operación en el periodo reportado: (a) persistencia local y servicios simulados para continuidad funcional del frontend, y (b) integración progresiva con GraphQL hasta llegar a Apollo + PostgreSQL para operaciones reales.
+
+```mermaid
+flowchart LR
+  U[Usuario SEP] --> FE[Frontend Angular 19 SPA]
+  ADM[Administrador] --> FE
+
+  FE --> LS[(localStorage
+  credenciales/sesión/archivos/tickets)]
+  FE --> MOCK[Servicios Mock y DataSources simulados]
+  FE --> GQL[GraphQL HTTP /graphql]
+
+  GQL --> APOLLO[Apollo Server + Express]
+  APOLLO --> PG[(PostgreSQL)]
+
+  FE --> EXT[Repositorio/Ligas externas de descarga]
+```
+
+---
+
+## 5) Frontend Angular: módulos/páginas implementadas
+
+Rutas funcionales:
+- `/inicio`
+- `/carga-masiva`
+- `/archivos-preescolar`
+- `/login`
+- `/descargas`
+- `/tickets`
+- `/tickets-historial`
+- `/admin/login`
+- `/admin/panel`
+
+**Descripción del diagrama:** este mapa de componentes muestra el enrutador como eje central de navegación y la distribución de páginas funcionales del sistema, incluyendo flujo de usuario final, soporte y administración.
+
+```mermaid
+graph TD
+  APP[App Angular] --> R[Router]
+  R --> I[InicioComponent]
+  R --> CM[CargaMasivaComponent]
+  R --> AG[ArchivosGuardadosComponent]
+  R --> L[LoginComponent]
+  R --> D[DescargasComponent]
+  R --> T[TicketsComponent]
+  R --> TH[TicketsHistorialComponent]
+  R --> AL[AdminLoginComponent]
+  R --> AP[AdminPanelComponent]
+  D --> SD[SeguimientoDescargasComponent]
+```
+
+---
+
+## 6) Librerías y frameworks utilizados
+
+## 6.1 Frontend
+- **Angular 19** (`@angular/core`, `router`, `forms`, etc.)
+- **RxJS** para flujos reactivos.
+- **SweetAlert2** para alertas y confirmaciones UX.
+- **TypeScript 5** + Angular CLI/Karma/Jasmine.
+
+## 6.2 Backend/API
+- **Node.js + TypeScript**
+- **Apollo Server + GraphQL**
+- **Express, CORS, Helmet, Compression**
+- **PostgreSQL** con `pg`
+- **XLSX** para parseo de archivos de carga
+
+**Descripción del diagrama:** el mindmap sintetiza el stack tecnológico realmente usado en el periodo, separando capa frontend y backend para evidenciar frameworks base y librerías complementarias.
+
+```mermaid
+mindmap
+  root((Stack técnico))
+    Frontend
+      Angular 19
+      RxJS
+      SweetAlert2
+      TypeScript
+    Backend
+      Node.js
+      Apollo Server
+      GraphQL
+      Express
+      PostgreSQL
+      XLSX
+```
+
+---
+
+## 7) Arquitectura de servicios frontend
+
+**Descripción del diagrama:** el diagrama de clases representa la separación por responsabilidades en servicios Angular (autenticación, almacenamiento local, estado de credenciales y consumo GraphQL), así como las dependencias entre servicios de dominio y el cliente de API.
+
+```mermaid
+classDiagram
+  class AuthService {
+    +registrarCredenciales()
+    +iniciarSesion()
+    +cerrarSesion()
+    +estaAutenticado()
+  }
+  class ArchivoStorageService {
+    +guardarArchivoPreescolar()
+    +obtenerRegistros()
+    +eliminarRegistro()
+  }
+  class EstadoCredencialesService {
+    +obtener()
+    +actualizar()
+    +coincideCorreo()
+  }
+  class GraphqlService {
+    +execute(query, variables)
+  }
+  class UsuariosService {
+    +crearUsuario()
+    +autenticarUsuario()
+  }
+  class EvaluacionesService {
+    +subirExcel()
+  }
+  class SeguimientoService {
+    +consultarSeguimiento()
+  }
+
+  UsuariosService --> GraphqlService
+  EvaluacionesService --> GraphqlService
+  EstadoCredencialesService --> AuthService
+```
+
+---
+
+## 8) Diciembre: operación basada en localStorage (sin dependencia real de API)
+
+Durante diciembre se implementó una arquitectura **offline-first/simulada** para destrabar entregables de frontend sin bloquearse por backend:
+
+- `AuthService`: controla credenciales/sesión en localStorage.
+- `ArchivoStorageService`: guarda archivos y metadatos, controla duplicados por hash.
+- `EstadoCredencialesService`: persiste estado de credenciales para continuidad UX.
+- `AdminAuthService`: token simulado para panel administrativo.
+- Servicios de seguimiento/versiones en modo mock.
+
+**Descripción del diagrama:** esta secuencia describe el flujo típico de diciembre sin backend obligatorio: validación de archivo, guardado con hash, registro de credenciales y persistencia en localStorage con confirmación al usuario.
+
+```mermaid
+sequenceDiagram
+  participant U as Usuario
+  participant CM as CargaMasivaComponent
+  participant EV as Validación Excel
+  participant AS as ArchivoStorageService
+  participant AU as AuthService
+  participant LS as localStorage
+
+  U->>CM: Selecciona archivo .xlsx
+  CM->>EV: Validar estructura/hojas/campos
+  EV-->>CM: Resultado validación
+  CM->>AS: guardarArchivoPreescolar()
+  AS->>LS: Guarda registro + hash + metadatos
+  CM->>AU: registrarCredenciales(cct, correo)
+  AU->>LS: Guarda credenciales/sesión
+  CM-->>U: Confirmación + contraseña temporal
+```
+
+---
+
+## 9) Enero: transición a integración GraphQL
+
+En enero se mantiene la experiencia frontend pero se activa integración real por capas para operaciones clave:
+
+- `GraphqlService` resuelve endpoint (`localhost:4000/graphql` en dev).
+- `UsuariosService` consume `createUser` y `authenticateUser`.
+- `EvaluacionesService` consume `uploadExcelAssessment`.
+- Se conserva soporte mock para funcionalidades aún no acopladas totalmente.
+
+**Descripción del diagrama (decisión de flujo):** este flujo explica la estrategia híbrida de enero: si el caso de uso ya estaba disponible en GraphQL se enviaba por API; en caso contrario se mantenía servicio mock/localStorage para no frenar operación.
+
+```mermaid
+flowchart TD
+  A[CargaMasiva/Login] --> B{Flujo disponible en GraphQL?}
+  B -- Sí --> C[GraphqlService.execute]
+  C --> D[Mutation createUser/authenticateUser/uploadExcelAssessment]
+  D --> E[(PostgreSQL)]
+  B -- No --> F[Servicio mock/localStorage]
+```
+
+**Descripción del diagrama (secuencia GraphQL):** esta secuencia detalla la autenticación real vía GraphQL: frontend ejecuta mutation, Apollo consulta PostgreSQL, y retorna el objeto de usuario para completar inicio de sesión en la SPA.
+
+```mermaid
+sequenceDiagram
+  participant FE as Frontend Angular
+  participant GS as GraphqlService
+  participant API as Apollo GraphQL
+  participant DB as PostgreSQL
+
+  FE->>GS: execute(AUTHENTICATE_USER_MUTATION)
+  GS->>API: POST /graphql
+  API->>DB: SELECT usuarios + rol
+  DB-->>API: datos de usuario
+  API-->>GS: { ok, user }
+  GS-->>FE: Usuario autenticado
+```
+
+---
+
+## 10) Backend GraphQL y componentes (enero)
+
+**Descripción del diagrama:** este componente lógico del backend muestra el punto de entrada (`index.ts`), definición de esquema (`typeDefs`), resolvedores por tipo (queries/mutations) y acceso a datos centralizado mediante `database.ts` hacia PostgreSQL.
+
+```mermaid
+graph LR
+  IDX[index.ts
+  Express + Apollo + /health] --> T[typeDefs.ts]
+  IDX --> R[resolvers.ts]
+  R --> Q[Query resolvers
+  healthCheck/getUser/listUsers/getCCT/getEvaluacion/getSolicitudes]
+  R --> M[Mutation resolvers
+  createUser/authenticateUser/updateUser/deleteUser/uploadExcelAssessment]
+  R --> DB[(database.ts
+  pg Pool + query/getClient)]
+  DB --> PG[(PostgreSQL)]
+```
+
+---
+
+## 11) Diagrama de despliegue técnico
+
+**Descripción del diagrama:** este despliegue resume la topología en ejecución: navegador consumiendo la SPA Angular, comunicación HTTP con endpoint `/graphql`, conexión de API a PostgreSQL y persistencia local complementaria en el cliente.
+
+```mermaid
+flowchart LR
+  B[Navegador del usuario] -->|HTTPS| FE[Angular SPA]
+  FE -->|POST /graphql| API[Node.js + Apollo GraphQL]
+  API -->|SQL via pg pool| DB[(PostgreSQL)]
+  B -->|Persistencia local| LS[(localStorage)]
+```
+
+---
+
+## 12) Matriz de componentes solicitada por contrato
+
+| Componente solicitado | Estado Dic | Estado Ene | Evidencia técnica |
+|---|---|---|---|
+| Estructura lógica frontend | Implementada | Consolidada | Router + componentes |
+| Módulos Angular/páginas | Implementados | Ajustados UX/navegación | rutas activas |
+| Librerías complementarias | Integradas | Estables | Angular/RxJS/SweetAlert2 |
+| Servicios API (frontend) | Simulados | Híbrido mock + real | servicios `GraphqlService`, `UsuariosService`, `EvaluacionesService` |
+| Conexión GraphQL | Parcial/preparación | Operativa en flujos clave | mutations de usuarios/carga |
+| Otros frameworks (backend) | En preparación | Operativos | Express + Apollo + PostgreSQL |
+
+---
+
+## 13) Conclusión para reporte de pago (diciembre-enero)
+
+1. **Sí se cumplió el análisis y evolución de arquitectura frontend**, con decisiones técnicas alineadas a continuidad operativa (localStorage/mocks) mientras maduraba la capa API.
+2. **Sí se avanzó en el entregable de diagrama y componentes**, al contar con arquitectura de frontend definida, servicios por dominio, integración gradual a GraphQL y backend operativo con PostgreSQL.
+3. En diciembre predominó la **simulación controlada** (válida para avance funcional); en enero se materializó la **transición a integración real GraphQL** en procesos críticos.
+
+---
+
+## 14) Anexo: diagrama de roadmap mensual
+
+**Descripción del diagrama:** el Gantt permite justificar temporalmente el trabajo del periodo, mostrando la progresión de entregables desde base Angular y validación local (diciembre) hasta integración GraphQL en flujos críticos (enero).
+
+```mermaid
+gantt
+  title Evolución técnica Dic 2025 - Ene 2026
+  dateFormat  YYYY-MM-DD
+  section Diciembre
+  Base Angular + rutas iniciales           :done, d1, 2025-12-01, 10d
+  Validación Excel en cliente              :done, d2, 2025-12-10, 8d
+  Credenciales/sesión en localStorage      :done, d3, 2025-12-12, 10d
+  section Enero
+  Reorganización navegación y módulos      :done, e1, 2026-01-08, 14d
+  Soporte/tickets y seguimiento            :done, e2, 2026-01-10, 14d
+  Integración GraphQL usuarios/carga       :done, e3, 2026-01-22, 9d
+```


### PR DESCRIPTION
### Motivation
- Entregar el documento contractual que establece y verifica criterios técnicos, estándares y buenas prácticas aplicadas al Frontend para el periodo diciembre 2025 – enero 2026, con evidencia verificable y alcance temporal explícito (excluye febrero). 
- Proveer artefactos complementarios que faciliten la revisión técnica y la trazabilidad (análisis de páginas vs PDF, avances API/BD y el informe mensual de arquitectura). 

### Description
- Se añadió `DOCUMENTO_ESTANDARES_CRITERIOS_TECNICOS_FRONTEND_DIC_ENE_2025_2026.md` con objetivos, fuentes de evidencia, lineamientos técnicos, validaciones ejecutadas, observaciones, acciones correctivas, matriz de cumplimiento y criterios de aceptación para auditoría interna. 
- Se creó `ANALISIS_FRONTEND_FALTANTE_VS_PAGINAS_EIA.md` con comparación del SPA actual frente a la plantilla `Paginas_EIA.pdf` (nota: el PDF no estaba disponible en el workspace al momento del análisis) y sugerencias de capturas. 
- Se añadió `AVANCES_APIS_CONECTADAS_DB.md` que resume queries/mutations GraphQL, endpoints REST de soporte y tablas de PostgreSQL alcanzadas por la capa API. 
- Se incorporó `INFORME_MENSUAL_ARQUITECTURA_DIC_ENE_2025_2026.md` con diagramas Mermaid, mapa de componentes, vistas de servicios, decisiones de integración (mock vs GraphQL) y Gantt de roadmap para justificar avances de dic/ene. 

### Testing
- Verificación de contenido realizada con búsquedas de texto en los ficheros (`rg`) para asegurar la presencia de secciones clave y la delimitación temporal, con resultados esperados (éxito). 
- Ejecución de build frontend con `cd web/frontend && npm run build` para validar el estado operativo actual del proyecto; la compilación falló por budgets de Angular/SCSS y advertencias sobre dependencia CommonJS (`sweetalert2`), problemas que existen en el proyecto y no derivan de los cambios documentales (falla detectada). 
- Inspección de pruebas unitarias del frontend (por ejemplo `archivo-storage.service.spec.ts`) para confirmar cobertura en lógica crítica (duplicados/reemplazo); las pruebas existen y fueron revisadas pero no se ejecutó `ng test` como parte de este cambio (ver nota). 
- Comprobación de que los nuevos archivos están presentes en el árbol del repo mediante listados y lecturas de archivo (`sed`/`nl`), con contenido coherente con el entregable (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1a1fe4848320935a43713fc9ff78)