### PR TITLE
Corregir parseo de Excel en la carga de evaluaciones

### DIFF
--- a/graphql-server/src/schema/resolvers.ts
+++ b/graphql-server/src/schema/resolvers.ts
@@ -264,12 +264,12 @@ export const resolvers = {
         throw new Error('Error al obtener preguntas frecuentes');
       }
     },
-    
+
     /**
      * Listar materiales de evaluación
      * @use-case CU-01
      */
-    getMateriales: async (_: any, { nivel, ciclo }: { nivel?: string, ciclo?: string }) => {
+    getMateriales: async (_: any, { nivel, ciclo }: { nivel?: string; ciclo?: string }) => {
       try {
         let sql = `
           SELECT 
@@ -284,23 +284,26 @@ export const resolvers = {
           WHERE m.activo = true
         `;
         const params: any[] = [];
-        
+
         if (nivel) {
           sql += ` AND ne.codigo = $${params.length + 1}`;
           params.push(nivel);
         }
-        
+
         if (ciclo) {
           sql += ` AND m.ciclo_escolar = $${params.length + 1}`;
           params.push(ciclo);
         }
-        
+
         sql += ` ORDER BY m.fecha_publicacion DESC`;
-        
+
         const result = await query(sql, params);
-        return result.rows.map(row => ({
+        return result.rows.map((row) => ({
           ...row,
-          fechaPublicacion: row.fechaPublicacion instanceof Date ? row.fechaPublicacion.toISOString() : row.fechaPublicacion
+          fechaPublicacion:
+            row.fechaPublicacion instanceof Date
+              ? row.fechaPublicacion.toISOString()
+              : row.fechaPublicacion,
         }));
       } catch (error) {
         logger.error('Error fetching materiales', error);
@@ -424,7 +427,8 @@ id,
         const row = result.rows[0];
         return {
           ...row,
-          fechaCarga: row.fechaCarga instanceof Date ? row.fechaCarga.toISOString() : row.fechaCarga,
+          fechaCarga:
+            row.fechaCarga instanceof Date ? row.fechaCarga.toISOString() : row.fechaCarga,
         } as EvaluacionRow;
       } catch (error) {
         logger.error('Error fetching evaluation', { id, error });
@@ -488,15 +492,14 @@ id,
         const result = await query(sql, params);
         return result.rows.map((row: any) => ({
           ...row,
-          fechaCarga: row.fechaCarga instanceof Date ? row.fechaCarga.toISOString() : row.fechaCarga,
+          fechaCarga:
+            row.fechaCarga instanceof Date ? row.fechaCarga.toISOString() : row.fechaCarga,
         }));
       } catch (error) {
         logger.error('Error fetching solicitudes from DB', { error });
         throw new Error('Error al obtener el historial de solicitudes');
       }
     },
-
-
 
     /**
      * Listar todos los tickets del sistema (Admin)
@@ -529,10 +532,14 @@ t.id,
           WHERE t.deleted_at IS NULL
           ORDER BY t.created_at DESC
   `);
-        return result.rows.map(row => ({
+        return result.rows.map((row) => ({
           ...row,
-          fechaCreacion: row.fechaCreacion instanceof Date ? row.fechaCreacion.toISOString() : row.fechaCreacion,
-          fechaActualizacion: row.fechaActualizacion instanceof Date ? row.fechaActualizacion.toISOString() : row.fechaActualizacion
+          fechaCreacion:
+            row.fechaCreacion instanceof Date ? row.fechaCreacion.toISOString() : row.fechaCreacion,
+          fechaActualizacion:
+            row.fechaActualizacion instanceof Date
+              ? row.fechaActualizacion.toISOString()
+              : row.fechaActualizacion,
         }));
       } catch (error) {
         logger.error('Error fetching all tickets', { error });
@@ -558,7 +565,7 @@ t.id,
           cctsRes,
           trendRes,
           levelRes,
-          efficiencyRes
+          efficiencyRes,
         ] = await Promise.all([
           query('SELECT COUNT(*) as count FROM usuarios'),
           query('SELECT COUNT(*) as count FROM usuarios WHERE activo = true'),
@@ -598,14 +605,14 @@ COALESCE(AVG(EXTRACT(EPOCH FROM(res.fecha_respuesta - t.created_at)) / 3600), 0)
               ORDER BY created_at ASC 
               LIMIT 1
 ) res
-  `)
+  `),
         ]);
 
         const totalSolicitudes = parseInt(solicitudesRes.rows[0].count);
-        const distribucionNivel = levelRes.rows.map(row => ({
+        const distribucionNivel = levelRes.rows.map((row) => ({
           label: row.label,
           cantidad: parseInt(row.cantidad),
-          porcentaje: totalSolicitudes > 0 ? (parseInt(row.cantidad) / totalSolicitudes) * 100 : 0
+          porcentaje: totalSolicitudes > 0 ? (parseInt(row.cantidad) / totalSolicitudes) * 100 : 0,
         }));
 
         const totalTickets = parseInt(ticketsRes.rows[0].count);
@@ -620,15 +627,17 @@ COALESCE(AVG(EXTRACT(EPOCH FROM(res.fecha_respuesta - t.created_at)) / 3600), 0)
           totalSolicitudes,
           solicitudesValidadas: parseInt(solicitudesValidRes.rows[0].count),
           totalCCTs: parseInt(cctsRes.rows[0].count),
-          tendenciaCargas: trendRes.rows.map(row => ({
+          tendenciaCargas: trendRes.rows.map((row) => ({
             fecha: row.fecha,
-            cantidad: parseInt(row.cantidad)
+            cantidad: parseInt(row.cantidad),
           })),
           distribucionNivel,
           eficienciaSoporte: {
-            tiempoPromedioRespuestaHoras: parseFloat(parseFloat(efficiencyRes.rows[0].avg_hours || 0).toFixed(2)),
-            tasaResolucion: totalTickets > 0 ? (ticketsResueltos / totalTickets) * 100 : 0
-          }
+            tiempoPromedioRespuestaHoras: parseFloat(
+              parseFloat(efficiencyRes.rows[0].avg_hours || 0).toFixed(2)
+            ),
+            tasaResolucion: totalTickets > 0 ? (ticketsResueltos / totalTickets) * 100 : 0,
+          },
         };
       } catch (error) {
         logger.error('Error fetching dashboard metrics', error);
@@ -727,10 +736,14 @@ t.numero_ticket as "folio",
           [userId]
         );
 
-        return result.rows.map(row => ({
+        return result.rows.map((row) => ({
           ...row,
-          fechaCreacion: row.fechaCreacion instanceof Date ? row.fechaCreacion.toISOString() : row.fechaCreacion,
-          fechaActualizacion: row.fechaActualizacion instanceof Date ? row.fechaActualizacion.toISOString() : row.fechaActualizacion
+          fechaCreacion:
+            row.fechaCreacion instanceof Date ? row.fechaCreacion.toISOString() : row.fechaCreacion,
+          fechaActualizacion:
+            row.fechaActualizacion instanceof Date
+              ? row.fechaActualizacion.toISOString()
+              : row.fechaActualizacion,
         }));
       } catch (error) {
         logger.error('Error fetching tickets', { error });
@@ -738,12 +751,17 @@ t.numero_ticket as "folio",
       }
     },
 
-    generateComprobante: async (_: any, { solicitudId }: { solicitudId: string }, context: GraphQLContext) => {
+    generateComprobante: async (
+      _: any,
+      { solicitudId }: { solicitudId: string },
+      context: GraphQLContext
+    ) => {
       if (!context.user) throw new Error('No autorizado');
 
       try {
         // Obtener datos de la solicitud
-        const res = await query(`
+        const res = await query(
+          `
            SELECT 
              s.folio,
              s.fecha_carga,
@@ -754,7 +772,9 @@ t.numero_ticket as "folio",
            FROM solicitudes_eia2 s
            JOIN usuarios u ON s.usuario_id = u.id
            WHERE s.id = $1
-         `, [solicitudId]);
+         `,
+          [solicitudId]
+        );
 
         if (res.rows.length === 0) throw new Error('Solicitud no encontrada');
         const sol = res.rows[0];
@@ -803,7 +823,7 @@ t.numero_ticket as "folio",
         return {
           success: true,
           fileName: `Comprobante_${sol.folio}.txt`, // Cambiar a .pdf cuando se integre libreria completa
-          contentBase64: base64
+          contentBase64: base64,
         };
       } catch (error) {
         logger.error('Error generating comprobante', error);
@@ -814,7 +834,11 @@ t.numero_ticket as "folio",
     /**
      * Descargar un archivo de resultado desde SFTP
      */
-    downloadAssessmentResult: async (_: any, { solicitudId, fileName }: { solicitudId: string, fileName: string }, context: GraphQLContext) => {
+    downloadAssessmentResult: async (
+      _: any,
+      { solicitudId, fileName }: { solicitudId: string; fileName: string },
+      context: GraphQLContext
+    ) => {
       if (!context.user) throw new Error('No autorizado');
 
       try {
@@ -839,21 +863,25 @@ t.numero_ticket as "folio",
 
         // 3. Descargar de SFTP
         const buffer = await sftpService.downloadBuffer(archivoMetadata.url);
-        if (!buffer) throw new Error('No se pudo recuperar el archivo del servidor de almacenamiento');
+        if (!buffer)
+          throw new Error('No se pudo recuperar el archivo del servidor de almacenamiento');
 
         return {
           success: true,
           fileName: fileName,
-          contentBase64: buffer.toString('base64')
+          contentBase64: buffer.toString('base64'),
         };
-
       } catch (error: any) {
-        logger.error('Error en downloadAssessmentResult', { solicitudId, fileName, error: error.message });
+        logger.error('Error en downloadAssessmentResult', {
+          solicitudId,
+          fileName,
+          error: error.message,
+        });
         return {
           success: false,
           fileName: fileName,
           contentBase64: '',
-          message: error.message
+          message: error.message,
         };
       }
     },
@@ -866,12 +894,15 @@ t.numero_ticket as "folio",
       // Los materiales son públicos para descarga
 
       try {
-        const res = await query('SELECT nombre, tipo, ruta_archivo FROM materiales_evaluacion WHERE id = $1', [id]);
+        const res = await query(
+          'SELECT nombre, tipo, ruta_archivo FROM materiales_evaluacion WHERE id = $1',
+          [id]
+        );
         if (res.rows.length === 0) throw new Error('Material no encontrado');
-        
+
         const material = res.rows[0];
         const buffer = await sftpService.downloadBuffer(material.ruta_archivo);
-        
+
         if (!buffer) throw new Error('No se pudo descargar el archivo del servidor');
 
         // Obtener extensión desde la ruta original si existe, sino asignar por tipo
@@ -899,7 +930,7 @@ t.numero_ticket as "folio",
               'materiales_evaluacion',
               id,
               JSON.stringify({ nombre: finalFileName, tipo: material.tipo }),
-              'PORTAL_PUBLICO'
+              'PORTAL_PUBLICO',
             ]
           );
         } catch (logError) {
@@ -909,17 +940,17 @@ t.numero_ticket as "folio",
         return {
           success: true,
           fileName: finalFileName,
-          contentBase64: buffer.toString('base64')
+          contentBase64: buffer.toString('base64'),
         };
       } catch (error: any) {
         logger.error('Error en downloadMaterial', { id, error: error.message });
         return {
           success: false,
           fileName: '',
-          contentBase64: ''
+          contentBase64: '',
         };
       }
-    }
+    },
   },
 
   Mutation: {
@@ -987,15 +1018,14 @@ t.numero_ticket as "folio",
 
         if (clavesCCT && clavesCCT.length > 0) {
           try {
-            const escuelas = await query(
-              `SELECT id FROM escuelas WHERE cct = $1 LIMIT 1`,
-              [clavesCCT[0]]
-            );
+            const escuelas = await query(`SELECT id FROM escuelas WHERE cct = $1 LIMIT 1`, [
+              clavesCCT[0],
+            ]);
             if (escuelas.rows.length > 0) {
-              await query(
-                'UPDATE usuarios SET escuela_id = $1 WHERE id = $2',
-                [escuelas.rows[0].id, createdUser.id]
-              );
+              await query('UPDATE usuarios SET escuela_id = $1 WHERE id = $2', [
+                escuelas.rows[0].id,
+                createdUser.id,
+              ]);
             }
           } catch (err) {
             logger.error('Error vinculando escuela al crear usuario', err);
@@ -1007,7 +1037,7 @@ t.numero_ticket as "folio",
         // Enviar credenciales por correo
         try {
           // Si el usuario tiene un CCT asociado lo pasamos, si no el email
-          const cctLabel = (clavesCCT && clavesCCT.length > 0) ? clavesCCT[0] : email;
+          const cctLabel = clavesCCT && clavesCCT.length > 0 ? clavesCCT[0] : email;
           await mailingService.sendCredentials(email, cctLabel, password);
           logger.info(`Credentials email sent to ${email}`);
         } catch (mailErr) {
@@ -1225,7 +1255,9 @@ t.numero_ticket as "folio",
             // US-2.7: Restricción de archivos Excel en evidencias de tickets
             const ext = evidencia.nombre.toLowerCase();
             if (ext.endsWith('.xlsx') || ext.endsWith('.xls')) {
-              throw new Error(`El archivo ${evidencia.nombre} no está permitido como evidencia (Excel restringido).`);
+              throw new Error(
+                `El archivo ${evidencia.nombre} no está permitido como evidencia (Excel restringido).`
+              );
             }
 
             // En un entorno real, guardaríamos el base64 en disco/S3.
@@ -1272,8 +1304,6 @@ t.numero_ticket as "folio",
       }
     },
 
-
-
     /**
      * Recuperar contraseña (envío de email con nueva contraseña)
      * @use-case CU-01: Autenticación
@@ -1310,7 +1340,9 @@ t.numero_ticket as "folio",
             const remainingMinutes = Math.ceil((cooldownMs - diffMs) / (60 * 1000));
             logger.warn(`Cooldown active for ${email}. Remaining: ${remainingMinutes} min`);
             await client.query('ROLLBACK');
-            throw new Error(`Espera ${remainingMinutes} minutos antes de solicitar otra contraseña.`);
+            throw new Error(
+              `Espera ${remainingMinutes} minutos antes de solicitar otra contraseña.`
+            );
           }
         }
 
@@ -1332,9 +1364,7 @@ t.numero_ticket as "folio",
         // 5. Enviar correo real
         await mailingService.sendPasswordRecovery(email, newPassword);
 
-        logger.info(
-          `Recovery email sent to ${email}`
-        );
+        logger.info(`Recovery email sent to ${email}`);
 
         await client.query('COMMIT');
         return 'Solicitud procesada';
@@ -1403,7 +1433,9 @@ t.numero_ticket as "folio",
         const fileHash = crypto.createHash('sha256').update(buffer).digest('hex');
         let userToLink = context.user?.id;
         if (!userToLink && email) {
-          const uRes = await client.query('SELECT id FROM usuarios WHERE email = $1', [email.trim().toLowerCase()]);
+          const uRes = await client.query('SELECT id FROM usuarios WHERE email = $1', [
+            email.trim().toLowerCase(),
+          ]);
           if (uRes.rows.length > 0) userToLink = uRes.rows[0].id;
         }
 
@@ -1412,65 +1444,99 @@ t.numero_ticket as "folio",
           workerResult = await runWorker();
         } catch (workerError: any) {
           // Trazabilidad de RECHAZO (Punto 3 de Criterios de Aceptación)
-          // Si el worker falla, intentamos extraer el CCT del nombre o metadata si es posible, 
+          // Si el worker falla, intentamos extraer el CCT del nombre o metadata si es posible,
           // pero al menos registramos el intento fallido.
           const errorMsg = workerError.message || 'Error de validación desconocido';
-          
+
           const rejRes = await client.query(
             `INSERT INTO solicitudes_eia2 (cct, archivo_original, fecha_carga, estado_validacion, archivo_path, archivo_size, hash_archivo, usuario_id, errores_validacion)
              VALUES ($1, $2, NOW(), 1, $3, $4, $5, $6, $7) RETURNING consecutivo`,
-            ['Desconocido', nombreArchivo, `storage/uploads/failed/${nombreArchivo}`, buffer.length, fileHash, userToLink || null, JSON.stringify([errorMsg])]
+            [
+              'Desconocido',
+              nombreArchivo,
+              `storage/uploads/failed/${nombreArchivo}`,
+              buffer.length,
+              fileHash,
+              userToLink || null,
+              JSON.stringify([errorMsg]),
+            ]
           );
           const rejectedConsecutivo = rejRes.rows[0]?.consecutivo;
 
           // Log de auditoría para rechazo
           await client.query(
-            "INSERT INTO log_actividades (id_usuario, accion, tabla, detalle, modulo) VALUES ($1, $2, $3, $4, $5)",
-            [userToLink || '00000000-0000-0000-0000-000000000000', 'UPLOAD_REJECTED', 'solicitudes_eia2', `Archivo ${nombreArchivo} rechazado (Folio: ${rejectedConsecutivo}): ${errorMsg}`, 'CARGA_MASIVA']
+            'INSERT INTO log_actividades (id_usuario, accion, tabla, detalle, modulo) VALUES ($1, $2, $3, $4, $5)',
+            [
+              userToLink || '00000000-0000-0000-0000-000000000000',
+              'UPLOAD_REJECTED',
+              'solicitudes_eia2',
+              `Archivo ${nombreArchivo} rechazado (Folio: ${rejectedConsecutivo}): ${errorMsg}`,
+              'CARGA_MASIVA',
+            ]
           );
 
           return {
             success: false,
             message: `Archivo rechazado por validación (Folio: ${rejectedConsecutivo}): ${errorMsg}`,
             consecutivo: rejectedConsecutivo?.toString(),
-            detalles: { errores: [errorMsg] }
+            detalles: { errores: [errorMsg] },
           };
         }
 
         const { cct, nivel, grado, alumnos, metadata } = workerResult;
 
         // Verificar duplicado por hash antes de proceder (Punto 6 Checklist)
-        const existingReq = await client.query('SELECT id FROM solicitudes_eia2 WHERE hash_archivo = $1 LIMIT 1', [fileHash]);
+        const existingReq = await client.query(
+          'SELECT id FROM solicitudes_eia2 WHERE hash_archivo = $1 LIMIT 1',
+          [fileHash]
+        );
         if (existingReq.rows.length > 0 && !confirmarReemplazo) {
           return {
             success: false,
             message: 'El archivo ya existe en el sistema. ¿Desea reemplazarlo?',
-            duplicadoDetectado: true
+            duplicadoDetectado: true,
           };
         }
 
-        const nivelMap: Record<string, number> = { PREESCOLAR: 1, PRIMARIA: 2, SECUNDARIA: 3, TELESECUNDARIA: 4 };
+        const nivelMap: Record<string, number> = {
+          PREESCOLAR: 1,
+          PRIMARIA: 2,
+          SECUNDARIA: 3,
+          TELESECUNDARIA: 4,
+        };
         const nivelId = nivelMap[nivel.toUpperCase()] || 2;
 
         await client.query('BEGIN');
 
         // Buscar Vinculación con Credenciales EIA2
-        const credRes = await client.query('SELECT id FROM credenciales_eia2 WHERE cct = $1', [cct]);
+        const credRes = await client.query('SELECT id FROM credenciales_eia2 WHERE cct = $1', [
+          cct,
+        ]);
         const credencialId = credRes.rows.length > 0 ? credRes.rows[0].id : null;
 
         let solicitudId;
         let consecutivo;
         if (existingReq.rows.length > 0) {
           solicitudId = existingReq.rows[0].id;
-          const upRes = await client.query('UPDATE solicitudes_eia2 SET updated_at = NOW(), usuario_id = $1, cct = $2, errores_validacion = NULL WHERE id = $3 RETURNING consecutivo', [
-            userToLink || null, cct, solicitudId,
-          ]);
+          const upRes = await client.query(
+            'UPDATE solicitudes_eia2 SET updated_at = NOW(), usuario_id = $1, cct = $2, errores_validacion = NULL WHERE id = $3 RETURNING consecutivo',
+            [userToLink || null, cct, solicitudId]
+          );
           consecutivo = upRes.rows[0].consecutivo;
         } else {
           const solRes = await client.query(
             `INSERT INTO solicitudes_eia2 (cct, archivo_original, fecha_carga, estado_validacion, nivel_educativo, archivo_path, archivo_size, hash_archivo, usuario_id, credencial_id)
              VALUES ($1, $2, NOW(), 1, $3, $4, $5, $6, $7, $8) RETURNING id, consecutivo`,
-            [cct, nombreArchivo, nivelId, `storage/uploads/${nombreArchivo}`, buffer.length, fileHash, userToLink || null, credencialId]
+            [
+              cct,
+              nombreArchivo,
+              nivelId,
+              `storage/uploads/${nombreArchivo}`,
+              buffer.length,
+              fileHash,
+              userToLink || null,
+              credencialId,
+            ]
           );
           solicitudId = solRes.rows[0].id;
           consecutivo = solRes.rows[0].consecutivo;
@@ -1479,17 +1545,38 @@ t.numero_ticket as "folio",
         // Procesar Escuela, Grupos, Estudiantes y Evaluaciones (Database I/O)
 
         // 1. Escuela
+        const turnosMap: Record<string, number> = {
+          MATUTINO: 1,
+          VESPERTINO: 2,
+          NOCTURNO: 3,
+          DISCONTINUO: 4,
+          'TIEMPO COMPLETO': 5,
+          'JORNADA AMPLIADA': 6,
+        };
+        const turnoId = turnosMap[metadata.turno?.toUpperCase() || ''] || 1;
+        const nombreEscuela = metadata.nombreEscuela?.trim() || 'Escuela sin nombre (Importada)';
+
         const escuelaRes = await client.query('SELECT id FROM escuelas WHERE cct = $1', [cct]);
         let escuelaId;
         if (escuelaRes.rows.length === 0) {
           const defaultRes = await client.query(
-            `INSERT INTO escuelas (cct, nombre, id_turno, id_nivel, id_entidad, id_ciclo)
-             VALUES ($1, $2, 1, $3, 14, 1) RETURNING id`,
-            [cct, 'Escuela sin nombre (Importada)', nivelId]
+            `INSERT INTO escuelas (cct, nombre, id_turno, id_nivel, id_entidad, id_ciclo, email)
+             VALUES ($1, $2, $3, $4, 14, 1, $5) RETURNING id`,
+            [cct, nombreEscuela, turnoId, nivelId, metadata.correo || null]
           );
           escuelaId = defaultRes.rows[0].id;
         } else {
           escuelaId = escuelaRes.rows[0].id;
+          await client.query(
+            `UPDATE escuelas
+             SET nombre = COALESCE(NULLIF($1, ''), nombre),
+                 id_turno = $2,
+                 id_nivel = $3,
+                 email = COALESCE(NULLIF($4, ''), email),
+                 updated_at = NOW()
+             WHERE id = $5`,
+            [nombreEscuela, turnoId, nivelId, metadata.correo || null, escuelaId]
+          );
         }
 
         if (userToLink) {
@@ -1500,7 +1587,7 @@ t.numero_ticket as "folio",
             );
             logger.info('Vinculación automática de usuario con escuela exitosa', {
               userId: userToLink,
-              escuelaId
+              escuelaId,
             });
           } catch (err) {
             logger.error('Error en vinculación automática', err);
@@ -1594,7 +1681,9 @@ t.numero_ticket as "folio",
             logger.error('Error durante la sincronización SFTP', err);
           } finally {
             // Limpiar archivo temporal
-            try { await fs.unlink(tempPath); } catch { }
+            try {
+              await fs.unlink(tempPath);
+            } catch {}
           }
         };
 
@@ -1603,8 +1692,15 @@ t.numero_ticket as "folio",
 
         // Log de auditoría para éxito
         await client.query(
-          "INSERT INTO log_actividades (id_usuario, accion, tabla, registro_id, detalle, modulo) VALUES ($1, $2, $3, $4, $5, $6)",
-          [userToLink || '00000000-0000-0000-0000-000000000000', 'UPLOAD_SUCCESS', 'solicitudes_eia2', solicitudId, `Archivo ${nombreArchivo} procesado exitosamente para CCT ${cct}`, 'CARGA_MASIVA']
+          'INSERT INTO log_actividades (id_usuario, accion, tabla, registro_id, detalle, modulo) VALUES ($1, $2, $3, $4, $5, $6)',
+          [
+            userToLink || '00000000-0000-0000-0000-000000000000',
+            'UPLOAD_SUCCESS',
+            'solicitudes_eia2',
+            solicitudId,
+            `Archivo ${nombreArchivo} procesado exitosamente para CCT ${cct}`,
+            'CARGA_MASIVA',
+          ]
         );
 
         return {
@@ -1643,13 +1739,19 @@ t.numero_ticket as "folio",
       const client = await getClient();
 
       // Validar permisos de administrador
-      if (!context.user || !['COORDINADOR_FEDERAL', 'COORDINADOR_ESTATAL'].includes(context.user.rol)) {
+      if (
+        !context.user ||
+        !['COORDINADOR_FEDERAL', 'COORDINADOR_ESTATAL'].includes(context.user.rol)
+      ) {
         throw new Error('No autorizado: Solo administradores pueden subir resultados');
       }
 
       try {
         // 1. Verificar que la solicitud existe
-        const solRes = await client.query('SELECT cct, resultados FROM solicitudes_eia2 WHERE id = $1', [solicitudId]);
+        const solRes = await client.query(
+          'SELECT cct, resultados FROM solicitudes_eia2 WHERE id = $1',
+          [solicitudId]
+        );
         if (solRes.rows.length === 0) {
           throw new Error('La solicitud de evaluación no existe');
         }
@@ -1692,7 +1794,7 @@ t.numero_ticket as "folio",
           nuevosResultados.push({
             nombre: nombre,
             url: remotePath,
-            size: buffer.length
+            size: buffer.length,
           });
         }
 
@@ -1712,15 +1814,14 @@ t.numero_ticket as "folio",
         return {
           success: true,
           message: `${nuevosResultados.length} archivos subidos correctamente`,
-          resultados: resultadosFinales
+          resultados: resultadosFinales,
         };
-
       } catch (error: any) {
         logger.error('Error en uploadAssessmentResults', { solicitudId, error: error.message });
         return {
           success: false,
           message: error.message,
-          resultados: []
+          resultados: [],
         };
       } finally {
         client.release();
@@ -1732,31 +1833,50 @@ t.numero_ticket as "folio",
      * @use-case CU-01
      */
     publicarMaterial: async (_: any, { input }: { input: any }, context: GraphQLContext) => {
-      if (!context.user || !['COORDINADOR_FEDERAL', 'COORDINADOR_ESTATAL'].includes(context.user.rol)) {
+      if (
+        !context.user ||
+        !['COORDINADOR_FEDERAL', 'COORDINADOR_ESTATAL'].includes(context.user.rol)
+      ) {
         throw new Error('No autorizado');
       }
 
       const client = await getClient();
       try {
-        let { nombre, tipo, nivelEducativo, cicloEscolar, periodoId, archivoBase64, nombreArchivo, overwrite } = input;
+        let {
+          nombre,
+          tipo,
+          nivelEducativo,
+          cicloEscolar,
+          periodoId,
+          archivoBase64,
+          nombreArchivo,
+          overwrite,
+        } = input;
 
         // 1. Obtener ID del nivel educativo
-        const levelRes = await client.query('SELECT id FROM cat_nivel_educativo WHERE codigo = $1', [nivelEducativo]);
+        const levelRes = await client.query(
+          'SELECT id FROM cat_nivel_educativo WHERE codigo = $1',
+          [nivelEducativo]
+        );
         if (levelRes.rows.length === 0) throw new Error('Nivel educativo no encontrado');
         const nivelId = levelRes.rows[0].id;
 
         // 2. Verificar duplicados por metadatos (Nombre, Tipo, Nivel, Ciclo)
-        const checkDuplicate = await client.query(`
+        const checkDuplicate = await client.query(
+          `
           SELECT id, ruta_archivo 
           FROM materiales_evaluacion 
           WHERE nombre = $1 AND tipo = $2 AND nivel_educativo = $3 AND ciclo_escolar = $4 AND activo = true
-        `, [nombre, tipo, nivelId, cicloEscolar]);
+        `,
+          [nombre, tipo, nivelId, cicloEscolar]
+        );
 
         if (checkDuplicate.rows.length > 0 && !overwrite) {
           return {
             success: false,
-            message: 'Ya existe un material publicado con estos mismos datos. ¿Desea sobrescribirlo?',
-            requiresConfirmation: true
+            message:
+              'Ya existe un material publicado con estos mismos datos. ¿Desea sobrescribirlo?',
+            requiresConfirmation: true,
           };
         }
 
@@ -1768,7 +1888,7 @@ t.numero_ticket as "folio",
         const uniqueName = `${tipo}_${Date.now()}_${nombreArchivo}`;
         const remoteDir = `/upload/materiales/${cicloEscolar}`;
         const remotePath = `${remoteDir}/${uniqueName}`;
-        
+
         await sftpService.connect();
         await sftpService.ensureDir(remoteDir);
 
@@ -1779,33 +1899,39 @@ t.numero_ticket as "folio",
 
         // Si es sobreescritura, desactivamos el anterior
         if (checkDuplicate.rows.length > 0 && overwrite) {
-          await client.query('UPDATE materiales_evaluacion SET activo = false WHERE id = $1', [checkDuplicate.rows[0].id]);
+          await client.query('UPDATE materiales_evaluacion SET activo = false WHERE id = $1', [
+            checkDuplicate.rows[0].id,
+          ]);
         }
 
-        const result = await client.query(`
+        const result = await client.query(
+          `
           INSERT INTO materiales_evaluacion (
             nombre, tipo, nivel_educativo, ruta_archivo, ciclo_escolar, periodo_id, usuario_id
           ) VALUES ($1, $2, $3, $4, $5, $6, $7)
           RETURNING id, nombre, tipo, ciclo_escolar as "cicloEscolar", fecha_publicacion as "fechaPublicacion", activo
-        `, [nombre, tipo, nivelId, remotePath, cicloEscolar, periodoId, context.user.id]);
+        `,
+          [nombre, tipo, nivelId, remotePath, cicloEscolar, periodoId, context.user.id]
+        );
 
         await client.query('COMMIT');
 
         return {
           success: true,
-          message: overwrite ? 'Material actualizado correctamente.' : 'Material publicado correctamente.',
+          message: overwrite
+            ? 'Material actualizado correctamente.'
+            : 'Material publicado correctamente.',
           material: {
             ...result.rows[0],
             nivelEducativo: nivelEducativo,
-            rutaArchivo: remotePath
-          }
+            rutaArchivo: remotePath,
+          },
         };
-
       } catch (error: any) {
         logger.error('Error en publicarMaterial', error);
         return {
           success: false,
-          message: error.message
+          message: error.message,
         };
       } finally {
         client.release();
@@ -1910,10 +2036,9 @@ t.numero_ticket as "folio",
         }
 
         // 3. Soft Delete
-        await query(
-          'UPDATE tickets_soporte SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1',
-          [ticketId]
-        );
+        await query('UPDATE tickets_soporte SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1', [
+          ticketId,
+        ]);
 
         return true;
       } catch (error) {
@@ -1967,7 +2092,11 @@ t.numero_ticket as "folio",
    * Field resolvers para Evaluacion
    */
   Evaluacion: {
-    estudiantes: async (parent: ParentWithId, _: any, context: GraphQLContext): Promise<EstudianteRow[]> => {
+    estudiantes: async (
+      parent: ParentWithId,
+      _: any,
+      context: GraphQLContext
+    ): Promise<EstudianteRow[]> => {
       return context.loaders.evaluationStudents.load(parent.id);
     },
   },

--- a/graphql-server/src/workers/excel-parser.ts
+++ b/graphql-server/src/workers/excel-parser.ts
@@ -1,0 +1,317 @@
+import * as XLSX from 'xlsx';
+
+export interface ParsedStudent {
+  curp: string;
+  nombre: string;
+  grupo: string;
+  evaluaciones: { materiaIndex: number; valor: number }[];
+}
+
+export interface SchoolMetadata {
+  nivelDetectado: string;
+  gradoDetectado: string;
+  turno: string;
+  nombreEscuela: string;
+  correo: string;
+}
+
+export interface ParsedAssessmentData {
+  cct: string;
+  nivel: string;
+  grado: number;
+  alumnos: ParsedStudent[];
+  metadata: SchoolMetadata;
+}
+
+const TURNOS_VALIDOS = new Set([
+  'MATUTINO',
+  'VESPERTINO',
+  'NOCTURNO',
+  'DISCONTINUO',
+  'TIEMPO COMPLETO',
+  'JORNADA AMPLIADA',
+]);
+
+const COLUMNAS_PREESCOLAR = buildColumnRange('F', 'P');
+const COLUMNAS_PRIMARIA: Record<string, string[]> = {
+  PRIMERO: buildColumnRange('F', 'O'),
+  SEGUNDO: buildColumnRange('F', 'O'),
+  TERCERO: buildColumnRange('F', 'AE'),
+  CUARTO: buildColumnRange('F', 'AE'),
+  QUINTO: buildColumnRange('F', 'AD'),
+  SEXTO: buildColumnRange('F', 'AD'),
+};
+const COLUMNAS_SECUNDARIA: Record<string, string[]> = {
+  PRIMERO: buildColumnRange('F', 'Z'),
+  SEGUNDO: buildColumnRange('F', 'Z'),
+  TERCERO: buildColumnRange('F', 'Y'),
+};
+
+export function parseExcelAssessmentBuffer(buffer: Buffer): ParsedAssessmentData {
+  const workbook = XLSX.read(buffer, { type: 'buffer' });
+  const errors: string[] = [];
+
+  if (!workbook.SheetNames.includes('ESC')) {
+    throw new Error('No se encontró la hoja obligatoria "ESC".');
+  }
+
+  const escSheet = workbook.Sheets.ESC;
+  const escData = extractEscData(escSheet, errors);
+  const nivel = detectLevel(workbook.SheetNames, escSheet);
+  if (!nivel) {
+    errors.push('No se pudo identificar el nivel educativo del archivo.');
+  }
+
+  const dataSheetName = findDataSheetName(workbook.SheetNames, nivel);
+  if (!dataSheetName) {
+    errors.push(
+      'No se encontró la hoja de captura de evaluaciones (ej. PREESCOLAR, PRIMERO, SEGUNDO, TERCERO).'
+    );
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join(' | '));
+  }
+
+  const sheetData = workbook.Sheets[dataSheetName!];
+  const grado = detectGrade(dataSheetName!, nivel!);
+  const alumnos = extractStudents(sheetData, dataSheetName!, nivel!, escData.cct, grado, errors);
+
+  if (!alumnos.length) {
+    errors.push(`No se encontraron estudiantes capturados en la hoja ${dataSheetName}.`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join(' | '));
+  }
+
+  return {
+    cct: escData.cct,
+    nivel: nivel!,
+    grado,
+    alumnos,
+    metadata: {
+      nivelDetectado: nivel!,
+      gradoDetectado: dataSheetName!.toUpperCase(),
+      turno: escData.turno,
+      nombreEscuela: escData.nombreEscuela,
+      correo: escData.correo,
+    },
+  };
+}
+
+function extractEscData(sheet: XLSX.WorkSheet, errors: string[]) {
+  const cct = firstNonEmptyCell(sheet, ['D9', 'E9', 'C9']);
+  const turno = firstNonEmptyCell(sheet, ['D11', 'E11']).toUpperCase();
+  const nombreEscuela = firstNonEmptyCell(sheet, ['D13', 'E13']);
+  const correo = firstNonEmptyCell(sheet, ['D18', 'E18']).toLowerCase();
+
+  if (!cct) {
+    errors.push('La CCT no está capturada en la hoja ESC.');
+  } else if (!/^[0-9]{2}[A-Z]{3}[0-9]{4}[A-Z]$/.test(cct)) {
+    errors.push(`La CCT "${cct}" tiene un formato inválido.`);
+  }
+
+  if (!turno) {
+    errors.push('Selecciona un turno válido en la hoja ESC.');
+  } else if (!TURNOS_VALIDOS.has(turno)) {
+    errors.push('El turno capturado no coincide con las opciones de la plantilla.');
+  }
+
+  if (!nombreEscuela) {
+    errors.push('Ingresa el nombre de la escuela en la hoja ESC.');
+  }
+
+  if (!correo) {
+    errors.push('Ingresa el correo de contacto en la hoja ESC.');
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(correo)) {
+    errors.push('El correo de contacto no tiene un formato válido.');
+  }
+
+  return { cct, turno, nombreEscuela, correo };
+}
+
+function detectLevel(sheetNames: string[], escSheet: XLSX.WorkSheet): string | null {
+  const explicit = normalizeCellValue(escSheet.C6?.v);
+  if (
+    explicit === 'PREESCOLAR' ||
+    explicit === 'PRIMARIA' ||
+    explicit === 'SECUNDARIA' ||
+    explicit === 'TELESECUNDARIA'
+  ) {
+    return explicit;
+  }
+
+  const normalized = sheetNames.map((name) => name.toUpperCase());
+  if (normalized.includes('PREESCOLAR')) return 'PREESCOLAR';
+  const primariaSheets = ['PRIMERO', 'SEGUNDO', 'TERCERO', 'CUARTO', 'QUINTO', 'SEXTO'];
+  if (primariaSheets.every((sheet) => normalized.includes(sheet))) return 'PRIMARIA';
+  if (['PRIMERO', 'SEGUNDO', 'TERCERO'].every((sheet) => normalized.includes(sheet)))
+    return 'SECUNDARIA';
+  return null;
+}
+
+function findDataSheetName(sheetNames: string[], nivel: string | null): string | undefined {
+  const normalizedMap = new Map(sheetNames.map((name) => [name.toUpperCase(), name]));
+  if (nivel === 'PREESCOLAR')
+    return normalizedMap.get('TERCERO') || normalizedMap.get('PREESCOLAR');
+  if (nivel === 'PRIMARIA') {
+    return ['PRIMERO', 'SEGUNDO', 'TERCERO', 'CUARTO', 'QUINTO', 'SEXTO']
+      .map((name) => normalizedMap.get(name))
+      .find(Boolean);
+  }
+  if (nivel === 'SECUNDARIA' || nivel === 'TELESECUNDARIA') {
+    return ['PRIMERO', 'SEGUNDO', 'TERCERO'].map((name) => normalizedMap.get(name)).find(Boolean);
+  }
+  return undefined;
+}
+
+function detectGrade(sheetName: string, nivel: string): number {
+  const gradeText = sheetName.toUpperCase();
+  const gradoMap: Record<string, number> = {
+    PREESCOLAR: 3,
+    PRIMERO: 1,
+    SEGUNDO: 2,
+    TERCERO: 3,
+    CUARTO: 4,
+    QUINTO: 5,
+    SEXTO: 6,
+  };
+  const found = Object.keys(gradoMap).find((key) => gradeText.includes(key));
+  if (found) return gradoMap[found];
+  return nivel === 'PREESCOLAR' ? 3 : 1;
+}
+
+function extractStudents(
+  sheet: XLSX.WorkSheet,
+  sheetName: string,
+  nivel: string,
+  cct: string,
+  grado: number,
+  errors: string[]
+): ParsedStudent[] {
+  const data = XLSX.utils.sheet_to_json(sheet, { range: 9, header: 'A', defval: '' }) as Array<
+    Record<string, string>
+  >;
+  const columnas = resolveEvaluationColumns(nivel, sheetName.toUpperCase());
+  if (!columnas.length) {
+    errors.push(`No se pudo determinar el rango de valoraciones para la hoja ${sheetName}.`);
+    return [];
+  }
+
+  const alumnos: ParsedStudent[] = [];
+  data.forEach((row, index) => {
+    const numeroLista = cleanText(row.B);
+    const nombre = cleanText(row.C);
+    const sexo = cleanText(row.D).toUpperCase();
+    const grupo = cleanText(row.E).toUpperCase();
+    const filaExcel = 10 + index;
+    const valoraciones = columnas.map((col) => {
+      const raw = cleanText(row[col]);
+      return raw === '' ? null : Number(raw);
+    });
+    const filaVacia =
+      !numeroLista && !nombre && !sexo && !grupo && valoraciones.every((valor) => valor === null);
+    if (filaVacia) return;
+
+    const erroresFila: string[] = [];
+    if (!numeroLista)
+      erroresFila.push(`Fila ${filaExcel} (${sheetName}): falta el número de lista.`);
+    else if (Number.isNaN(Number(numeroLista)))
+      erroresFila.push(`Fila ${filaExcel} (${sheetName}): el número de lista debe ser numérico.`);
+
+    if (!nombre)
+      erroresFila.push(
+        `Fila ${filaExcel} (${sheetName}): captura el nombre completo del estudiante.`
+      );
+    if (!sexo) erroresFila.push(`Fila ${filaExcel} (${sheetName}): indica el sexo (H/M).`);
+    else if (!['H', 'M'].includes(sexo))
+      erroresFila.push(`Fila ${filaExcel} (${sheetName}): el sexo debe ser H o M.`);
+
+    if (!grupo) erroresFila.push(`Fila ${filaExcel} (${sheetName}): captura el grupo.`);
+    else if (!/^[A-Z]$/.test(grupo))
+      erroresFila.push(`Fila ${filaExcel} (${sheetName}): el grupo debe ser una sola letra (A-Z).`);
+
+    const evaluaciones: { materiaIndex: number; valor: number }[] = [];
+    valoraciones.forEach((valor, idx) => {
+      if (valor === null) {
+        erroresFila.push(`Fila ${filaExcel} (${sheetName}): falta la valoración ${idx + 1}.`);
+        return;
+      }
+      if (Number.isNaN(valor) || valor < 0 || valor > 3) {
+        erroresFila.push(
+          `Fila ${filaExcel} (${sheetName}): la valoración ${idx + 1} debe estar entre 0 y 3.`
+        );
+        return;
+      }
+      evaluaciones.push({ materiaIndex: idx, valor });
+    });
+
+    if (erroresFila.length > 0) {
+      errors.push(...erroresFila);
+      return;
+    }
+
+    alumnos.push({
+      curp: buildSyntheticCurp(cct, grado, grupo, Number(numeroLista), nombre),
+      nombre,
+      grupo,
+      evaluaciones,
+    });
+  });
+
+  return alumnos;
+}
+
+function resolveEvaluationColumns(nivel: string, sheetName: string): string[] {
+  if (nivel === 'PREESCOLAR') return COLUMNAS_PREESCOLAR;
+  if (nivel === 'PRIMARIA') return COLUMNAS_PRIMARIA[sheetName] || [];
+  if (nivel === 'SECUNDARIA' || nivel === 'TELESECUNDARIA')
+    return COLUMNAS_SECUNDARIA[sheetName] || [];
+  return [];
+}
+
+function buildSyntheticCurp(
+  cct: string,
+  grado: number,
+  grupo: string,
+  numeroLista: number,
+  nombre: string
+): string {
+  const normalizedName = nombre
+    .normalize('NFD')
+    .replace(/[^\w\s]/g, '')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, '')
+    .toUpperCase();
+  return `${cct}${grado}${grupo}${String(numeroLista).padStart(2, '0')}${normalizedName}`.slice(
+    0,
+    18
+  );
+}
+
+function firstNonEmptyCell(sheet: XLSX.WorkSheet, addresses: string[]): string {
+  for (const address of addresses) {
+    const value = normalizeCellValue(sheet[address]?.v);
+    if (value) return value;
+  }
+  return '';
+}
+
+function cleanText(value: unknown): string {
+  return normalizeCellValue(value);
+}
+
+function normalizeCellValue(value: unknown): string {
+  return value == null ? '' : String(value).trim().replace(/\s+/g, ' ');
+}
+
+function buildColumnRange(start: string, end: string): string[] {
+  const cols: string[] = [];
+  const startCode = XLSX.utils.decode_col(start);
+  const endCode = XLSX.utils.decode_col(end);
+  for (let col = startCode; col <= endCode; col++) {
+    cols.push(XLSX.utils.encode_col(col));
+  }
+  return cols;
+}

--- a/graphql-server/src/workers/worker-excel.ts
+++ b/graphql-server/src/workers/worker-excel.ts
@@ -1,5 +1,5 @@
 import { parentPort } from 'worker_threads';
-import * as XLSX from 'xlsx';
+import { parseExcelAssessmentBuffer } from './excel-parser.js';
 
 /**
  * Worker para procesar archivos Excel de evaluación diagnóstica
@@ -7,155 +7,21 @@ import * as XLSX from 'xlsx';
  */
 
 interface WorkerInput {
-    archivoBase64: string;
-    nombreArchivo: string;
+  archivoBase64: string;
+  nombreArchivo: string;
 }
-
-interface ParsedStudent {
-    curp: string;
-    nombre: string;
-    grupo: string;
-    evaluaciones: { materiaIndex: number; valor: number }[];
-}
-
 
 if (parentPort) {
-    parentPort.on('message', (message: WorkerInput) => {
-        const errors: string[] = [];
-        try {
-            const { archivoBase64 } = message;
-            const buffer = Buffer.from(archivoBase64, 'base64');
-            const workbook = XLSX.read(buffer, { type: 'buffer' });
-
-            // 1. Estructura base (Hojas requeridas)
-            if (!workbook.SheetNames.includes('ESC')) {
-                errors.push('No se encontró la hoja obligatoria "ESC".');
-            }
-
-            // 2. Extraer y validar CCT e Identificadores en Hoja ESC
-            const sheetEsc = workbook.Sheets['ESC'];
-            const dataEsc: any[][] = XLSX.utils.sheet_to_json(sheetEsc, { header: 1 });
-            
-            let cct = '';
-            let nivel = '';
-            
-            if (sheetEsc) {
-                // Validación de etiquetas de cabecera (Punto 6: Consistencia de cabeceras)
-                const cctLabel = (dataEsc[8] && dataEsc[8][1]) ? dataEsc[8][1].toString().trim() : '';
-                if (!cctLabel.includes('CCT')) {
-                    errors.push('La estructura de la hoja ESC es inválida (falta etiqueta CCT en B9).');
-                }
-
-                // Extracción de CCT (Punto 2)
-                cct = (dataEsc[8] && dataEsc[8][3]) ? dataEsc[8][3].toString().trim() : '';
-                if (!cct) {
-                    errors.push('La CCT no está capturada en la celda D9 de la hoja ESC.');
-                } else if (!/^[0-9]{2}[A-Z]{3}[0-9]{4}[A-Z]$/.test(cct)) {
-                    errors.push(`La CCT "${cct}" tiene un formato inválido.`);
-                }
-
-                // Extracción de Nivel (Punto 3)
-                nivel = (dataEsc[5] && dataEsc[5][2]) ? dataEsc[5][2].toString().toUpperCase() : '';
-            }
-
-            // Fallback de detección de nivel si no está en ESC
-            const sheetsNormalized = workbook.SheetNames.map(n => n.toUpperCase());
-            if (!nivel) {
-                if (sheetsNormalized.includes('PREESCOLAR')) nivel = 'PREESCOLAR';
-                else if (sheetsNormalized.includes('SEXTO')) nivel = 'PRIMARIA';
-                else if (sheetsNormalized.includes('SECUNDARIA')) nivel = 'SECUNDARIA';
-            }
-
-            if (!nivel) {
-                errors.push('No se pudo identificar el nivel educativo del archivo.');
-            }
-
-            // 3. Identificar Hoja de Datos y Grado
-            const validGrades = ['PRIMERO', 'SEGUNDO', 'TERCERO', 'CUARTO', 'QUINTO', 'SEXTO', 'PREESCOLAR', 'SECUNDARIA'];
-            const dataSheetName = workbook.SheetNames.find(n => 
-                validGrades.some(g => n.toUpperCase().includes(g))
-            );
-
-            if (!dataSheetName) {
-                errors.push('No se encontró la hoja de captura de evaluaciones (ej. PRIMERO, SEGUNDO, etc.).');
-            }
-
-            if (errors.length > 0) {
-                parentPort?.postMessage({ success: false, error: errors.join(' | ') });
-                return;
-            }
-
-            const sheetData = workbook.Sheets[dataSheetName!];
-            const dataAlumnos: any[][] = XLSX.utils.sheet_to_json(sheetData, { header: 1 });
-
-            // Detectar grado
-            const gradoMap: Record<string, number> = {
-                PRIMERO: 1, SEGUNDO: 2, TERCERO: 3, CUARTO: 4, QUINTO: 5, SEXTO: 6,
-                '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6
-            };
-            const gradeText = dataSheetName!.toUpperCase();
-            const foundGradeKey = Object.keys(gradoMap).find(k => gradeText.includes(k));
-            const baseGrado = foundGradeKey ? gradoMap[foundGradeKey] : 1;
-
-            // 4. Procesar Alumnos y Validaciones de Rango/Campos (Puntos 4 y 5)
-            const alumnos: ParsedStudent[] = [];
-            const studentRows = dataAlumnos.slice(1); // Omitir cabecera
-
-            studentRows.forEach((row, index) => {
-                if (!row || row.length < 2) return;
-                
-                const curp = (row[1] || '').toString().trim();
-                const nombre = (row[2] || '').toString().trim();
-                const grupo = (row[3] || 'A').toString().trim();
-
-                // Si tiene CURP o Nombre, debe tener ambos
-                if (curp || nombre) {
-                    if (!curp) errors.push(`Fila ${index + 2}: Falta CURP del estudiante.`);
-                    if (!nombre) errors.push(`Fila ${index + 2}: Falta nombre del estudiante.`);
-                    
-                    const evaluations: { materiaIndex: number; valor: number }[] = [];
-                    // Validar rangos 0-3 (Punto 4)
-                    for (let col = 6; col < Math.min(row.length, 10); col++) {
-                        const val = row[col];
-                        if (val !== undefined && val !== null && val !== '') {
-                            const nVal = parseInt(val.toString());
-                            if (isNaN(nVal) || nVal < 0 || nVal > 3) {
-                                errors.push(`Fila ${index + 2}, Col ${(col + 1)}: Valor "${val}" fuera de rango (0-3).`);
-                            } else {
-                                evaluations.push({ materiaIndex: col - 6, valor: nVal });
-                            }
-                        }
-                    }
-
-                    if (curp && nombre) {
-                        alumnos.push({ curp, nombre, grupo, evaluaciones: evaluations });
-                    }
-                }
-            });
-
-            if (alumnos.length === 0) {
-                errors.push('No se encontraron registros de estudiantes con evaluaciones válidas.');
-            }
-
-            if (errors.length > 0) {
-                parentPort?.postMessage({ success: false, error: errors.join(' | ') });
-                return;
-            }
-
-            // Éxito
-            parentPort?.postMessage({
-                success: true,
-                data: {
-                    cct, nivel, grado: baseGrado, alumnos,
-                    metadata: { nivelDetectado: nivel, gradoDetectado: gradeText }
-                }
-            });
-
-        } catch (error: any) {
-            parentPort?.postMessage({
-                success: false,
-                error: `Error crítico en procesamiento: ${error.message}`
-            });
-        }
-    });
+  parentPort.on('message', (message: WorkerInput) => {
+    try {
+      const buffer = Buffer.from(message.archivoBase64, 'base64');
+      const data = parseExcelAssessmentBuffer(buffer);
+      parentPort?.postMessage({ success: true, data });
+    } catch (error: any) {
+      parentPort?.postMessage({
+        success: false,
+        error: error?.message || 'Error crítico en procesamiento',
+      });
+    }
+  });
 }

--- a/graphql-server/tests/workers/excel-parser.test.ts
+++ b/graphql-server/tests/workers/excel-parser.test.ts
@@ -1,0 +1,132 @@
+import * as XLSX from 'xlsx';
+import { parseExcelAssessmentBuffer } from '../../src/workers/excel-parser';
+
+describe('parseExcelAssessmentBuffer', () => {
+  it('parsea correctamente un archivo preescolar validado en frontend', () => {
+    const workbook = XLSX.utils.book_new();
+
+    const escSheet = XLSX.utils.aoa_to_sheet([]);
+    escSheet.C6 = { t: 's', v: 'PREESCOLAR' };
+    escSheet.D9 = { t: 's', v: '01DJN0001A' };
+    escSheet.D11 = { t: 's', v: 'MATUTINO' };
+    escSheet.D13 = { t: 's', v: 'ANDRES OSUAN' };
+    escSheet.D18 = { t: 's', v: 'pepe.arevalo74@gmail.com' };
+    escSheet['!ref'] = 'A1:E20';
+    XLSX.utils.book_append_sheet(workbook, escSheet, 'ESC');
+
+    const data = [
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      {
+        B: 1,
+        C: 'ADRIANA MANGUEN RODRIGUEZ',
+        D: 'M',
+        E: 'A',
+        F: 1,
+        G: 2,
+        H: 3,
+        I: 3,
+        J: 2,
+        K: 1,
+        L: 2,
+        M: 3,
+        N: 1,
+        O: 2,
+        P: 3,
+      },
+      {
+        B: 2,
+        C: 'BERNARDO RUIZ GONZALEZ',
+        D: 'H',
+        E: 'A',
+        F: 2,
+        G: 3,
+        H: 1,
+        I: 2,
+        J: 3,
+        K: 3,
+        L: 1,
+        M: 1,
+        N: 2,
+        O: 2,
+        P: 3,
+      },
+    ];
+    const tercero = XLSX.utils.json_to_sheet(data, { skipHeader: true });
+    tercero['!ref'] = 'A1:P12';
+    XLSX.utils.book_append_sheet(workbook, tercero, 'TERCERO');
+
+    const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+    const result = parseExcelAssessmentBuffer(buffer);
+
+    expect(result.cct).toBe('01DJN0001A');
+    expect(result.nivel).toBe('PREESCOLAR');
+    expect(result.grado).toBe(3);
+    expect(result.metadata.turno).toBe('MATUTINO');
+    expect(result.metadata.nombreEscuela).toBe('ANDRES OSUAN');
+    expect(result.alumnos).toHaveLength(2);
+    expect(result.alumnos[0]).toMatchObject({
+      nombre: 'ADRIANA MANGUEN RODRIGUEZ',
+      grupo: 'A',
+    });
+    expect(result.alumnos[0].evaluaciones).toHaveLength(11);
+    expect(result.alumnos[0].curp).toHaveLength(18);
+  });
+
+  it('rechaza grupos inválidos aunque el archivo tenga datos', () => {
+    const workbook = XLSX.utils.book_new();
+    const escSheet = XLSX.utils.aoa_to_sheet([]);
+    escSheet.C6 = { t: 's', v: 'PREESCOLAR' };
+    escSheet.D9 = { t: 's', v: '01DJN0001A' };
+    escSheet.D11 = { t: 's', v: 'MATUTINO' };
+    escSheet.D13 = { t: 's', v: 'ANDRES OSUAN' };
+    escSheet.D18 = { t: 's', v: 'pepe.arevalo74@gmail.com' };
+    escSheet['!ref'] = 'A1:E20';
+    XLSX.utils.book_append_sheet(workbook, escSheet, 'ESC');
+
+    const tercero = XLSX.utils.json_to_sheet(
+      [
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        {
+          B: 1,
+          C: 'ADRIANA MANGUEN RODRIGUEZ',
+          D: 'M',
+          E: 'MATUTINO',
+          F: 1,
+          G: 2,
+          H: 3,
+          I: 3,
+          J: 2,
+          K: 1,
+          L: 2,
+          M: 3,
+          N: 1,
+          O: 2,
+          P: 3,
+        },
+      ],
+      { skipHeader: true }
+    );
+    tercero['!ref'] = 'A1:P11';
+    XLSX.utils.book_append_sheet(workbook, tercero, 'TERCERO');
+
+    const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+
+    expect(() => parseExcelAssessmentBuffer(buffer)).toThrow('el grupo debe ser una sola letra');
+  });
+});


### PR DESCRIPTION
### Motivation
- Se detectó que el worker backend releía el Excel con coordenadas/columnas distintas a las usadas por la validación en frontend, lo que provocaba que archivos válidos en la UI fallaran al persistir (ej. errores por longitud de campo). 
- El cambio busca alinear el parseo backend con las mismas reglas y celdas que valida el cliente y persistir correctamente metadata crítica (turno, nombre y correo) para evitar datos truncados o inválidos.

### Description
- Se añadió un parser central `graphql-server/src/workers/excel-parser.ts` que normaliza la lectura de la hoja `ESC`, determina nivel/grado, valida filas y columnas de valoraciones y construye la estructura de datos que consume el backend. 
- El worker ahora delega todo el parseo al parser central mediante `parseExcelAssessmentBuffer` (`graphql-server/src/workers/worker-excel.ts`) en lugar de contener lógica ad-hoc duplicada. 
- Se actualizó la resolución de la mutación de subida para usar la metadata extraída (`metadata.turno`, `metadata.nombreEscuela`, `metadata.correo`) y mapear/guardar el `turno` y `email` al crear o actualizar el registro de `escuelas` (`graphql-server/src/schema/resolvers.ts`). 
- Añadí pruebas unitarias del parser en `graphql-server/tests/workers/excel-parser.test.ts` que cubren un caso preescolar válido y un caso con grupo inválido para asegurar consistencia con la validación del frontend.

### Testing
- Se ejecutó `npm --prefix graphql-server run build` y la compilación TypeScript terminó correctamente. (✅)
- Se realizaron pruebas de humo del parser con Node en modo módulo importando `dist/workers/excel-parser.js` y construyendo workbooks sintéticos, validando que el parser devuelve la CCT, nivel, grado, turno, cantidad de alumnos y curp esperados; ambos casos (positivo y negativo) se comportaron según lo esperado. (✅)
- Se intentó ejecutar la suite de Jest `npm --prefix graphql-server test -- --runInBand excel-parser.test.ts` pero en este entorno Jest no arrancó por la combinación `type: "module"` y `jest.config.js` usando `module.exports`, por lo que los tests unitarios automatizados no se pudieron ejecutar aquí; el parser sí se probó manualmente con Node y la build pasó. (⚠️)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9f4bccffc83208c68a7fceaf3954c)