### PR TITLE
fix(frontend): corrección de mapeo en estatus de tickets (CU-13)

### DIFF
--- a/web/frontend/src/app/components/tickets/tickets.component.ts
+++ b/web/frontend/src/app/components/tickets/tickets.component.ts
@@ -341,7 +341,7 @@ export class TicketsComponent implements OnInit {
   private mapEstatus(estado: string): 'pendiente' | 'en-proceso' | 'respondido' {
     switch (estado) {
       case 'ABIERTO': return 'pendiente';
-      case 'EN PROCESO': return 'en-proceso';
+      case 'EN_PROCESO': return 'en-proceso';
       case 'CERRADO': case 'RESUELTO': return 'respondido';
       default: return 'pendiente';
     }


### PR DESCRIPTION
- Se corrigió un error de dedo en tickets.component.ts donde se usaba 'EN PROCESO' en lugar de 'EN_PROCESO'.
- Se verificó que el mapeo de estados coincida con los códigos del catálogo de la base de datos.
- Se completó la verificación del caso de uso de Gestión de Tickets de Soporte.