### PR TITLE
Fix failing backend CI tests (ESM mocks + JWT test setup)

### DIFF
--- a/graphql-server/src/services/mailing.service.spec.ts
+++ b/graphql-server/src/services/mailing.service.spec.ts
@@ -3,7 +3,12 @@ import { MailingService } from './mailing.service';
 import nodemailer from 'nodemailer';
 
 // Mock de nodemailer
-jest.mock('nodemailer');
+jest.mock('nodemailer', () => ({
+  __esModule: true,
+  default: {
+    createTransport: jest.fn(),
+  },
+}));
 
 describe('MailingService (Issue #315 - Refactor & Security)', () => {
   let service: MailingService;
@@ -12,7 +17,7 @@ describe('MailingService (Issue #315 - Refactor & Security)', () => {
   beforeEach(() => {
     mockSendMail = jest.fn() as any;
     mockSendMail.mockResolvedValue({ messageId: 'test-id' });
-    (nodemailer.createTransport as any).mockReturnValue({
+    (nodemailer.createTransport as jest.Mock).mockReturnValue({
       sendMail: mockSendMail,
     });
 

--- a/graphql-server/tests/schema/authenticateUser.test.ts
+++ b/graphql-server/tests/schema/authenticateUser.test.ts
@@ -44,10 +44,14 @@ import * as crypto from 'crypto';
 
 describe('authenticateUser Resolver Tests', () => {
   const queryMock = query as any;
+  const buildPasswordHash = (password: string, salt = 'fixed-salt-for-tests') => {
+    const hash = crypto.scryptSync(password, salt, 64).toString('hex');
+    return `${salt}:${hash}`;
+  };
   
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(crypto, 'timingSafeEqual').mockImplementation(() => true);
+    process.env.JWT_SECRET = 'test-secret-jwt';
   });
 
   describe('JWT Integrity', () => {
@@ -69,7 +73,7 @@ describe('authenticateUser Resolver Tests', () => {
       const mockUser = {
         id: 'u-1',
         email: 'test@example.com',
-        password_hash: 'salt:hash',
+        password_hash: buildPasswordHash('correct'),
         rol: 'COORDINADOR_FEDERAL',
         activo: true,
         intentosFallidos: 0,
@@ -78,9 +82,6 @@ describe('authenticateUser Resolver Tests', () => {
 
       queryMock.mockResolvedValueOnce({ rows: [mockUser] }); // Buscar
       queryMock.mockResolvedValueOnce({ rows: [] });      // Update success
-
-      jest.spyOn(crypto, 'timingSafeEqual').mockReturnValue(true);
-      jest.spyOn(crypto, 'scryptSync').mockReturnValue(Buffer.from('hash', 'hex'));
 
       const result = await (resolvers.Mutation as any).authenticateUser(
         null, 
@@ -97,7 +98,7 @@ describe('authenticateUser Resolver Tests', () => {
       const mockUser = {
         id: 'u-1',
         email: 'attacker@example.com',
-        password_hash: 'salt:hash',
+        password_hash: buildPasswordHash('correct'),
         rol: 'CONSULTA',
         activo: true,
         intentosFallidos: 4,
@@ -106,8 +107,6 @@ describe('authenticateUser Resolver Tests', () => {
 
       queryMock.mockImplementationOnce(() => Promise.resolve({ rows: [mockUser] })); // Buscar
       queryMock.mockImplementationOnce(() => Promise.resolve({ rows: [] }));      // Update lockout
-
-      jest.spyOn(crypto, 'timingSafeEqual').mockReturnValue(false);
 
       const result = await (resolvers.Mutation as any).authenticateUser(
         null, 

--- a/graphql-server/tests/schema/generateComprobante.test.ts
+++ b/graphql-server/tests/schema/generateComprobante.test.ts
@@ -33,11 +33,10 @@ jest.mock('../../src/services/report-consolidator.service', () => ({
 }));
 
 import resolvers, { GraphQLContext } from '../../src/schema/resolvers';
-import { query, getClient } from '../../src/config/database';
+import { query } from '../../src/config/database';
 
 describe('generateComprobante resolver', () => {
   const queryMock = query as any;
-  const getClientMock = getClient as any;
 
   const createContext = (user?: GraphQLContext['user']): GraphQLContext =>
     ({

--- a/graphql-server/tests/schema/resolvers.test.ts
+++ b/graphql-server/tests/schema/resolvers.test.ts
@@ -38,10 +38,14 @@ import * as crypto from 'crypto';
 describe('Resolvers GraphQL - Coverage #272', () => {
   const queryMock = query as any;
   const getClientMock = getClient as any;
+  const buildPasswordHash = (password: string, salt = 'fixed-salt-for-tests') => {
+    const hash = crypto.scryptSync(password, salt, 64).toString('hex');
+    return `${salt}:${hash}`;
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(crypto, 'timingSafeEqual').mockImplementation(() => true);
+    process.env.JWT_SECRET = 'test-secret-jwt';
   });
 
   describe('Query.getMyTickets', () => {
@@ -63,7 +67,7 @@ describe('Resolvers GraphQL - Coverage #272', () => {
       const mockUser = {
         id: 'u1',
         email: 'admin@sep.gob.mx',
-        password_hash: 'salt:hash',
+        password_hash: buildPasswordHash('p'),
         rol: 'ADMIN',
         activo: true,
         intentosFallidos: 0,


### PR DESCRIPTION
### Motivation
- CI tests were failing due to ESM mocking incompatibilities, an unused test import, attempts to spy on read-only crypto functions, and missing JWT secret in tests.

### Description
- Mocked `nodemailer` in `src/services/mailing.service.spec.ts` with an explicit ESM-style default shape and a typed `createTransport` mock to avoid `mockReturnValue` runtime errors.
- Removed the unused `getClient` import/mock in `tests/schema/generateComprobante.test.ts` to eliminate a TS6133 unused variable/lint error.
- Replaced attempts to spy on `crypto.timingSafeEqual` by generating real `scryptSync` password hashes in `tests/schema/authenticateUser.test.ts` and `tests/schema/resolvers.test.ts` so authentication tests validate properly without spying on read-only APIs.
- Set `process.env.JWT_SECRET` in the auth-related test `beforeEach` hooks so JWT generation/validation works in the CI environment.

### Testing
- Ran `npm test -- --ci --coverage` inside the `graphql-server` folder and all test suites passed (8/8 suites, 32/32 tests) with coverage report generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40eb624048320ab8e8663fc028109)